### PR TITLE
resolve redirect state change issue

### DIFF
--- a/jumpscale/packages/admin/frontend/components/solutions/SolutionChatflow.vue
+++ b/jumpscale/packages/admin/frontend/components/solutions/SolutionChatflow.vue
@@ -20,17 +20,19 @@
       if(window.admin_chatflow_end_listener_set === undefined) { // avoid setting multiple listeners
         window.admin_chatflow_end_listener_set = true
         window.addEventListener("message", event => {
-          let message = "chat ended"
-          if(event.origin != location.origin || event.data != message)
+          let message = "chat ended: "
+          let len = message.length
+          if(event.origin != location.origin || event.data.slice(0, len) != message)
             return;
-          if(this.topic == "pools"){
+          let topic = event.data.slice(len)
+          if(topic == "pools"){
             this.$router.push({
               name: "Capacity Pools"
             })
           }else{
             this.$router.push({
               name: "Solution",
-              params: {type: this.topic}
+              params: {type: topic}
             })
           }
         })

--- a/jumpscale/packages/chatflows/frontend/App.vue
+++ b/jumpscale/packages/chatflows/frontend/App.vue
@@ -130,7 +130,7 @@
           case 'end':
             end = true
             localStorage.removeItem(this.chatUID)
-            window.parent.postMessage("chat ended", location.origin)
+            window.parent.postMessage("chat ended: " + this.chat, location.origin)
             break
           case 'user_info':
             this.sendUserInfo()

--- a/jumpscale/packages/marketplace/frontend/components/solutions/SolutionChatflow.vue
+++ b/jumpscale/packages/marketplace/frontend/components/solutions/SolutionChatflow.vue
@@ -14,12 +14,14 @@
       if(window.marketplace_chatflow_end_listener_set === undefined) { // avoid setting multiple listeners
         window.marketplace_chatflow_end_listener_set = true
         window.addEventListener("message", event => {
-          let message = "chat ended"
-          if(event.origin != location.origin || event.data != message)
+          let message = "chat ended: "
+          let len = message.length
+          if(event.origin != location.origin || event.data.slice(0, len) != message)
             return;
+          let topic = event.data.slice(len)
           this.$router.push({
             name: "Solution",
-            params: {type: this.topic}
+            params: {type: topic}
           })
         })
       }

--- a/jumpscale/packages/threebot_deployer/frontend/components/solutions/SolutionChatflow.vue
+++ b/jumpscale/packages/threebot_deployer/frontend/components/solutions/SolutionChatflow.vue
@@ -15,8 +15,10 @@
       if(window.threebot_deployer_chatflow_end_listener_set === undefined) { // avoid setting multiple listeners
         window.threebot_deployer_chatflow_end_listener_set = true
         window.addEventListener("message", event => {
-          let message = "chat ended"
-          if(event.origin != location.origin || event.data != message)
+
+          let message = "chat ended: "
+          let len = message.length
+          if(event.origin != location.origin || event.data.slice(0, len) != message)
             return;
           this.$router.push({
             name: "Workloads",


### PR DESCRIPTION
### Description

The redirection should not be based on `this` object since after component rerendering the actual component object that is present in the DOM is different than the one created the event handler. So the event handler in the old code accesses the data of the old destroyed object. The solution name now is passed to the event listener in the message.

### Related Issues

#971 