### PR TITLE
Add identities updating  option in dashboard

### DIFF
--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -71,7 +71,7 @@ class Admin(BaseActor):
             j.clients.explorer.default_addr_set(url=url)
 
             # update our solutions
-            j.sals.reservation_chatflow.get_solutions_explorer()
+            j.sals.reservation_chatflow.update_local_reservations()
 
             return j.data.serializers.json.dumps({"data": {"type": explorer_type, "url": explorers[explorer_type]}})
         else:
@@ -117,7 +117,7 @@ class Admin(BaseActor):
             j.core.identity.set_default(identity_instance_name)
 
             # update our solutions
-            j.sals.reservation_chatflow.get_solutions_explorer()
+            j.sals.reservation_chatflow.update_local_reservations()
 
             return j.data.serializers.json.dumps({"data": {"instance_name": identity_instance_name}})
         else:

--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -29,9 +29,11 @@ class Admin(BaseActor):
         return j.data.serializers.json.dumps(
             {
                 "data": {
+                    "instance_name": j.core.identity.me.instance_name,
                     "name": j.core.identity.me.tname,
                     "email": j.core.identity.me.email,
                     "tid": j.core.identity.me.tid,
+                    "explorer_url": j.core.identity.me.explorer_url,
                 }
             }
         )
@@ -76,6 +78,75 @@ class Admin(BaseActor):
             return j.data.serializers.json.dumps(
                 {"data": f"{explorer_type} is not a valid explorer type, must be 'testnet' or 'main'"}
             )
+
+    @actor_method
+    def list_identities(self) -> str:
+        identities = j.core.identity.list_all()
+        identity_data = {}
+        for identity_name in identities:
+            identity = j.core.identity.get(identity_name)
+            identity_data[identity_name] = identity.to_dict()
+            identity_data[identity_name]["instance_name"] = identity.instance_name
+            identity_data[identity_name].pop("__words")
+        return j.data.serializers.json.dumps({"data": identity_data})
+
+    @actor_method
+    def get_identity(self, identity_instance_name: str) -> str:
+        identity_names = j.core.identity.list_all()
+        if identity_instance_name in identity_names:
+            identity = j.core.identity.get(identity_instance_name)
+
+            return j.data.serializers.json.dumps(
+                {
+                    "data": {
+                        "instance_name": identity.instance_name,
+                        "name": identity.tname,
+                        "email": identity.email,
+                        "tid": identity.tid,
+                        "explorer_url": identity.explorer_url,
+                    }
+                }
+            )
+        else:
+            return j.data.serializers.json.dumps({"data": f"{identity_instance_name} doesn't exist"})
+
+    @actor_method
+    def set_identity(self, identity_instance_name: str) -> str:
+        identity_names = j.core.identity.list_all()
+        if identity_instance_name in identity_names:
+            j.core.identity.set_default(identity_instance_name)
+
+            # update our solutions
+            j.sals.reservation_chatflow.get_solutions_explorer()
+
+            return j.data.serializers.json.dumps({"data": {"instance_name": identity_instance_name}})
+        else:
+            return j.data.serializers.json.dumps({"data": f"{identity_instance_name} doesn't exist"})
+
+    @actor_method
+    def add_identity(self, identity_instance_name: str, tname: str, email: str, words: str, explorer_type: str) -> str:
+        explorer_url = f"https://{explorers[explorer_type]}/explorer"
+        if identity_instance_name in j.core.identity.list_all():
+            return j.data.serializers.json.dumps({"data": "Identity with the same instance name already exists"})
+        new_identity = j.core.identity.new(
+            name=identity_instance_name, tname=tname, email=email, words=words, explorer_url=explorer_url
+        )
+        new_identity.register()
+        new_identity.save()
+        return j.data.serializers.json.dumps({"data": "New identity successfully created and registered"})
+
+    @actor_method
+    def delete_identity(self, identity_instance_name: str) -> str:
+        identity_names = j.core.identity.list_all()
+        if identity_instance_name in identity_names:
+            identity = j.core.identity.get(identity_instance_name)
+            if identity.instance_name == j.core.identity.me.instance_name:
+                return j.data.serializers.json.dumps({"data": "Cannot delete current default identity"})
+
+            j.core.identity.delete(identity_instance_name)
+            return j.data.serializers.json.dumps({"data": f"{identity_instance_name} deleted successfully"})
+        else:
+            return j.data.serializers.json.dumps({"data": f"{identity_instance_name} doesn't exist"})
 
 
 Actor = Admin

--- a/jumpscale/packages/admin/frontend/api.js
+++ b/jumpscale/packages/admin/frontend/api.js
@@ -13,7 +13,7 @@ const apiClient = {
       return axios({
         url: `${baseURL}/logs/list_logs`,
         method: "post",
-        headers: {'Content-Type': 'application/json'},
+        headers: { 'Content-Type': 'application/json' },
         data: { appname: appname }
       })
     },
@@ -30,7 +30,7 @@ const apiClient = {
       return axios({
         url: `${baseURL}/alerts/list_alerts`,
         method: "post",
-        headers: {'Content-Type': 'application/json'}
+        headers: { 'Content-Type': 'application/json' }
       })
     },
     deleteAll: () => {
@@ -45,22 +45,22 @@ const apiClient = {
       return axios({
         url: `${baseURL}/wallet/get_wallets`,
         method: "post",
-        headers: {'Content-Type': 'application/json'}
+        headers: { 'Content-Type': 'application/json' }
       })
     },
     get: (name) => {
       return axios({
         url: `${baseURL}/wallet/get_wallet_info`,
         method: "post",
-        headers: {'Content-Type': 'application/json'},
-        data: {name: name}
+        headers: { 'Content-Type': 'application/json' },
+        data: { name: name }
       })
     },
     create: (name) => {
       return axios({
         url: `${baseURL}/wallet/create_wallet`,
         method: "post",
-        data: {name: name}
+        data: { name: name }
       })
     },
     import: (name, secret, network) => {
@@ -74,9 +74,17 @@ const apiClient = {
       return axios({
         url: `${baseURL}/wallet/delete_wallet`,
         method: "post",
-        data: {name: name}
+        data: { name: name }
       })
-    }
+    },
+    updateTrustlines: (name) => {
+      return axios({
+        url: `${baseURL}/wallet/update_trustlines`,
+        method: "post",
+        data: { name: name }
+      })
+    },
+
   },
   packages: {
     list: () => {
@@ -96,8 +104,8 @@ const apiClient = {
       return axios({
         url: `${baseURL}/packages/delete_package`,
         method: "post",
-        headers: {'Content-Type': 'application/json'},
-        data: {name: name}
+        headers: { 'Content-Type': 'application/json' },
+        data: { name: name }
       })
     },
     getInstalled: () => {
@@ -116,16 +124,16 @@ const apiClient = {
       return axios({
         url: `${baseURL}/admin/add_admin`,
         method: "post",
-        headers: {'Content-Type': 'application/json'},
-        data: {name: name}
+        headers: { 'Content-Type': 'application/json' },
+        data: { name: name }
       })
     },
     remove: (name) => {
       return axios({
         url: `${baseURL}/admin/delete_admin`,
         method: "post",
-        headers: {'Content-Type': 'application/json'},
-        data: {name: name}
+        headers: { 'Content-Type': 'application/json' },
+        data: { name: name }
       })
     },
     getCurrentUser: () => {
@@ -142,8 +150,8 @@ const apiClient = {
       return axios({
         url: `${baseURL}/admin/set_explorer`,
         method: "post",
-        headers: {'Content-Type': 'application/json'},
-        data: {explorer_type: explorerType}
+        headers: { 'Content-Type': 'application/json' },
+        data: { explorer_type: explorerType }
       })
     }
   },
@@ -154,6 +162,46 @@ const apiClient = {
       })
     },
   },
+  identities: {
+    list: () => {
+      return axios({
+        url: `${baseURL}/admin/list_identities`
+      })
+    },
+    add: (identity_instance_name, tname, email, words, explorer_type) => {
+      return axios({
+        url: `${baseURL}/admin/add_identity`,
+        method: "post",
+        headers: { 'Content-Type': 'application/json' },
+        data: { identity_instance_name: identity_instance_name, tname: tname, email: email, words: words, explorer_type: explorer_type }
+      })
+    },
+    setIdentity: (identity_instance_name) => {
+      return axios({
+        url: `${baseURL}/admin/set_identity`,
+        method: "post",
+        headers: { 'Content-Type': 'application/json' },
+        data: { identity_instance_name: identity_instance_name }
+      })
+    },
+    getIdentity: (identity_instance_name) => {
+      return axios({
+        url: `${baseURL}/admin/get_identity`,
+        method: "post",
+        headers: { 'Content-Type': 'application/json' },
+        data: { identity_instance_name: identity_instance_name }
+      })
+    },
+    deleteIdentity: (identity_instance_name) => {
+      return axios({
+        url: `${baseURL}/admin/delete_identity`,
+        method: "post",
+        headers: { 'Content-Type': 'application/json' },
+        data: { identity_instance_name: identity_instance_name }
+      })
+    }
+  },
+
   solutions: {
     getCount: () => {
       return axios({
@@ -164,8 +212,8 @@ const apiClient = {
       return axios({
         url: `/tfgrid_solutions/actors/solutions/list_solutions`,
         method: "post",
-        headers: {'Content-Type': 'application/json'},
-        data: {solution_type: solution_type}
+        headers: { 'Content-Type': 'application/json' },
+        data: { solution_type: solution_type }
       })
     },
     getAll: () => {
@@ -177,23 +225,23 @@ const apiClient = {
       return axios({
         url: `/tfgrid_solutions/actors/solutions/cancel_solution`,
         method: "post",
-        headers: {'Content-Type': 'application/json'},
-        data: {solution_type: solutionType, solution_name: solutionName}
+        headers: { 'Content-Type': 'application/json' },
+        data: { solution_type: solutionType, solution_name: solutionName }
       })
     }
   },
   health: {
-    getMemoryUsage () {
+    getMemoryUsage() {
       return axios({
         url: `${baseURL}/health/get_memory_usage`
       })
     },
-    getDiskUsage () {
+    getDiskUsage() {
       return axios({
         url: `${baseURL}/health/get_disk_space`
       })
     },
-    getRunningProcesses () {
+    getRunningProcesses() {
       return axios({
         url: `${baseURL}/health/get_running_processes`
       })

--- a/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
@@ -34,14 +34,14 @@ module.exports = {
             this.loading = true
             this.error = null
             if(!this.form.instance_name || !this.form.tname || !this.form.email || !this.form.words || !this.form.explorer_type){
-                this.alert("All fields required", "error")
+                this.error = "All fields required"
                 this.loading = false
             }
             else{
                 this.$api.identities.add(this.form.instance_name, this.form.tname, this.form.email, this.form.words, this.explorers[this.form.explorer_type].type).then((response) => {
                     responseMessage = JSON.parse(response.data).data
                     if(responseMessage == "Identity with the same instance name already exists"){
-                        this.alert(responseMessage, "error")
+                        this.error = responseMessage
                     }
                     else{
                         this.done("New Identity added", "success")

--- a/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
@@ -1,0 +1,58 @@
+<template>
+  <base-dialog title="Add identity" v-model="dialog" :error="error" :loading="loading">
+    <template #default>
+      <v-form>
+        <v-text-field v-model="form.instance_name" label="Identity instance name" dense></v-text-field>
+        <v-text-field v-model="form.tname" label="3bot name" dense></v-text-field>
+        <v-text-field v-model="form.email" label="Email" dense></v-text-field>
+        <v-text-field v-model="form.words" label="Words" dense></v-text-field>
+        <v-select v-model="form.explorer_type" label="Explorer type" :items="explorer_labels" dense></v-select>
+      </v-form>
+    </template>
+    <template #actions>
+      <v-btn text @click="close">Close</v-btn>
+      <v-btn text @click="submit">Add</v-btn>
+    </template>
+  </base-dialog>
+</template>
+
+<script>
+
+module.exports = {
+  mixins: [dialog],
+    data () {
+      return {
+        explorers: {
+          "Main Network": {url: "https://explorer.grid.tf", type: "main"},
+          "Test Network": {url: "https://explorer.testnet.grid.tf", type: "testnet"}
+        },
+        explorer_labels:["Main Network","Test Network"]
+      }
+    },
+    methods: {
+        submit () {
+            this.loading = true
+            this.error = null
+            if(!this.form.instance_name || !this.form.tname || !this.form.email || !this.form.words || !this.form.explorer_type){
+                this.alert("All fields required", "error")
+                this.loading = false
+            }
+            else{
+                this.$api.identities.add(this.form.instance_name, this.form.tname, this.form.email, this.form.words, this.explorers[this.form.explorer_type].type).then((response) => {
+                    responseMessage = JSON.parse(response.data).data
+                    if(responseMessage == "Identity with the same instance name already exists"){
+                        this.alert(responseMessage, "error")
+                    }
+                    else{
+                        this.done("New Identity added", "success")
+                    }
+                }).catch((error) => {
+                    this.error = error.message
+                }).finally(() => {
+                    this.loading = false
+                })
+            }
+        }
+    }
+}
+</script>

--- a/jumpscale/packages/admin/frontend/components/settings/IdentityInfo.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/IdentityInfo.vue
@@ -1,0 +1,98 @@
+<template>
+  <base-dialog title="Identity details" v-model="dialog" :loading="loading">
+    <template #default>
+      <v-simple-table v-if="identity">
+        <template v-slot:default>
+          <tbody>
+            <tr>
+              <td>Instance Name</td>
+              <td>{{ name }}</td>
+            </tr>
+            <tr>
+              <td>3bot ID</td>
+              <td>{{ identity.tid }}</td>
+            </tr>
+            <tr>
+              <td>3bot Name</td>
+              <td>{{ identity.name }}</td>
+            </tr>
+            <tr>
+              <td>Email</td>
+              <td>{{ identity.email }}</td>
+            </tr>
+            <tr>
+              <td>Explorer URL</td>
+              <td>{{ identity.explorer_url }}</td>
+            </tr>
+          </tbody>
+        </template>
+      </v-simple-table>
+    </template>
+    <template #actions>
+      <v-btn icon @click.stop="deleteIdentity">
+        <v-icon color="primary" left>mdi-delete</v-icon>
+      </v-btn>
+      <v-btn text color="primary" @click.stop="setDefault" >Set Default</v-btn>
+      <v-btn text color="error" @click.done="close">Close</v-btn>
+    </template>
+  </base-dialog>
+</template>
+
+<script>
+
+module.exports = {
+  props: {name: String},
+  mixins: [dialog],
+  data () {
+    return {
+      identity: null,
+    }
+  },
+  watch: {
+    dialog (val) {
+      if (val) {
+        this.getIdentityInfo()
+      } else {
+        this.identity = null
+      }
+    }
+  },
+  methods: {
+    getIdentityInfo () {
+      this.loading = true
+      this.$api.identities.getIdentity(this.name).then((response) => {
+        this.identity = JSON.parse(response.data).data
+      }).finally(() => {
+        this.loading = false
+      })
+    },
+    setDefault(){
+        this.$api.identities.setIdentity(this.name).then((response) => {
+          this.$parent.$parent.$parent.$parent.getIdentity()
+          this.done("Identity Updated", "success")
+        }).catch((error) => {
+          console.log(error)
+          this.alert("Failed to update identity", "error")
+        }).finally(()=>{
+          this.dialog = false
+        })
+
+      },
+    deleteIdentity(){
+      this.$api.identities.deleteIdentity(this.name).then((response) => {
+        responseMessage = JSON.parse(response.data).data
+        if(responseMessage == "Cannot delete current default identity"){
+          this.alert(responseMessage, "error")
+        }
+        else{
+          this.done("Identity deleted", "success")
+        }
+      }).catch((error) => {
+        this.alert("Failed to delete identity", "error")
+      }).finally(()=>{
+          this.dialog = false
+      })
+    }
+  }
+}
+</script>

--- a/jumpscale/packages/admin/frontend/components/settings/Settings.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/Settings.vue
@@ -31,12 +31,28 @@
 
           </v-col>
         </v-row>
+        <v-row align="start" justify="start">
+          <v-col class="mt-0 pt-0" cols="12" md="4">
+            <base-section title="Identities" icon="mdi-account-multiple" :loading="loading.identities">
+              <template #actions>
+                <v-btn text @click.stop="dialogs.addIdentity = true">
+                  <v-icon left>mdi-plus</v-icon> New
+                </v-btn>
+              </template>
+              <v-chip class="mr-2 mb-2" @change="setIdentity" outlined v-for="(identity, i) in identities" :key="i" :color="getColor(identity.instance_name)" @click="openIdentity(identity.instance_name)">
+                {{identity.instance_name}}
+              </v-chip>
+            </base-section>
+          </v-col>
+        </v-row>
       </template>
     </base-component>
-    
+
     <add-admin v-model="dialogs.addAdmin" @done="listAdmins"></add-admin>
     <remove-admin v-model="dialogs.removeAdmin" :name="selectedAdmin" @done="listAdmins"></remove-admin>
-  
+    <identity-info v-model="dialogs.identityInfo" :name="selectedIdentity" @done="listIdentities"></identity-info>
+    <add-identity v-model="dialogs.addIdentity" @done="listIdentities"></add-identity>
+
   </div>
 </template>
 
@@ -45,24 +61,32 @@
     components: {
       'add-admin': httpVueLoader("./AddAdmin.vue"),
       'remove-admin': httpVueLoader("./RemoveAdmin.vue"),
+      'identity-info': httpVueLoader("./IdentityInfo.vue"),
+      'add-identity': httpVueLoader("./AddIdentity.vue")
     },
     data () {
       return {
         loading: {
           explorers: false,
           admins: false,
+          identities: false
         },
         selectedAdmin: null,
         dialogs: {
           addAdmin: false,
-          removeAdmin: false
+          removeAdmin: false,
+          identityInfo: false,
+          addIdentity: false,
         },
         admins: [],
         explorers: [
           {name: "Main Network", url: "https://explorer.grid.tf", type: "main"},
           {name: "Test Network", url: "https://explorer.testnet.grid.tf", type: "testnet"}
         ],
-        explorer: null
+        explorer: null,
+        identity: null,
+        selectedIdentity:null,
+        identities: []
       }
     },
     methods: {
@@ -92,11 +116,52 @@
         }).catch((error) => {
           this.alert("Failed to update explorer", "error")
         })
-      },      
+      },
+      listIdentities(){
+        this.getCurrentIdentity()
+        this.loading.identities = true
+        this.$api.identities.list().then((response) => {
+          this.identities = JSON.parse(response.data).data
+        }).finally(() => {
+          this.loading.identities = false
+        })
+
+      },
+      openIdentity(identity){
+        this.selectedIdentity = identity
+        this.dialogs.identityInfo = true
+      },
+      getCurrentIdentity () {
+        this.loading.identities = true
+        this.$api.admins.getCurrentUser().then((response) => {
+          this.identity = JSON.parse(response.data).data.instance_name
+        }).finally(() => {
+          this.loading.identities = false
+        })
+      },
+      setIdentity(identityInstanceName){
+        this.$api.identities.setIdentity(identityInstanceName).then((response) => {
+          this.alert("Identity Updated", "success")
+        }).catch((error) => {
+          this.alert("Failed to update identity", "error")
+        })
+
+      },
+      getColor(identityInstanceName){
+        if(identityInstanceName == this.identity){
+          return "primary"
+        }
+        else{
+          return ""
+        }
+
+      }
     },
     mounted () {
       this.listAdmins()
       this.getCurrentExplorer()
+      this.getCurrentIdentity()
+      this.listIdentities()
     }
   }
 </script>

--- a/jumpscale/packages/admin/frontend/components/wallets/Wallet.vue
+++ b/jumpscale/packages/admin/frontend/components/wallets/Wallet.vue
@@ -42,9 +42,10 @@
       </v-simple-table>
     </template>
     <template #actions>
+      <v-btn text @click="updateTrustlines">Update trustlines</v-btn>
       <v-btn text @click="close">Close</v-btn>
     </template>
-  </base-dialog>  
+  </base-dialog>
 </template>
 
 <script>
@@ -75,6 +76,15 @@ module.exports = {
       }).finally(() => {
         this.loading = false
       })
+    },
+    updateTrustlines(){
+      this.loading = true
+      this.$api.wallets.updateTrustlines(this.name).then((response) => {
+        this.done("Trustlines updated", "success")
+      }).finally(() => {
+        this.loading = false
+      })
+
     }
   }
 }


### PR DESCRIPTION
Identities
- Add/register new identity from dashboard settings
- View identities in dashboard settings
- Delete identity from dashboard
- Change default identity used from dashboard (will be set in ` j.core.identity.me`)

Wallets
- Add update known trustline option for wallets from dashboard

![Screenshot from 2020-07-20 16-04-31](https://user-images.githubusercontent.com/17128393/87949985-04607180-caa7-11ea-951f-8dd1755869bf.png)
![Screenshot from 2020-07-20 16-04-39](https://user-images.githubusercontent.com/17128393/87949991-05919e80-caa7-11ea-8ddc-ab8884cab89f.png)
![Screenshot from 2020-07-20 16-05-24](https://user-images.githubusercontent.com/17128393/87950000-075b6200-caa7-11ea-8d50-b564013b4225.png)

![Screenshot from 2020-07-20 16-05-05](https://user-images.githubusercontent.com/17128393/87949993-062a3500-caa7-11ea-8987-e04e9c896039.png)




