### PR TITLE
fix nginx startupcmd

### DIFF
--- a/jumpscale/tools/nginx/nginxserver.py
+++ b/jumpscale/tools/nginx/nginxserver.py
@@ -30,7 +30,9 @@ class NginxServer(Base):
         nginx.save()
         cmd = j.tools.startupcmd.get(self.name)
         cmd.start_cmd = f"nginx -c {self.config_path}"
-        cmd.ports = [8999]
+        cmd.process_strings_regex = [
+            r"nginx.* \-c {CONFIG_PATH}".format(CONFIG_PATH=j.sals.fs.expanduser(self.config_path))
+        ]
         if not cmd.is_running():
             cmd.start()
 


### PR DESCRIPTION
- Match process by name regex instead of port, cause in sometimes process couldn't be accessed with normal user after increasing its cap