### PR TITLE
whitespace nowrap for datatable headers

### DIFF
--- a/jumpscale/packages/admin/frontend/index.html
+++ b/jumpscale/packages/admin/frontend/index.html
@@ -7,6 +7,12 @@
     <link href="style.css" rel="stylesheet"></link>
     <title>3Bot Admin</title>
     <link rel="icon" type="image/png" href="assets/3bot.png"/>
+
+    <style>
+        .v-data-table-header th {
+            white-space: nowrap;
+        }
+    </style>
   </head>
 
   <body>


### PR DESCRIPTION
### Description

Forces headers to be aligned
I think it's caused by small screen

here's how it looks when i zoomed out 
![image](https://user-images.githubusercontent.com/64129/92107466-22c7c580-ede6-11ea-92dd-c60d33a23c84.png)

and now on small screen
![image](https://user-images.githubusercontent.com/64129/92107949-e5176c80-ede6-11ea-960e-ac843ad8fdad.png)


#924 
https://github.com/vuetifyjs/vuetify/issues/10164
