### PR TITLE
Change epoch to Creation date in workload info in admin dashboard

### DIFF
--- a/jumpscale/packages/admin/frontend/components/workloads/Workloads.vue
+++ b/jumpscale/packages/admin/frontend/components/workloads/Workloads.vue
@@ -148,7 +148,8 @@ module.exports = {
             workload.state = Workload_STATE[workload.info.result.state];
             workload.message = workload.info.result.message;
             // convert date
-            workload.epoch = new Date(workload.epoch * 1000).toLocaleString();
+            workload["Creation Date"] = new Date(workload.epoch * 1000).toLocaleString();
+            delete workload["epoch"];
             // convert vloume type
             if (workload.workload_type === "Volume")
               workload.type = VOLUMES_TYPE[workload.type];


### PR DESCRIPTION
### Description

Change `epoch` to `Creation Date` in workload info view in admin dashboard

### Changes

![Screenshot from 2020-09-02 12-07-04](https://user-images.githubusercontent.com/17128393/91968374-dd879300-ed14-11ea-9042-5bc6dd115c2e.png)


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/876

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
