### PR TITLE
log failed workloads due to explorer errors

### DIFF
--- a/jumpscale/sals/chatflows/chatflows.py
+++ b/jumpscale/sals/chatflows/chatflows.py
@@ -143,6 +143,10 @@ class GedisChatBot:
                 getattr(self, step_name)()
             except StopChatFlow as e:
                 internal_error = True
+                j.logger.exception("error", exception=e)
+                j.tools.alerthandler.alert_raise(
+                    appname="chatflows", category="internal_errors", message=str(e), alert_type="exception"
+                )
                 if e.msg:
                     self.send_error(
                         e.msg + ". Please use the refresh button on the upper right to restart the chatflow", **e.kwargs

--- a/jumpscale/sals/reservation_chatflow/deployer.py
+++ b/jumpscale/sals/reservation_chatflow/deployer.py
@@ -621,8 +621,10 @@ class ChatflowDeployer:
                 success = workload.info.result.state.value == 1
                 if not success:
                     error_message = workload.info.result.message
-                    j.logger.error(
-                        f"Workload {workload.id} failed to deploy due to error {error_message}. For more details: {j.core.identity.me.explorer_url}/reservations/workloads/{workload.id}"
+                    msg = f"Workload {workload.id} failed to deploy due to error {error_message}. For more details: {j.core.identity.me.explorer_url}/reservations/workloads/{workload.id}"
+                    j.logger.error(msg)
+                    j.tools.alerthandler.alert_raise(
+                        appname="chatflows", category="internal_errors", message=msg, alert_type="exception"
                     )
                 return success
             if expiration_provisioning < j.data.time.get().timestamp:

--- a/jumpscale/sals/reservation_chatflow/deployer.py
+++ b/jumpscale/sals/reservation_chatflow/deployer.py
@@ -618,7 +618,13 @@ class ChatflowDeployer:
                 """
                 bot.md_show_update(deploying_message, md=True)
             if workload.info.result.workload_id:
-                return workload.info.result.state.value == 1
+                success = workload.info.result.state.value == 1
+                if not success:
+                    error_message = workload.info.result.message
+                    j.logger.error(
+                        f"Workload {workload.id} failed to deploy due to error {error_message}. For more details: {j.core.identity.me.explorer_url}/reservations/workloads/{workload.id}"
+                    )
+                return success
             if expiration_provisioning < j.data.time.get().timestamp:
                 if workload.info.workload_type != WorkloadType.Network_resource:
                     j.sals.reservation_chatflow.solutions.cancel_solution([workload_id])


### PR DESCRIPTION
### Description

log failed workloads

### Changes

log failed workloads in wait_workload method in deployer.py

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/798


![image](https://user-images.githubusercontent.com/32568986/91836687-6fc36480-ec4b-11ea-8ed9-c3362f7d2776.png)

due to {} is empty because this is manually raised before the workload has a result