### PR TITLE
avoid reloading the entire page when cancelling workloads

### DIFF
--- a/jumpscale/packages/admin/frontend/components/base/Dialog.vue
+++ b/jumpscale/packages/admin/frontend/components/base/Dialog.vue
@@ -3,10 +3,9 @@
     <v-card :loading="loading" :disabled="loading">
       <v-card-title class="headline">{{title}}</v-card-title>
       <v-card-text class="pa-5">
+        <v-alert v-if="error" dense outlined type="error" class="mb-5">{{error}}</v-alert>
 
-        <v-alert v-if="error" dense outlined type="error" class="mb-5">
-          {{error}}
-        </v-alert>
+        <v-alert v-if="info" dense outlined type="info" class="mb-5">{{info}}</v-alert>
 
         <slot name="default"></slot>
       </v-card-text>
@@ -20,22 +19,23 @@
 </template>
 
 <script>
-  module.exports = {
-    props: { 
-      value: Boolean, 
-      title: String,
-      error: String,
-      loading: Boolean
-    },
-    computed: {
-      dialog: {
-        get () {
-          return this.value
-        },
-        set (value) {
-          this.$emit('input', value)
-        }
+module.exports = {
+  props: {
+    value: Boolean,
+    title: String,
+    error: String,
+    info: String,
+    loading: Boolean,
+  },
+  computed: {
+    dialog: {
+      get() {
+        return this.value;
       },
-    }
-  }
+      set(value) {
+        this.$emit("input", value);
+      },
+    },
+  },
+};
 </script>

--- a/jumpscale/packages/admin/frontend/components/workloads/CancelWorkload.vue
+++ b/jumpscale/packages/admin/frontend/components/workloads/CancelWorkload.vue
@@ -1,8 +1,12 @@
 <template>
-  <base-dialog title="Cancel Workload" v-model="dialog" :error="error" :loading="loading">
-    <template #default>
-      Are you sure you want to cancel workload {{ wid }}?
-    </template>
+  <base-dialog
+    title="Cancel Workload"
+    v-model="dialog"
+    :error="error"
+    :info="info"
+    :loading="loading"
+  >
+    <template #default>Are you sure you want to cancel workload {{ workload.id }}?</template>
     <template #actions>
       <v-btn text @click="close">Close</v-btn>
       <v-btn text color="error" @click="submit">Confirm</v-btn>
@@ -11,22 +15,29 @@
 </template>
 
 <script>
-
 module.exports = {
   mixins: [dialog],
-  props: ["wid"],
+  props: ["workload"],
   methods: {
-    submit () {
-      this.loading = true
-      this.error = null
-      this.$api.solutions.cancelWorkload(this.wid).then(response => {
-        this.$router.go(0);
-      }).catch(err => {
-        console.log("failed")
-        this.loading = false
-        this.error = err
-      });
-    }
-  }
-}
+    submit() {
+      this.loading = true;
+      this.error = null;
+      this.info = null;
+
+      this.$api.solutions
+        .cancelWorkload(this.workload.id)
+        .then((response) => {
+          this.loading = false;
+          this.workload.next_action = "DELETE";
+          this.info = "workload successfully deleted";
+          setTimeout(() => this.close(), 2000);
+        })
+        .catch((err) => {
+          console.log(err);
+          this.loading = false;
+          this.error = err.response.data["error"];
+        });
+    },
+  },
+};
 </script>

--- a/jumpscale/packages/admin/frontend/components/workloads/Workload.vue
+++ b/jumpscale/packages/admin/frontend/components/workloads/Workload.vue
@@ -2,29 +2,29 @@
   <div>
     <base-dialog title="Workload Details" v-model="dialog" :loading="loading">
       <template #default>
-          <v-simple-table>
-              <template v-slot:default>
-                <tbody>
-                    <tr v-for="(item, key) in data" :key="key">
-                        <th>{{ key }}</th>
-                        <td> {{ item }} </td>
-                    </tr>
-                </tbody>
-              </template>
+        <v-simple-table>
+          <template v-slot:default>
+            <tbody>
+              <tr v-for="(item, key) in workload" :key="key">
+                <th>{{ key }}</th>
+                <td>{{ item }}</td>
+              </tr>
+            </tbody>
+          </template>
+        </v-simple-table>
       </template>
       <template #actions>
-      <v-btn text @click="close">Close</v-btn>
-      <v-btn text color="error" @click="cancel()">Cancel Workload</v-btn>
-    </template>
+        <v-btn text @click="close">Close</v-btn>
+        <v-btn text color="error" v-if="cancel_button" @click="cancel()">Cancel workload</v-btn>
+      </template>
     </base-dialog>
-    <cancel-workload v-model="dialogs.cancelWorkload" v-if="data" :wid="data.id"></cancel-workload>
+    <cancel-workload v-model="dialogs.cancelWorkload" v-if="workload" :workload="workload"></cancel-workload>
   </div>
 </template>
 
 <script>
-
 module.exports = {
-  props: {data: Object},
+  props: { workload: Object },
   mixins: [dialog],
   components: {
     "cancel-workload": httpVueLoader("./CancelWorkload.vue"),
@@ -34,13 +34,17 @@ module.exports = {
       dialogs: {
         cancelWorkload: false,
       },
-      wid:null,
     };
   },
-  methods: {
-    cancel () {
-        this.dialogs.cancelWorkload = true;
+  computed: {
+      cancel_button() {
+        return !(this.workload.next_action == "DELETE" || this.workload.next_action == "DELETED")
       },
-  }
-}
+  },
+  methods: {
+    cancel() {
+      this.dialogs.cancelWorkload = true;
+    },
+  },
+};
 </script>

--- a/jumpscale/packages/admin/frontend/components/workloads/Workloads.vue
+++ b/jumpscale/packages/admin/frontend/components/workloads/Workloads.vue
@@ -3,136 +3,163 @@
     <base-component title="Workloads" icon="mdi-clipboard-list-outline" :loading="loading">
       <template #actions>
         <v-btn color="primary" :disabled="!delete_enabled" @click="cancelSelected">
-          <v-icon left>mdi-delete</v-icon> Delete Selected
+          <v-icon left>mdi-delete</v-icon>Delete Selected
         </v-btn>
       </template>
       <template #default>
-        <v-data-table v-model="selected_rows" show-select :headers="headers" :items="data" @click:row="open">
-            <template v-slot:item.epoch="{ item }">
-            {{ new Date(item.epoch * 1000).toLocaleString() }}
-          </template>
+        <v-data-table
+          v-model="selected_rows"
+          show-select
+          :headers="headers"
+          :items="data"
+          @click:row="open"
+        >
+          <template v-slot:item.epoch="{ item }">{{ new Date(item.epoch * 1000).toLocaleString() }}</template>
           <template v-slot:body.prepend="{ headers }">
-          <tr>
-              <td>
-              </td>
+            <tr>
+              <td></td>
               <td>
                 <v-text-field v-model="filters.id" clearable filled hide-details dense></v-text-field>
               </td>
               <td>
-              <v-select v-model="filters.workload_type" :items="types" clearable filled hide-details dense></v-select>
+                <v-select
+                  v-model="filters.workload_type"
+                  :items="types"
+                  clearable
+                  filled
+                  hide-details
+                  dense
+                ></v-select>
               </td>
               <td>
-              <v-select v-model="filters.pool_id" :items="pools" clearable filled hide-details dense></v-select>
+                <v-select
+                  v-model="filters.pool_id"
+                  :items="pools"
+                  clearable
+                  filled
+                  hide-details
+                  dense
+                ></v-select>
               </td>
               <td>
-              <v-select v-model="filters.next_action" :items="actions" clearable filled hide-details dense></v-select>
+                <v-select
+                  v-model="filters.next_action"
+                  :items="actions"
+                  clearable
+                  filled
+                  hide-details
+                  dense
+                ></v-select>
               </td>
-          </tr>
+            </tr>
           </template>
         </v-data-table>
       </template>
     </base-component>
 
-    <workload-info v-model="dialogs.dialog" :data="selected"></workload-info>
-    <patch-cancel v-model="dialogs.patchCancelWorkloads" :wids="wids"></patch-cancel>
+    <workload-info v-model="dialogs.dialog" v-if="selected" :workload="selected"></workload-info>
+    <patch-cancel v-model="dialogs.patchCancelWorkloads" :selected="todelete"></patch-cancel>
   </div>
 </template>
 
 
 <script>
-  module.exports = {
-    components: {
-      'workload-info': httpVueLoader("./Workload.vue"),
-      'patch-cancel': httpVueLoader("./PatchCancel.vue")
-    },
-    data () {
-      return {
-        loading: false,
-        selected: null,
-        selected_rows: [],
-        workloads: [],
-        types: [],
-        pools: [],
-        actions: [],
-        filters: {
-          id: null,
-          pool_id: null,
-          workload_type: null,
-          next_action: null,
-        },
-        headers: [
-          {text: "ID", value: "id"},
-          {text: "Workload Type", value: "workload_type"},
-          {text: "Pool", value: "pool_id"},
-          {text: "Next Action", value: "next_action"},
-          {text: "Creation Time", value: "epoch"},
-        ],
-        dialogs: {
-          dialog: false,
-          patchCancelWorkloads: false,
-        },
-      }
-    },
-    computed: {
-      data () {
-        return this.workloads.filter((record) => {
-          let result = []
-          Object.keys(this.filters).forEach(key => {
-            result.push(!this.filters[key] || String(record[key]).includes(this.filters[key]))
-          })
-          return result.every(Boolean)
-        })
+module.exports = {
+  components: {
+    "workload-info": httpVueLoader("./Workload.vue"),
+    "patch-cancel": httpVueLoader("./PatchCancel.vue"),
+  },
+  data() {
+    return {
+      loading: false,
+      selected: null,
+      selected_rows: [],
+      workloads: [],
+      types: [],
+      pools: [],
+      actions: [],
+      filters: {
+        id: null,
+        pool_id: null,
+        workload_type: null,
+        next_action: null,
       },
-      delete_enabled() {
-        if (this.selected_rows.length > 0) {
-          return true
-        }
-        return false
+      headers: [
+        { text: "ID", value: "id" },
+        { text: "Workload Type", value: "workload_type" },
+        { text: "Pool", value: "pool_id" },
+        { text: "Next Action", value: "next_action" },
+        { text: "Creation Time", value: "epoch" },
+      ],
+      dialogs: {
+        dialog: false,
+        patchCancelWorkloads: false,
       },
-      wids () {
-          let res = []
-          for (i = 0; i < this.selected_rows.length; i++) {
-              res.push(this.selected_rows[i].id)
-          }
-          return res
-      }
+    };
+  },
+  computed: {
+    data() {
+      return this.workloads.filter((record) => {
+        let result = [];
+        Object.keys(this.filters).forEach((key) => {
+          result.push(
+            !this.filters[key] ||
+              String(record[key]).includes(this.filters[key])
+          );
+        });
+        return result.every(Boolean);
+      });
     },
-    methods: {
-      getWorkloads () {
-        this.loading = true
-        this.pools = []
-        this.types = []
-        this.actions = []
-        this.$api.solutions.getAll().then((response) => {
-          this.workloads = JSON.parse(response.data).data
+    delete_enabled() {
+      return this.selected_rows.length > 0;
+    },
+    todelete() {
+      let res = [];
+      for (i = 0; i < this.selected_rows.length; i++) {
+        res.push(this.selected_rows[i]);
+      }
+      return res;
+    },
+  },
+  methods: {
+    getWorkloads() {
+      this.loading = true;
+      this.pools = [];
+      this.types = [];
+      this.actions = [];
+      this.$api.solutions
+        .getAll()
+        .then((response) => {
+          this.workloads = JSON.parse(response.data).data;
           for (let i = 0; i < this.workloads.length; i++) {
             let workload = this.workloads[i];
             if (!this.pools.includes(workload.pool_id)) {
-                this.pools.push(workload.pool_id)
+              this.pools.push(workload.pool_id);
             }
             if (!this.actions.includes(workload.next_action)) {
-                this.actions.push(workload.next_action)
+              this.actions.push(workload.next_action);
             }
             if (!this.types.includes(workload.workload_type)) {
-                this.types.push(workload.workload_type)
+              this.types.push(workload.workload_type);
             }
           }
-        }).finally (() => {
-          this.loading = false
         })
-      },
-      open (workload) {
-        this.selected = workload
-        this.dialogs.dialog = true
-      },
-      cancelSelected() {
-        this.dialogs.patchCancelWorkloads = true
-      },
+        .finally(() => {
+          this.loading = false;
+        });
     },
-    mounted () {
-      this.getWorkloads()
-    }
-  }
+    open(workload) {
+      this.selected = workload;
+      this.dialogs.dialog = true;
+    },
+    cancelSelected() {
+      this.dialogs.patchCancelWorkloads = true;
+    },
+  },
+  mounted() {
+    this.getWorkloads();
+  },
+};
 </script>
 
 

--- a/jumpscale/packages/admin/frontend/mixins/dialog.js
+++ b/jumpscale/packages/admin/frontend/mixins/dialog.js
@@ -4,6 +4,7 @@ dialog = {
     return {
       form: {},
       error: null,
+      info: null,
       loading: false
     }
   },
@@ -28,6 +29,7 @@ dialog = {
     },
     close () {
       this.error = null
+      this.info = null
       this.dialog = false
       this.reset()
     }


### PR DESCRIPTION
Instead we now just update the required field on the workload object and
close the dialog window