### PR TITLE
Make it possible to run threebot locally withouth requiring privileged

### DIFF
--- a/jumpscale/packages/admin/package.toml
+++ b/jumpscale/packages/admin/package.toml
@@ -1,5 +1,4 @@
 name = "admin"
-ports = [80, 443]
 
 [[static_dirs]]
 name = "frontend"

--- a/jumpscale/packages/admin_old/package.toml
+++ b/jumpscale/packages/admin_old/package.toml
@@ -1,5 +1,4 @@
 name = "admin_old"
-ports = [80, 443]
 
 [[static_dirs]]
 name = "frontend"

--- a/jumpscale/packages/auth/package.toml
+++ b/jumpscale/packages/auth/package.toml
@@ -1,5 +1,4 @@
 name = "auth"
-ports = [ 80, 443]
 
 [[static_dirs]]
 name = "static"

--- a/jumpscale/packages/chatflows/package.toml
+++ b/jumpscale/packages/chatflows/package.toml
@@ -1,5 +1,4 @@
 name = "chatflows"
-ports = [ 80, 443]
 [[static_dirs]]
 name = "frontend"
 path_url = "/static"

--- a/jumpscale/packages/codeserver/package.toml
+++ b/jumpscale/packages/codeserver/package.toml
@@ -1,8 +1,6 @@
 name = "codeserver"
-ports = [80, 443]
 [[servers]]
 name = "default"
-ports = [80, 443]
 [[servers.locations]]
 type = "proxy"
 host = "127.0.0.1"

--- a/jumpscale/packages/farmmanagement/package.toml
+++ b/jumpscale/packages/farmmanagement/package.toml
@@ -1,5 +1,4 @@
 name = "farmmanagement"
-ports = [ 80, 443]
 [[static_dirs]]
 name = "frontend"
 path_url = "/"

--- a/jumpscale/packages/tfgrid_solutions/package.toml
+++ b/jumpscale/packages/tfgrid_solutions/package.toml
@@ -1,2 +1,1 @@
 name = "tfgrid_solutions"
-ports = [ 80, 443]

--- a/jumpscale/packages/weblibs/package.toml
+++ b/jumpscale/packages/weblibs/package.toml
@@ -1,5 +1,4 @@
 name = "weblibs"
-ports = [80, 443]
 [[static_dirs]]
 name = "static"
 path_url = "/"

--- a/jumpscale/servers/threebot/__init__.py
+++ b/jumpscale/servers/threebot/__init__.py
@@ -1,4 +1,5 @@
 from jumpscale.core.base import StoredFactory
+from jumpscale.sals.nginx.nginx import PORTS
 
 
 class ThreebotServerFactory(StoredFactory):
@@ -21,7 +22,8 @@ class ThreebotServerFactory(StoredFactory):
         """
         return super().get("default", *args, **kwargs)
 
-    def start_default(self, wait=False):
+    def start_default(self, wait=False, local=False):
+        PORTS.init_default_ports(local)
         server = self.get("default")
         server.save()
         server.start(wait=wait)

--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -8,6 +8,7 @@ import shutil
 from urllib.parse import urlparse
 from gevent.pywsgi import WSGIServer
 from jumpscale.core.base import Base, fields
+from jumpscale.sals.nginx.nginx import PORTS
 
 
 GEDIS = "gedis"
@@ -98,16 +99,17 @@ class NginxPackageConfig:
         return [default_server]
 
     def apply(self):
+        default_ports = [PORTS.HTTP, PORTS.HTTPS]
         servers = self.default_config + self.package.config.get("servers", [])
         for server in servers:
-            for port in server.get("ports", [80, 443]):
-
+            ports = server.get("ports", default_ports) or default_ports
+            for port in ports:
                 server_name = server.get("name")
                 if server_name != "default":
                     server_name = f"{self.package.name}_{server_name}"
 
                 website = self.nginx.get_website(server_name, port=port)
-                website.ssl = server.get("ssl", port == 443)
+                website.ssl = server.get("ssl", port == PORTS.HTTPS)
                 website.includes = server.get("includes", [])
                 website.domain = server.get("domain", self.default_config[0].get("domain"))
                 website.letsencryptemail = server.get(
@@ -131,7 +133,7 @@ class NginxPackageConfig:
                         loc = website.get_proxy_location(location_name)
                         loc.scheme = location.get("scheme", "http")
                         loc.host = location.get("host")
-                        loc.port = location.get("port")
+                        loc.port = location.get("port", PORTS.HTTP)
                         loc.path_dest = location.get("path_dest", "")
                         loc.websocket = location.get("websocket", False)
                     


### PR DESCRIPTION
ports

`threebstart start` now takes an extra optional paramater `--local` which will configure nginx to use ports in the 8xxx range
And extra check was added that when nginx can not bind to port 80 it
will raise error intrusction you to either use setcap or start threboot
with local flag

All `defaults` ports have been removed from the builtin packages

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>