### PR TITLE
Change identity instance name to name in new identity of admin dahboard

### DIFF
--- a/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
@@ -2,7 +2,7 @@
   <base-dialog title="Add identity" v-model="dialog" :error="error" :loading="loading">
     <template #default>
       <v-form>
-        <v-text-field v-model="form.instance_name" label="Identity instance name" dense></v-text-field>
+        <v-text-field v-model="form.instance_name" label="Identity name" dense></v-text-field>
         <v-text-field v-model="form.tname" label="3Bot name" dense></v-text-field>
         <v-text-field v-model="form.email" label="Email" dense></v-text-field>
         <v-text-field v-model="form.words" label="Words" dense></v-text-field>


### PR DESCRIPTION
### Description

Change identity instance name to name in new identity of admin dahboard

### Changes
`Identity instance name` field changed to `Identity name`
![Screenshot from 2020-09-03 14-05-22](https://user-images.githubusercontent.com/17128393/92113037-011f0c00-edef-11ea-8c87-52c5582d85a6.png)


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/942

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
