### PR TITLE
Remove class from 3bot info json object in deployer UI

### DIFF
--- a/jumpscale/packages/threebot_deployer/frontend/components/solutions/Info.vue
+++ b/jumpscale/packages/threebot_deployer/frontend/components/solutions/Info.vue
@@ -66,6 +66,7 @@ module.exports = {
   mixins: [dialog],
   computed: {
     json() {
+      delete this.data["class"];
       return this.data;
     },
     title() {


### PR DESCRIPTION
### Description

Class added to the data object is removed from the dict to avoid being shown in the info card

### Changes
before:
![Screenshot from 2020-09-02 10-19-26](https://user-images.githubusercontent.com/17128393/91958539-c8583780-ed07-11ea-96b1-cfa2d20e9065.png)

after:
![Screenshot from 2020-09-02 10-33-59](https://user-images.githubusercontent.com/17128393/91958594-d73eea00-ed07-11ea-99b6-13e7e00f4af1.png)

### Related Issues

-

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
