### PR TITLE
Renamed chatflow info tooltip

### DIFF
--- a/jumpscale/packages/admin/frontend/components/solutions/Solution.vue
+++ b/jumpscale/packages/admin/frontend/components/solutions/Solution.vue
@@ -25,7 +25,7 @@
                   >mdi-information-outline</v-icon>
                 </a>
               </template>
-              <span>Chatflow Information</span>
+              <span>Go to How-to Manual</span>
             </v-tooltip>
           </v-card-title>
 

--- a/jumpscale/packages/admin/frontend/components/solutions/Solutions.vue
+++ b/jumpscale/packages/admin/frontend/components/solutions/Solutions.vue
@@ -64,7 +64,7 @@
                       <v-icon color="primary" v-bind="attrs" v-on="on" right>mdi-information-outline</v-icon>
                     </a>
                   </template>
-                  <span>Chatflow Information</span>
+                  <span>Go to How-to Manual</span>
                 </v-tooltip>
               </v-card-title>
               <v-card-text style="height:100px" class="mx-2 text--primary">

--- a/jumpscale/packages/marketplace/frontend/components/Home.vue
+++ b/jumpscale/packages/marketplace/frontend/components/Home.vue
@@ -52,7 +52,7 @@
                       <v-icon color="primary" v-bind="attrs" v-on="on" right>mdi-information-outline</v-icon>
                     </a>
                   </template>
-                  <span>Chatflow Information</span>
+                  <span>Go to How-to Manual</span>
                 </v-tooltip>
             </v-card-title>
             <v-card-text style="height:100px" class="mx-2 text--primary">

--- a/jumpscale/packages/marketplace/frontend/components/solutions/Solution.vue
+++ b/jumpscale/packages/marketplace/frontend/components/solutions/Solution.vue
@@ -25,7 +25,7 @@
                   >mdi-information-outline</v-icon>
                 </a>
               </template>
-              <span>Chatflow Information</span>
+              <span>Go to How-to Manual</span>
             </v-tooltip>
           </v-card-title>
 


### PR DESCRIPTION
### Description

Renamed chatflow info tooltip to "Go to manual"

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/833
