### PR TITLE
extend to fit to the new expiration date

### DIFF
--- a/jumpscale/packages/threebot_deployer/chats/extend.py
+++ b/jumpscale/packages/threebot_deployer/chats/extend.py
@@ -51,7 +51,7 @@ class ExtendThreebot(MarketPlaceChatflow):
                     break
         currency = self.single_choice("Please choose the currency", assets, required=True)
         self.currencies = [currency]
-        self.pool_info, self.qr_code = deployer.extend_solution_pool(
+        self.pool_info, self.qr_code = deployer.extend_solution_pool_to_fit(
             self, self.pool_id, self.expiration, self.currencies, **self.query
         )
 

--- a/jumpscale/packages/threebot_deployer/chats/extend.py
+++ b/jumpscale/packages/threebot_deployer/chats/extend.py
@@ -51,7 +51,7 @@ class ExtendThreebot(MarketPlaceChatflow):
                     break
         currency = self.single_choice("Please choose the currency", assets, required=True)
         self.currencies = [currency]
-        self.pool_info, self.qr_code = deployer.extend_solution_pool_to_fit(
+        self.pool_info, self.qr_code = deployer.extend_solution_pool(
             self, self.pool_id, self.expiration, self.currencies, **self.query
         )
 

--- a/jumpscale/sals/marketplace/deployer.py
+++ b/jumpscale/sals/marketplace/deployer.py
@@ -245,7 +245,7 @@ class MarketPlaceDeployer(ChatflowDeployer):
             selected_pool_ids.append(pool.pool_id)
         return selected_nodes, selected_pool_ids
 
-    def extend_solution_pool_to_fit(self, bot, pool_id, expiration, currency, **resources):
+    def extend_solution_pool(self, bot, pool_id, expiration, currency, **resources):
         cu, su = self.calculate_capacity_units(**resources)
         cu = cu * expiration
         su = su * expiration
@@ -263,16 +263,6 @@ class MarketPlaceDeployer(ChatflowDeployer):
             return pool_info, qr_code
         else:
             return None, None
-
-    def extend_solution_pool(self, bot, pool_id, expiration, currency, **resources):
-        cu, su = self.calculate_capacity_units(**resources)
-        cu = int(cu * expiration)
-        su = int(su * expiration)
-        if not isinstance(currency, list):
-            currency = [currency]
-        pool_info = j.sals.zos.pools.extend(pool_id, cu, su, currency)
-        qr_code = self.show_payment(pool_info, bot)
-        return pool_info, qr_code
 
     def create_solution_pool(self, bot, username, farm_name, expiration, currency, **resources):
         cu, su = self.calculate_capacity_units(**resources)

--- a/jumpscale/sals/marketplace/deployer.py
+++ b/jumpscale/sals/marketplace/deployer.py
@@ -245,17 +245,14 @@ class MarketPlaceDeployer(ChatflowDeployer):
             selected_pool_ids.append(pool.pool_id)
         return selected_nodes, selected_pool_ids
 
-    def calculate_pool_units(self, pool_id):
-        pool = j.sals.zos.pools.get(pool_id)
-        return pool.cus, pool.sus
-
     def extend_solution_pool_to_fit(self, bot, pool_id, expiration, currency, **resources):
         cu, su = self.calculate_capacity_units(**resources)
         cu = cu * expiration
         su = su * expiration
-        old_cu, old_ru = self.calculate_pool_units(pool_id)
+        pool = j.sals.zos.pools.get(pool_id)
+        old_cu, old_su = pool.cus, pool.sus
         cu = math.ceil(cu - old_cu)
-        su = math.ceil(su - old_ru)
+        su = math.ceil(su - old_su)
         cu = max(cu, 0)
         su = max(su, 0)
         if not isinstance(currency, list):


### PR DESCRIPTION
### Description

When extending a 3Bot instance. The cus and sus required where calculated from the deployment old start date until the new expiration date. So the user will pay twice for the old period (he will get an over extended expiration date he didn't ask for).

### Changes

Calculate the current curs and rus and pay only for the difference.

### Related Issues

#936
