### PR TITLE
clean workloads in app chatflows using context

### DIFF
--- a/jumpscale/packages/marketplace/chats/mattermost.py
+++ b/jumpscale/packages/marketplace/chats/mattermost.py
@@ -1,9 +1,7 @@
-from textwrap import dedent
-
-from jumpscale.packages.tfgrid_solutions.chats.mattermost import MattermostDeploy as BaseMattermostDeploy
-from jumpscale.sals.chatflows.chatflows import chatflow_step, StopChatFlow
+from jumpscale.packages.tfgrid_solutions.chats.mattermost import MattermostDeploy
+from jumpscale.sals.chatflows.chatflows import chatflow_step
 from jumpscale.sals.marketplace import MarketPlaceAppsChatflow, deployer, solutions
-from jumpscale.loader import j
+from jumpscale.sals.reservation_chatflow import deployment_context, DeploymentFailed
 
 
 class MattermostDeploy(MarketPlaceAppsChatflow):
@@ -31,6 +29,7 @@ class MattermostDeploy(MarketPlaceAppsChatflow):
         self.user_email = self.user_info()["email"]
 
     @chatflow_step(title="Reservation", disable_previous=True)
+    @deployment_context()
     def reservation(self):
         var_dict = {
             "MYSQL_ROOT_PASSWORD": "mostest",
@@ -60,7 +59,9 @@ class MattermostDeploy(MarketPlaceAppsChatflow):
 
         success = deployer.wait_workload(_id, self)
         if not success:
-            raise StopChatFlow(f"Failed to create subdomain {self.domain} on gateway" f" {self.gateway.node_id} {_id}")
+            raise DeploymentFailed(
+                f"Failed to create subdomain {self.domain} on gateway" f" {self.gateway.node_id} {_id}"
+            )
         self.solution_url = f"https://{self.domain}"
 
         # create volume
@@ -75,7 +76,9 @@ class MattermostDeploy(MarketPlaceAppsChatflow):
         )
         success = deployer.wait_workload(vol_id, self)
         if not success:
-            raise StopChatFlow(f"Failed to deploy volume on node {self.selected_node.node_id} {vol_id}")
+            raise DeploymentFailed(
+                f"Failed to deploy volume on node {self.selected_node.node_id} {vol_id}", solution_uuid=self.solution_id
+            )
         volume_config[vol_mount_point] = vol_id
 
         # Create container
@@ -99,7 +102,7 @@ class MattermostDeploy(MarketPlaceAppsChatflow):
         success = deployer.wait_workload(self.resv_id, self)
         if not success:
             solutions.cancel_solution(self.solution_metadata["owner"], [self.resv_id])
-            raise StopChatFlow(f"Failed to deploy workload {self.resv_id}")
+            raise DeploymentFailed(f"Failed to deploy workload {self.resv_id}", solution_uuid=self.solution_id)
 
         # expose threebot container
         _id = deployer.expose_and_create_certificate(
@@ -119,7 +122,10 @@ class MattermostDeploy(MarketPlaceAppsChatflow):
         success = deployer.wait_workload(_id, self)
         if not success:
             # solutions.cancel_solution(self.workload_ids)
-            raise StopChatFlow(f"Failed to create trc container on node {self.selected_node.node_id}" f" {_id}")
+            raise DeploymentFailed(
+                f"Failed to create trc container on node {self.selected_node.node_id}" f" {_id}",
+                solution_uuid=self.solution_id,
+            )
 
 
 chat = MattermostDeploy

--- a/jumpscale/packages/marketplace/chats/taiga.py
+++ b/jumpscale/packages/marketplace/chats/taiga.py
@@ -119,9 +119,9 @@ class TaigaDeploy(MarketPlaceAppsChatflow):
                 solution_uuid=self.solution_id,
             )
         )
-        self.resv_id = deployer.wait_workload(self.workload_ids[1], self)
-        if not self.resv_id:
-            raise DeploymentFailed(f"Failed to deploy workload {self.resv_id}", solution_uuid=self.solution_id)
+        success = deployer.wait_workload(self.workload_ids[1], self)
+        if not success:
+            raise DeploymentFailed(f"Failed to deploy workload {self.workload_ids[1]}", solution_uuid=self.solution_id)
 
         # expose threebot container
         self.workload_ids.append(
@@ -141,10 +141,10 @@ class TaigaDeploy(MarketPlaceAppsChatflow):
                 **self.solution_metadata,
             )
         )
-        nginx_wid = deployer.wait_workload(self.workload_ids[2], self)
-        if not nginx_wid:
+        success = deployer.wait_workload(self.workload_ids[2], self)
+        if not success:
             raise DeploymentFailed(
-                f"Failed to create trc container on node {self.selected_node.node_id} {nginx_wid}",
+                f"Failed to create trc container on node {self.selected_node.node_id} {self.workload_ids[1]}",
                 solution_uuid=self.solution_id,
             )
 

--- a/jumpscale/packages/marketplace/chats/taiga.py
+++ b/jumpscale/packages/marketplace/chats/taiga.py
@@ -119,9 +119,9 @@ class TaigaDeploy(MarketPlaceAppsChatflow):
                 solution_uuid=self.solution_id,
             )
         )
-        success = deployer.wait_workload(self.workload_ids[1], self)
+        success = deployer.wait_workload(self.workload_ids[-1], self)
         if not success:
-            raise DeploymentFailed(f"Failed to deploy workload {self.workload_ids[1]}", solution_uuid=self.solution_id)
+            raise DeploymentFailed(f"Failed to deploy workload {self.workload_ids[-1]}", solution_uuid=self.solution_id)
 
         # expose threebot container
         self.workload_ids.append(
@@ -141,10 +141,10 @@ class TaigaDeploy(MarketPlaceAppsChatflow):
                 **self.solution_metadata,
             )
         )
-        success = deployer.wait_workload(self.workload_ids[2], self)
+        success = deployer.wait_workload(self.workload_ids[-1], self)
         if not success:
             raise DeploymentFailed(
-                f"Failed to create trc container on node {self.selected_node.node_id} {self.workload_ids[1]}",
+                f"Failed to create trc container on node {self.selected_node.node_id} {self.workload_ids[-1]}",
                 solution_uuid=self.solution_id,
             )
 

--- a/jumpscale/sals/reservation_chatflow/__init__.py
+++ b/jumpscale/sals/reservation_chatflow/__init__.py
@@ -1,6 +1,23 @@
 from .reservation_chatflow import reservation_chatflow
 from .deployer import deployer
 from .solutions import solutions
+from jumpscale.sals.chatflows.chatflows import StopChatFlow
+from contextlib import ContextDecorator
+
+
+class DeploymentFailed(StopChatFlow):
+    def __init__(self, msg=None, solution_uuid=None, **kwargs):
+        super().__init__(msg, **kwargs)
+        self.solution_uuid = solution_uuid
+
+
+class deployment_context(ContextDecorator):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, exc_tb):
+        if exc_type == DeploymentFailed and exc.solution_uuid:
+            solutions.cancel_solution_by_uuid(exc.solution_uuid)
 
 
 # TODO: remove the below on releasing jsng 11.0.0a3

--- a/jumpscale/sals/reservation_chatflow/solutions.py
+++ b/jumpscale/sals/reservation_chatflow/solutions.py
@@ -626,5 +626,11 @@ class ChatflowSolutions:
             result[-1].update(c_dict["capacity"])
         return result
 
+    def cancel_solution_by_uuid(self, solution_uuid):
+        # Get workloads with specific UUID
+        for workload in j.sals.zos.workloads.list(j.core.identity.me.tid, next_action="DEPLOY"):
+            if solution_uuid == self.get_solution_uuid(workload):
+                j.sals.zos.workloads.decomission(workload.id)
+
 
 solutions = ChatflowSolutions()


### PR DESCRIPTION
### Description

use context to clean chatflow workloads in app chatflows to allow pool reuse

### Changes

app chatflows in marketplace and threebot deployer

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/602
