### PR TITLE
Fixed developer options in setting in admin panel

### DIFF
--- a/jumpscale/packages/admin/frontend/components/settings/Settings.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/Settings.vue
@@ -96,6 +96,7 @@ module.exports = {
       loading: {
         admins: false,
         identities: false,
+        developerOptions: false,
       },
       selectedAdmin: null,
       dialogs: {


### PR DESCRIPTION
### Description

Fixed developer options in setting in admin panel

### Changes

initialized the loading variable

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/921