### PR TITLE
use the correct port with https redirection when starting local threebot

### DIFF
--- a/jumpscale/sals/nginx/nginx.py
+++ b/jumpscale/sals/nginx/nginx.py
@@ -112,6 +112,7 @@ class Location(Base):
             base_dir=j.core.dirs.BASEDIR,
             location=self,
             threebot_connect=j.core.config.get_config().get("threebot_connect", True),
+            https_port=PORTS.HTTPS
         )
 
     def configure(self):

--- a/jumpscale/sals/nginx/templates/location.conf
+++ b/jumpscale/sals/nginx/templates/location.conf
@@ -17,7 +17,7 @@ location {{ location.path_url }} {
 
     {% if location.force_https %}
         if ($scheme = http) {
-            return 301 https://$host:{{ https_port }}$request_uri;
+            return 302 https://$host:{{ https_port }}$request_uri;
         }
     {% endif %}
 

--- a/jumpscale/sals/nginx/templates/location.conf
+++ b/jumpscale/sals/nginx/templates/location.conf
@@ -17,7 +17,7 @@ location {{ location.path_url }} {
 
     {% if location.force_https %}
         if ($scheme = http) {
-            return 301 https://$host$request_uri;
+            return 301 https://$host:{{ https_port }}$request_uri;
         }
     {% endif %}
 


### PR DESCRIPTION
### Description

Use the correct port with https redirection when starting local threebot.

### Changes

Update the nginx configuration in nginx sal.

### Related Issues

#249.

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
