### PR TITLE
allow containers to have an yggdrasil interface

### DIFF
--- a/jumpscale/clients/explorer/models.py
+++ b/jumpscale/clients/explorer/models.py
@@ -42,6 +42,7 @@ class Location(Base):
     def __str__(self):
         return ",".join([x for x in [self.continent, self.country, self.city] if x])
 
+
 class Farm(Base):
     id = fields.Integer()
     threebot_id = fields.Integer()
@@ -55,7 +56,6 @@ class Farm(Base):
 
     def __str__(self):
         return " - ".join([x for x in [self.name, str(self.location)] if x])
-        
 
 
 class WorkloadsAmount(Base):
@@ -247,6 +247,7 @@ class ContainerNetworkConnection(Base):
     network_id = fields.String(default="")
     ipaddress = fields.IPAddress()
     public_ip6 = fields.Boolean()
+    yggdrasil_ip = fields.Boolean()
 
 
 class ContainerLogsRedis(Base):

--- a/jumpscale/sals/zos/container.py
+++ b/jumpscale/sals/zos/container.py
@@ -33,6 +33,7 @@ class ContainerGenerator:
         interactive: bool = False,
         secret_env: dict = {},
         public_ipv6: bool = False,
+        yggdrasil_ip: bool = False,
         storage_url: str = "zdb://hub.grid.tf:9900",
     ) -> Container:
         """Create a container workload object
@@ -72,6 +73,7 @@ class ContainerGenerator:
         net.network_id = network_name
         net.ipaddress = ip_address
         net.public_ip6 = public_ipv6
+        net.yggdrasil_ip = yggdrasil_ip
         cont.network_connection.append(net)
 
         cont.capacity.cpu = cpu

--- a/jumpscale/sals/zos/signature.py
+++ b/jumpscale/sals/zos/signature.py
@@ -124,6 +124,7 @@ def _container_challenge(container):
         b.write(str(nc.network_id))
         b.write(str(nc.ipaddress))
         b.write(str(nc.public_ip6).lower())
+        b.write(str(nc.yggdrasil_ip).lower())
     b.write(str(container.capacity.cpu))
     b.write(str(container.capacity.memory))
     b.write(str(container.capacity.disk_size))


### PR DESCRIPTION
### Description

Allow container workloads to have an yggdrasil network interface

### Changes

Add extra argument into the container create method

### Related Issues

https://github.com/threefoldtech/zos/issues/868

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
