### PR TITLE
show workload node_id and state in the frontend

### DIFF
--- a/jumpscale/packages/admin/frontend/components/workloads/Workloads.vue
+++ b/jumpscale/packages/admin/frontend/components/workloads/Workloads.vue
@@ -142,9 +142,17 @@ module.exports = {
             if (!this.types.includes(workload.workload_type)) {
               this.types.push(workload.workload_type);
             }
+            // show node id
+            workload["node id"] = workload.info.node_id;
+            // show workload state
+            workload.state = Workload_STATE[workload.info.result.state];
+            workload.message = workload.info.result.message;
+            // convert date
             workload.epoch = new Date(workload.epoch * 1000).toLocaleString();
+            // convert vloume type
             if (workload.workload_type === "Volume")
               workload.type = VOLUMES_TYPE[workload.type];
+            // convert container disk type
             if (workload.workload_type === "Container") {
               workload.capacity.disk_type =
                 VOLUMES_TYPE[workload.capacity.disk_type];

--- a/jumpscale/packages/admin/frontend/data.js
+++ b/jumpscale/packages/admin/frontend/data.js
@@ -194,3 +194,9 @@ const VOLUMES_TYPE = {
   0: "HDD",
   1: "SSD"
 }
+
+const Workload_STATE = {
+  0: "Error",
+  1: "Ok",
+  2: "Deleted",
+}


### PR DESCRIPTION
### Description

Added `node id`, `state`, and `message` if there. and still JSON view for more details. 

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/476

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings


![image](https://user-images.githubusercontent.com/36021484/90977536-67ca3d00-e546-11ea-9fe6-4342c258eef2.png)

