### PR TITLE
split the last step to two in network and 4to6

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/chats/4to6gw.py
+++ b/jumpscale/packages/tfgrid_solutions/chats/4to6gw.py
@@ -6,13 +6,7 @@ from jumpscale.sals.reservation_chatflow import deployer
 
 
 class FourToSixGateway(GedisChatBot):
-    steps = [
-        "select_pool",
-        "gateway_start",
-        "wireguard_public_get",
-        "wg_reservation",
-        "wg_config",
-    ]
+    steps = ["select_pool", "gateway_start", "wireguard_public_get", "wg_reservation", "wg_config", "success"]
     title = "4to6 GW"
 
     @chatflow_step(title="Pool")
@@ -81,13 +75,15 @@ Endpoint = {{peer.endpoint}}
             template_text=wgconfigtemplate, cfg=cfg, privatekey=self.privatekey.decode()
         )
         config = config
+        self.filename = "wg-{}.conf".format(self.resv_id)
+        self.download_file(msg=f"<pre>{config}</pre>", data=config, filename=self.filename, html=True)
 
-        filename = "wg-{}.conf".format(self.resv_id)
-        self.download_file(msg=f"<pre>{config}</pre>", data=config, filename=filename, html=True)
+    @chatflow_step(title="Success", final_step=True, disable_previous=True)
+    def success(self):
         res = f"""
 # In order to connect to the 4 to 6 gateway execute this command:
 \n<br/>\n
-## ```wg-quick up ./{filename}```
+## ```wg-quick up ./{self.filename}```
                     """
         self.md_show(res, md=True)
 

--- a/jumpscale/packages/tfgrid_solutions/chats/network.py
+++ b/jumpscale/packages/tfgrid_solutions/chats/network.py
@@ -7,13 +7,7 @@ from jumpscale.sals.reservation_chatflow import deployer, solutions
 
 
 class NetworkDeploy(GedisChatBot):
-    steps = [
-        "welcome",
-        "start",
-        "ip_config",
-        "network_reservation",
-        "network_info",
-    ]
+    steps = ["welcome", "start", "ip_config", "network_reservation", "network_info", "success"]
     title = "Network"
 
     @chatflow_step(title="Welcome")
@@ -118,15 +112,18 @@ to download your configuration
 
         self.md_show(message, md=True, html=True)
 
-        filename = "wg-{}.conf".format(self.config["rid"])
-        self.download_file(msg=f'<pre>{self.config["wg"]}</pre>', data=self.config["wg"], filename=filename, html=True)
+        self.filename = "wg-{}.conf".format(self.config["rid"])
+        self.download_file(
+            msg=f'<pre>{self.config["wg"]}</pre>', data=self.config["wg"], filename=self.filename, html=True
+        )
 
+    @chatflow_step(title="Success", disable_previous=True, final_step=True)
+    def success(self):
         message = f"""
 ### In order to have the network active and accessible from your local/container machine. To do this, execute this command:
 \n<br />\n
-#### ```wg-quick up /etc/wireguard/{filename}```
+#### ```wg-quick up /etc/wireguard/{self.filename}```
 \n<br />\n
-# Click next
             """
 
         self.md_show(message, md=True)


### PR DESCRIPTION
### Description

Fix the issue that a user has to click finish through multiple steps in network and 4to6 gateway chatflows for it to actually end.

### Changes

1. Remove "click next" at the last step of network deployment.
2. Split the download and success message into two separate steps.
### Related Issues

#978