### PR TITLE
remove ubuntu:19.10 from version choice

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/chats/ubuntu.py
+++ b/jumpscale/packages/tfgrid_solutions/chats/ubuntu.py
@@ -11,7 +11,7 @@ from jumpscale.sals.reservation_chatflow import deployer, solutions
 
 class UbuntuDeploy(GedisChatBot):
     HUB_URL = "https://hub.grid.tf/tf-bootable"
-    IMAGES = ["ubuntu-18.04", "ubuntu-19.10", "ubuntu-20.04"]
+    IMAGES = ["ubuntu-18.04", "ubuntu-20.04"]
 
     steps = [
         "ubuntu_name",


### PR DESCRIPTION
### Changes

- remove ubuntu:19.10 from version choice

### Related Issues

[Remove 19.10 release from ubuntu solution](#684)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
