### PR TITLE
Add spacing in deploying message of loading in reservation chatflow sal

### DIFF
--- a/jumpscale/sals/reservation_chatflow/deployer.py
+++ b/jumpscale/sals/reservation_chatflow/deployer.py
@@ -660,10 +660,10 @@ class ChatflowDeployer:
             remaning_time = j.data.time.get(expiration_provisioning).humanize(granularity=["minute", "second"])
             if bot:
                 deploying_message = f"""
-# Deploying...\n\n
+# Deploying...<br><br>
 
-\n\nWorkload ID: {workload_id} \n
-\n\nDeployment should take around 2 to 3 minutes, but might take longer and will be cancelled if it is not successful in {remaning_time}
+Workload ID: {workload_id}
+\n\nDeployment should take around 2 to 3 minutes, but might take longer and will be cancelled if it is not successful in 10 mins
                 """
                 bot.md_show_update(deploying_message, md=True)
             if workload.info.result.workload_id:


### PR DESCRIPTION
### Description

Add spacing in deploying message of loading in reservation chatflow sal

### Changes
Added spacing between deploying and the workload ID:
![Screenshot from 2020-09-03 15-56-38](https://user-images.githubusercontent.com/17128393/92124920-abeaf680-edfe-11ea-8c00-9708cd8840a9.png)


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/965

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
