### PR TITLE
Add links in header for terms, disclaimer and manual...

### DIFF
--- a/jumpscale/packages/admin/frontend/App.vue
+++ b/jumpscale/packages/admin/frontend/App.vue
@@ -1,20 +1,17 @@
 <template>
   <v-app>
     <v-app-bar app>
-      <v-switch
-        v-model="darkTheme"
-        hide-details
-        inset
-        label="Dark mode"
-      ></v-switch>
+      <v-switch v-model="darkTheme" hide-details inset label="Dark mode"></v-switch>
       <v-spacer></v-spacer>
       <v-chip label flat color="transparent" class="pr-5">
-        <v-icon color="primary" left>mdi-clock-outline</v-icon> {{ timenow }}
+        <v-icon color="primary" left>mdi-clock-outline</v-icon>
+        {{ timenow }}
       </v-chip>
       <v-menu v-if="user.username" v-model="menu" :close-on-content-click="false" offset-x>
         <template v-slot:activator="{ on }">
           <v-btn text v-on="on">
-            <v-icon color="primary" left>mdi-account</v-icon> {{user.username}}
+            <v-icon color="primary" left>mdi-account</v-icon>
+            {{user.username}}
           </v-btn>
         </template>
         <v-card>
@@ -30,6 +27,27 @@
                 <v-list-item-subtitle>{{user.email}}</v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-btn text color="blue" :to="'/terms'">Terms and Conditions</v-btn>
+              </v-list-item-content>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-btn text color="blue" :to="'/disclaimer'">Disclaimer</v-btn>
+              </v-list-item-content>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-btn
+                  text
+                  :link="true"
+                  color="blue"
+                  href="https://manual-testnet.threefold.io/#/"
+                  target="_blank"
+                >Manual</v-btn>
+              </v-list-item-content>
+            </v-list-item>
           </v-list>
 
           <v-divider></v-divider>
@@ -43,17 +61,11 @@
       </v-menu>
     </v-app-bar>
 
-    <v-navigation-drawer
-      color="navbar"
-      class="elevation-3"
-      :mini-variant="mini"
-      app
-      permanent
-      dark
-    >
+    <v-navigation-drawer color="navbar" class="elevation-3" :mini-variant="mini" app permanent dark>
       <v-sheet color="#148F77">
         <v-list class="text-center">
-          <img src="./assets/3bot.png" :width="mini ? 40 : 128"/><br>
+          <img src="./assets/3bot.png" :width="mini ? 40 : 128" />
+          <br />
           <v-list-item v-if="identity">
             <v-list-item-content>
               <v-list-item-title>{{identity.name}} ({{identity.id}})</v-list-item-title>
@@ -65,7 +77,7 @@
           </v-list-item>
           <v-list-item v-else>
             <v-btn text block @click.stop="dialogs.identity = true">
-              <v-icon left>mdi-account-cog</v-icon> Set identity
+              <v-icon left>mdi-account-cog</v-icon>Set identity
             </v-btn>
           </v-list-item>
         </v-list>
@@ -103,20 +115,20 @@
 </template>
 
 <script>
-module.exports =  {
-  data () {
+module.exports = {
+  data() {
     return {
       darkTheme: this.$vuetify.theme.dark,
       user: {},
       identity: null,
       menu: false,
-      mini:false,
+      mini: false,
       timenow: null,
       clockInterval: null,
       dialogs: {
         identity: false
       }
-    }
+    };
   },
   components: {
     identities: httpVueLoader("./Identity.vue")
@@ -124,65 +136,65 @@ module.exports =  {
   computed: {},
   methods: {},
   computed: {
-    pages () {
-      return this.$router.options.routes.filter((page) => {
-        return page.meta.listed
-      })
+    pages() {
+      return this.$router.options.routes.filter(page => {
+        return page.meta.listed;
+      });
     }
   },
   watch: {
-    darkTheme(val){
-        $cookies.set('darkTheme', val ? "1" : "0")
-        this.$vuetify.theme.dark = val
+    darkTheme(val) {
+      $cookies.set("darkTheme", val ? "1" : "0");
+      this.$vuetify.theme.dark = val;
     }
   },
   methods: {
-    getCurrentUser () {
-      this.$api.user.currentUser().then((response) => {
-        this.user = response.data
-      })
+    getCurrentUser() {
+      this.$api.user.currentUser().then(response => {
+        this.user = response.data;
+      });
     },
-    getIdentity () {
-      this.$api.identity.get().then((response) => {
-        this.identity = JSON.parse(response.data)
-      })
+    getIdentity() {
+      this.$api.identity.get().then(response => {
+        this.identity = JSON.parse(response.data);
+      });
     },
-    setTimeLocal () {
-      this.timenow = new Date().toLocaleString()
+    setTimeLocal() {
+      this.timenow = new Date().toLocaleString();
     },
     getCookie(cname) {
-        var name = cname + "=";
-        var ca = document.cookie.split(';');
-        for(var i = 0; i < ca.length; i++) {
-          var c = ca[i];
-          while (c.charAt(0) == ' ') {
-            c = c.substring(1);
-          }
-          if (c.indexOf(name) == 0) {
-            return c.substring(name.length, c.length);
-          }
+      var name = cname + "=";
+      var ca = document.cookie.split(";");
+      for (var i = 0; i < ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == " ") {
+          c = c.substring(1);
         }
-        return "";
-      },
-      checkDarkMode(){
-        let cookie = this.getCookie("darkTheme")
-        if (cookie == "")
-          this.$vuetify.theme.dark = this.darkTheme = false
-        else
-          this.$vuetify.theme.dark = this.darkTheme = cookie == "1" ? true : false;
+        if (c.indexOf(name) == 0) {
+          return c.substring(name.length, c.length);
+        }
       }
+      return "";
+    },
+    checkDarkMode() {
+      let cookie = this.getCookie("darkTheme");
+      if (cookie == "") this.$vuetify.theme.dark = this.darkTheme = false;
+      else
+        this.$vuetify.theme.dark = this.darkTheme =
+          cookie == "1" ? true : false;
+    }
   },
   mounted() {
-    this.checkDarkMode()
+    this.checkDarkMode();
     this.getIdentity();
     this.getCurrentUser();
-    this.setTimeLocal()
+    this.setTimeLocal();
     this.clockInterval = setInterval(() => {
-     this.setTimeLocal()
+      this.setTimeLocal();
     }, 1000);
   },
-  destroyed () {
-    clearInterval(this.clockInterval)
+  destroyed() {
+    clearInterval(this.clockInterval);
   }
 };
 </script>

--- a/jumpscale/packages/admin/frontend/api.js
+++ b/jumpscale/packages/admin/frontend/api.js
@@ -2,6 +2,13 @@
 const baseURL = "/admin/actors"
 
 const apiClient = {
+  content: {
+    get: (url) => {
+      return axios({
+        url: url
+      })
+    }
+  },
   logs: {
     listApps: () => {
       return axios({
@@ -218,7 +225,7 @@ const apiClient = {
     },
     getPools: (include_hidden) => {
       return axios({
-        method:"post",
+        method: "post",
         url: `/tfgrid_solutions/actors/solutions/list_pools`,
         data: {
           include_hidden: include_hidden || false,

--- a/jumpscale/packages/admin/frontend/components/base/MarkdownViewer.vue
+++ b/jumpscale/packages/admin/frontend/components/base/MarkdownViewer.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-container>
+    <v-row v-if="loading" style="height:100%" align="center" justify="center">
+      <v-progress-circular size="100" width="5" color="primary" indeterminate></v-progress-circular>
+    </v-row>
+    <!-- <vue-simple-markdown v-else :source="source" :emoji="false"></vue-simple-markdown> -->
+    <div v-html="source"></div>
+  </v-container>
+</template>
+
+<script>
+module.exports = {
+  data() {
+    return {
+      source: "",
+      loading: true
+    };
+  },
+  props: {
+    url: String,
+    baseUrl: String
+  },
+  mounted() {
+    this.loading = true;
+    this.$root.$emit("sidebar", true);
+    this.$api.content.get(this.url).then(res => {
+      let options = {};
+      if (this.baseUrl) {
+        options.baseUrl = this.baseUrl;
+      }
+      this.source = marked(res.data, options);
+      this.loading = false;
+    });
+  }
+};
+</script>

--- a/jumpscale/packages/admin/frontend/components/legal/Disclaimer.vue
+++ b/jumpscale/packages/admin/frontend/components/legal/Disclaimer.vue
@@ -1,0 +1,6 @@
+<template>
+  <markdown-view
+    base-url="https://wiki.threefold.io/#/"
+    url="https://raw.githubusercontent.com/threefoldfoundation/legal/master/src/tf_grid_testnet_disclaimer.md"
+  ></markdown-view>
+</template>

--- a/jumpscale/packages/admin/frontend/components/legal/Terms.vue
+++ b/jumpscale/packages/admin/frontend/components/legal/Terms.vue
@@ -1,0 +1,7 @@
+<template>
+  <markdown-view
+    base-url="https://wiki.threefold.io/#/"
+    url="https://raw.githubusercontent.com/threefoldfoundation/legal/master/src/termsconditions.md"
+  ></markdown-view>
+</template>
+

--- a/jumpscale/packages/admin/frontend/index.html
+++ b/jumpscale/packages/admin/frontend/index.html
@@ -24,6 +24,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.55.0/mode/python/python.min.js"></script>
     <script src="https://unpkg.com/vue-json-tree@0.4.1/dist/json-tree.js"></script>
     <script src="https://unpkg.com/vue-cookies@1.5.12/vue-cookies.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+
     <script src="api.js"></script>
     <script src="data.js"></script>
     <script src="index.js"></script>

--- a/jumpscale/packages/admin/frontend/index.js
+++ b/jumpscale/packages/admin/frontend/index.js
@@ -12,7 +12,7 @@ const vuetify = new Vuetify({
       dark: {
         navbar: '#363636'
       },
-      light:{
+      light: {
         primary: '#1B4F72',
         navbar: '#1B4F72',
         secondary: '#CCCBCA',
@@ -31,6 +31,8 @@ const baseSection = httpVueLoader('./components/base/Section.vue')
 const external = httpVueLoader('./components/base/External.vue')
 const popup = httpVueLoader('./components/base/Popup.vue')
 const code = httpVueLoader('./components/base/Code.vue')
+const markdownViewer = httpVueLoader('./components/base/MarkdownViewer.vue')
+
 
 const app = httpVueLoader('./App.vue')
 const dashboard = httpVueLoader('./components/dashboard/Dashboard.vue')
@@ -51,7 +53,8 @@ const solutions = httpVueLoader('./components/solutions/Solutions.vue')
 const solution = httpVueLoader('./components/solutions/Solution.vue')
 const solutionChatflow = httpVueLoader('./components/solutions/SolutionChatflow.vue')
 const backup = httpVueLoader('./components/backup/Backup.vue')
-
+const terms = httpVueLoader('./components/legal/Terms.vue')
+const disclaimer = httpVueLoader('./components/legal/Disclaimer.vue')
 
 Vue.use(VueCodemirror)
 
@@ -72,6 +75,8 @@ Vue.component("json-renderer", JSONRender)
 Vue.component("external", external)
 Vue.component("popup", popup)
 Vue.component("code-area", code)
+Vue.component("markdown-view", markdownViewer)
+
 
 const router = new VueRouter({
   routes: [
@@ -93,6 +98,8 @@ const router = new VueRouter({
     { name: "Settings", path: '/settings', component: settings, meta: { icon: "mdi-tune", listed: true } },
     { name: "SolutionChatflow", path: '/solutions/:topic', component: solutionChatflow, props: true, meta: { icon: "mdi-tune" } },
     { name: "Solution", path: '/solutions/workloads/:type', component: solution, props: true, meta: { icon: "mdi-tune" } },
+    { name: "Terms", path: '/terms', component: terms, meta: { icon: "mdi-apps" } },
+    { name: "Disclaimer", path: '/disclaimer', component: disclaimer, meta: { icon: "mdi-apps" } },
   ]
 })
 

--- a/jumpscale/packages/marketplace/frontend/App.vue
+++ b/jumpscale/packages/marketplace/frontend/App.vue
@@ -33,6 +33,22 @@
                 <v-btn text color="blue" :to="'/terms'">Terms and Conditions</v-btn>
               </v-list-item-content>
             </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-btn text color="blue" :to="'/disclaimer'">Disclaimer</v-btn>
+              </v-list-item-content>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-content>
+                <v-btn
+                  text
+                  :link="true"
+                  color="blue"
+                  href="https:/manual-testnet.threefold.io/#/"
+                  target="_blank"
+                >Manual</v-btn>
+              </v-list-item-content>
+            </v-list-item>
           </v-list>
           <v-divider></v-divider>
           <v-card-actions>
@@ -58,26 +74,26 @@ module.exports = {
       user: {},
       menu: false,
       mini: false,
-      solutionCount: {},
+      solutionCount: {}
     };
   },
   computed: {},
   methods: {},
   methods: {
     getCurrentUser() {
-      this.$api.admins.getCurrentUser().then((response) => {
+      this.$api.admins.getCurrentUser().then(response => {
         this.user = response.data;
       });
     },
     getSolutionCount() {
-      this.$api.solutions.getCount().then((response) => {
+      this.$api.solutions.getCount().then(response => {
         this.solutionCount = response.data.data;
       });
-    },
+    }
   },
   mounted() {
     this.getCurrentUser();
     this.getSolutionCount();
-  },
+  }
 };
 </script>

--- a/jumpscale/packages/marketplace/frontend/api.js
+++ b/jumpscale/packages/marketplace/frontend/api.js
@@ -1,6 +1,13 @@
 // const axios = require('axios')
 
 const apiClient = {
+  content: {
+    get: (url) => {
+      return axios({
+        url: url
+      })
+    }
+  },
   admins: {
     getCurrentUser: () => {
       return axios({

--- a/jumpscale/packages/marketplace/frontend/components/Disclaimer.vue
+++ b/jumpscale/packages/marketplace/frontend/components/Disclaimer.vue
@@ -1,0 +1,6 @@
+<template>
+  <markdown-view
+    base-url="https://wiki.threefold.io/#/"
+    url="https://raw.githubusercontent.com/threefoldfoundation/legal/master/src/tf_grid_testnet_disclaimer.md"
+  ></markdown-view>
+</template>

--- a/jumpscale/packages/marketplace/frontend/components/Home.vue
+++ b/jumpscale/packages/marketplace/frontend/components/Home.vue
@@ -73,44 +73,44 @@ module.exports = {
       loading: false,
       solutionCount: {},
       searchText: "",
-      apps: Object.values(APPS),
+      apps: Object.values(APPS)
     };
   },
   computed: {
     filteredSolutions() {
       if (this.searchText) {
-        return this.solutions.filter((obj) => {
+        return this.solutions.filter(obj => {
           return obj.name === this.searchText;
         });
       } else return this.solutions;
     },
     filteredApps() {
       if (this.searchText) {
-        return this.apps.filter((obj) => {
+        return this.apps.filter(obj => {
           return obj.name === this.searchText;
         });
       } else return this.apps;
-    },
+    }
   },
   methods: {
     openChatflow(solutionTopic) {
       this.$router.push({
         name: "SolutionChatflow",
-        params: { topic: solutionTopic },
+        params: { topic: solutionTopic }
       });
     },
     viewWorkloads(solutionType) {
       this.$router.push({ name: "Solution", params: { type: solutionType } });
     },
     getSolutionCount() {
-      this.$api.solutions.getCount().then((response) => {
+      this.$api.solutions.getCount().then(response => {
         this.solutionCount = response.data.data;
       });
-    },
+    }
   },
   mounted() {
     this.getSolutionCount();
-  },
+  }
 };
 </script>
 

--- a/jumpscale/packages/marketplace/frontend/components/License.vue
+++ b/jumpscale/packages/marketplace/frontend/components/License.vue
@@ -3,11 +3,16 @@
     <v-card flat height="100%" class="pa-5" outlined>
       <v-card-title class="justify-center">Terms and Conditions for using TF Grid Marketplace</v-card-title>
       <v-card-text>
-        It's required that you as a Marketplace user you agree to the
+        It's required that you as TF Grid user you agree to the
         <a
           target="_blank"
           href="https://wiki.threefold.io/#/terms_conditions"
-        >Terms and Conditions</a>
+        >Terms and Conditions.</a>
+        After that, to get started quickly, please check
+        <a
+          target="_blank"
+          href="https://manual-testnet.threefold.io/#/getting_started"
+        >pre-requisites</a>
       </v-card-text>
       <v-divider></v-divider>
       <v-card-actions>
@@ -33,18 +38,18 @@
 <script>
 module.exports = {
   methods: {
-    accept: function (event) {
-      this.$api.license.accept().then((result) => {
+    accept: function(event) {
+      this.$api.license.accept().then(result => {
         this.$root.$emit("sidebar", true);
         this.$router.push({ path: "/" });
       });
-    },
+    }
   },
   data() {
     return { showConfirmation: false };
   },
   mounted() {
     this.$root.$emit("sidebar", false);
-  },
+  }
 };
 </script>

--- a/jumpscale/packages/marketplace/frontend/components/MarkdownViewer.vue
+++ b/jumpscale/packages/marketplace/frontend/components/MarkdownViewer.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-container>
+    <v-row v-if="loading" style="height:100%" align="center" justify="center">
+      <v-progress-circular size="100" width="5" color="primary" indeterminate></v-progress-circular>
+    </v-row>
+    <!-- <vue-simple-markdown v-else :source="source" :emoji="false"></vue-simple-markdown> -->
+    <div v-html="source"></div>
+  </v-container>
+</template>
+
+<script>
+module.exports = {
+  data() {
+    return {
+      source: "",
+      loading: true
+    };
+  },
+  props: {
+    url: String,
+    baseUrl: String
+  },
+  mounted() {
+    this.loading = true;
+    this.$root.$emit("sidebar", true);
+    this.$api.content.get(this.url).then(res => {
+      let options = {};
+      if (this.baseUrl) {
+        options.baseUrl = this.baseUrl;
+      }
+      this.source = marked(res.data, options);
+      this.loading = false;
+    });
+  }
+};
+</script>

--- a/jumpscale/packages/marketplace/frontend/components/Terms.vue
+++ b/jumpscale/packages/marketplace/frontend/components/Terms.vue
@@ -1,69 +1,7 @@
 <template>
-  <v-card flat height="100%" class="pa-5" outlined>
-    <v-card-text>
-      <p class="display-1 text--primary">The ThreeFold Grid: A High Level Introduction</p>
-      <div class="text--primary">
-        <p>
-          <img width="95%" src="./assets/tf_principle_banner.png" alt="TF Banner" />
-        </p>
-        <p>
-          Originally the internet was intended to be fully peer2peer, today thats not the case. Few datacenters in centralized locations deliver all the capacity for the current internet. This capacity is mainly storage &amp; compute capacity.
-          ThreeFold wants to restore this situation.
-        </p>
-        <p>The ThreeFold Grid is a platform on which any internet experience (or service) can be built on.</p>
-        <ul>
-          <li>Any application which can run on linux (which is +- all) can run on top of the TFGrid.</li>
-          <li>There are already more than 20 projects who are committed to run their workloads on top of the TFGrid.</li>
-        </ul>
-        <br />
-        <p>A dedicated digital currency called TFT has been created to allow anyone to sell/buy this IT capacity (Storage,Compute, Network).</p>
-        <h4 id="the-threefold-grid-is-active">The ThreeFold grid is active</h4>
-        <p>TFGrid today has:</p>
-        <ul>
-          <li>+18000 CPU cores</li>
-          <li>+90,000,000 GB of online storage</li>
-        </ul>
-        <br />
-        <p>TFGrid is the largest peer-to-peer network of Internet (compute, storage and network) capacity in the world. The sum of all IT capacity in the TFGrid is larger than the sum of all IT capacity as used for all blockchain projects (May 2020). This may sound a lot but actually its still small compared to the massive centralized cloud vendors.</p>
-        <p>The system is not distributed enough yet, there are only 50-60 locations, more farmers are needed to grow the grid to its full potential.</p>
-        <p>The ThreeFold Grid needs computers (servers) to function. Servers of all shapes and sizes can be added to the ThreeFold Grid, by anyone, anywhere in the world. Zero-OS is an opensource operating system which needs to be run on the servers to make them extend the grid. People who add these computers to the grid are called farmers. This is a fully decentralized process, farmers downloads the Zero-OS operating system and boot their servers (3nodes). The 3nodes will register themselves in a database called TFDirectory and TFGrid users can then find the capacity they need to run their applications.</p>
-        <h4 id="how-mature-is-the-tfgrid-">How mature is the TFGrid?</h4>
-        <ul>
-          <li>Our Zero-OS is beta quality and is at 2nd major release.</li>
-          <li>The workloads can be registered using json format for our smart contract for IT layer.</li>
-          <li>Experts can use any development language to use the grid as is by using this smart contract for IT layer.</li>
-          <li>We can use some help to improve the documentation though.</li>
-          <li>The marketplace you find here makes your life more easy to play with the ZOS 2.2 (0.4) on TFGrid 2.2</li>
-        </ul>
-        <br />
-        <h4
-          id="there-is-also-an-automation-layer-called-3bot"
-        >There is also an automation layer called 3Bot</h4>
-        <ul>
-          <li>3Bot is your virtual system administrator and here you can see our brand new 2.2 version, deploy your own version on the marketplace (v2.2).</li>
-          <li>Its a very powerful tool to allow you to automate &amp; manage thousands of virtual workload.</li>
-          <li>Python language can be used to extend this tool and make it your own.</li>
-          <li>This new admin panel is alpha quality, be reminded that the workload itself is running on Zero-OS and the smart contract for IT layer which is beta quality.</li>
-        </ul>
-        <br />
-        <h4 id="terms-and-conditions">Terms and Conditions</h4>
-        <p>
-          you cannot use this marketplace or the 3Bot unless you agree with
-          see
-          <a
-            target="_blank"
-            href="https://wiki.threefold.io/#/terms_conditions"
-          >Terms and Conditions</a>
-        </p>
-      </div>
-    </v-card-text>
-  </v-card>
+  <markdown-view
+    base-url="https://wiki.threefold.io/#/"
+    url="https://raw.githubusercontent.com/threefoldfoundation/legal/master/src/termsconditions.md"
+  ></markdown-view>
 </template>
 
-<script>
-module.exports = {
-  mounted() {
-    this.$root.$emit("sidebar", true);
-  },
-};
-</script>

--- a/jumpscale/packages/marketplace/frontend/index.html
+++ b/jumpscale/packages/marketplace/frontend/index.html
@@ -28,6 +28,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.55.0/addon/scroll/simplescrollbars.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.55.0/mode/python/python.min.js"></script>
   <script src="https://unpkg.com/vue-json-tree@0.4.1/dist/json-tree.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+
   <script src="data.js"></script>
   <script src="api.js"></script>
   <script src="index.js"></script>

--- a/jumpscale/packages/marketplace/frontend/index.js
+++ b/jumpscale/packages/marketplace/frontend/index.js
@@ -26,6 +26,7 @@ const baseSection = httpVueLoader('./components/base/Section.vue')
 const external = httpVueLoader('./components/base/External.vue')
 const popup = httpVueLoader('./components/base/Popup.vue')
 const code = httpVueLoader('./components/base/Code.vue')
+const markdownViewer = httpVueLoader('./components/MarkdownViewer.vue')
 
 const app = httpVueLoader('./App.vue')
 const home = httpVueLoader('./components/Home.vue')
@@ -33,7 +34,7 @@ const solution = httpVueLoader('./components/solutions/Solution.vue')
 const solutionChatflow = httpVueLoader('./components/solutions/SolutionChatflow.vue')
 const license = httpVueLoader('./components/License.vue')
 const terms = httpVueLoader('./components/Terms.vue')
-
+const disclaimer = httpVueLoader('./components/Disclaimer.vue')
 
 Vue.component("base-component", baseComponent)
 Vue.component("base-section", baseSection)
@@ -41,12 +42,14 @@ Vue.component("base-dialog", baseDialog)
 Vue.component("external", external)
 Vue.component("popup", popup)
 Vue.component("code-area", code)
+Vue.component("markdown-view", markdownViewer)
 
 const router = new VueRouter({
   routes: [
     { name: "Home", path: '/', component: home, meta: { icon: "mdi-tune" } },
     { name: "License", path: '/license', component: license, meta: { icon: "mdi-apps" } },
     { name: "Terms", path: '/terms', component: terms, meta: { icon: "mdi-apps" } },
+    { name: "Disclaimer", path: '/disclaimer', component: disclaimer, meta: { icon: "mdi-apps" } },
     { name: "Solution", path: '/:type', component: solution, props: true, meta: { icon: "mdi-apps" } },
     { name: "SolutionChatflow", path: '/solutions/:topic', component: solutionChatflow, props: true, meta: { icon: "mdi-tune" } },
 


### PR DESCRIPTION
### Description

Add links in header for terms, disclaimer and manual and renders them directly from github links.

### Changes

The following changes were both done to marketplace/demo and admin packages:

- Show a link to get started in licence confirmation page (#374).
- Added a new component to render remote markdown (#717, #718).
- Add terms, disclaimer and manual as new items to the user drop-down in the header (#717, #718, #752)


### Related Issues

Mentioned per change above.
