### PR TITLE
use pointer cursor when hovering row of the table logs

### DIFF
--- a/jumpscale/packages/admin/frontend/components/logs/Logs.vue
+++ b/jumpscale/packages/admin/frontend/components/logs/Logs.vue
@@ -142,4 +142,7 @@ input {
 .v-text-field {
   padding: 10px 0px !important;
 }
+.v-data-table tr {
+  cursor: pointer;
+}
 </style>


### PR DESCRIPTION
it makes it more explicit for user they can clock on the row to get a
detailed view of the log

fixes #381