### PR TITLE
Make IPv4 the default version in new network chatflow

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/chats/network.py
+++ b/jumpscale/packages/tfgrid_solutions/chats/network.py
@@ -48,7 +48,10 @@ class NetworkDeploy(GedisChatBot):
     def ip_config(self):
         ips = ["IPv6", "IPv4"]
         self.ipversion = self.single_choice(
-            "How would you like to connect to your network? IPv4 or IPv6? If unsure, choose IPv4", ips, required=True
+            "How would you like to connect to your network? IPv4 or IPv6? If unsure, choose IPv4",
+            ips,
+            required=True,
+            default="IPv4",
         )
         self.md_show_update("searching for access node...")
         pools = [p for p in j.sals.zos.pools.list() if p.node_ids]


### PR DESCRIPTION
### Description

Make IPv4 the default version in new network chatflow

### Changes
Once directed to this step the default is already IPv4
![Screenshot from 2020-09-03 19-44-09](https://user-images.githubusercontent.com/17128393/92149866-e4023180-ee1e-11ea-8acb-8bfee8564966.png)


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/946

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
