### PR TITLE
Change default and add min date and time for pool extension 

### DIFF
--- a/jumpscale/sals/marketplace/deployer.py
+++ b/jumpscale/sals/marketplace/deployer.py
@@ -354,12 +354,15 @@ class MarketPlaceDeployer(ChatflowDeployer):
         wgcfg = result["wg"]
         return pool_info, wgcfg
 
-    def ask_expiration(self, bot, default=None, msg=""):
+    def ask_expiration(self, bot, default=None, msg="", min=None):
         default = default or j.data.time.get().timestamp + 3900
+        min = min or 3600
+        timestamp_now = j.data.time.get().timestamp
+        min_message = f"Date/time should be at least {j.data.time.get(timestamp_now+min).humanize()} from now"
         self.expiration = bot.datetime_picker(
             "Please enter solution expiration time." if not msg else msg,
             required=True,
-            min_time=[3600, "Date/time should be at least 1 hour from now"],
+            min_time=[min, min_message],
             default=default,
         )
         return self.expiration - j.data.time.get().timestamp


### PR DESCRIPTION
Change default and add min date and time for pool extension in threebot deployer to be current pool time left

### Description

- Add default 
- Add minimum validation check to disable a date before the current pool expiry time

### Changes
 When a pool has nothing consuming it, the empty_at is a max number, so if it its tht max number then the min and default are 1 hour from now. If not then they are the current pool empty_at value

![Screenshot from 2020-09-03 13-59-40](https://user-images.githubusercontent.com/17128393/92112223-c23c8680-eded-11ea-80f5-5ac1ca1cdc6b.png)

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/932

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
