### PR TITLE
add one time token for threebot to authorize the requests

### DIFF
--- a/jumpscale/packages/admin/frontend/components/backup/marketplace/Backup.vue
+++ b/jumpscale/packages/admin/frontend/components/backup/marketplace/Backup.vue
@@ -17,7 +17,7 @@
 
       <template #default>
         <v-alert v-if="!inited" text prominent class="ma-5" border="right" type="info">
-          <span>Your repo is not inited, plesaed init it first</span>
+          <span>Your repo is not inited, please init it first</span>
           <v-btn
             text
             class="ml-5"
@@ -88,6 +88,10 @@ module.exports = {
         .inited()
         .then((response) => {
           this.inited = response.data;
+          if(this.inited){
+              this.checkAutoBackup();
+              this.listSnapshots();
+          }
         })
         .catch((error) => {
           this.error = error.message;
@@ -143,8 +147,6 @@ module.exports = {
   },
   mounted() {
     this.checkReposInit();
-    this.checkAutoBackup();
-    this.listSnapshots();
   },
 };
 </script>

--- a/jumpscale/packages/admin/frontend/components/backup/marketplace/InitRepos.vue
+++ b/jumpscale/packages/admin/frontend/components/backup/marketplace/InitRepos.vue
@@ -28,7 +28,7 @@ module.exports = {
           location.reload();
         })
         .catch(error => {
-          this.error = error.message;
+          this.error = `${error.message}. Backup service is only available through online deployed 3Bots`;
         })
         .finally(() => {
           this.loading = false;

--- a/jumpscale/packages/admin/frontend/components/backup/minio/Backup.vue
+++ b/jumpscale/packages/admin/frontend/components/backup/minio/Backup.vue
@@ -17,7 +17,7 @@
 
       <template #default>
         <v-alert v-if="!inited" text prominent class="ma-5" border="right" type="info">
-          <span>Your repo is not inited, plesaed init it first</span>
+          <span>Your repo is not inited, please init it first</span>
           <v-btn
             text
             class="ml-5"

--- a/jumpscale/packages/backup/actors/threebot_deployer.py
+++ b/jumpscale/packages/backup/actors/threebot_deployer.py
@@ -8,6 +8,7 @@ from jumpscale.loader import j
 from jumpscale.servers.gedis.baseactor import BaseActor, actor_method
 
 MARKETPLACE_URL = os.environ.get("MARKETPLACE_URL", "https://deploy3bot.grid.tf/")
+BACKUP_TOKEN = os.environ.get("BACKUP_TOKEN", "")
 CREATE_USER_ENDPOINT = "threebot_deployer/actors/backup/init"
 PUBLIC_KEY_ENDPOINT = "threebot_deployer/actors/backup/public_key"
 REPO_NAMES = ["config_backup_1", "config_backup_2"]
@@ -35,7 +36,7 @@ class Backup(BaseActor):
         priv_key = j.core.identity.me.nacl.private_key
         box = Box(priv_key, mrkt_pub_key)
         password_encrypted = box.encrypt(password.encode(), encoder=nacl.encoding.Base64Encoder).decode()
-        data = {"threebot_name": tname, "passwd": password_encrypted, "new": new}
+        data = {"threebot_name": tname, "passwd": password_encrypted, "new": new, "token": BACKUP_TOKEN}
         url = os.path.join(MARKETPLACE_URL, CREATE_USER_ENDPOINT)
         response = requests.post(url, json=data, headers=headers)
         if response.status_code != 200:

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
@@ -19,6 +19,7 @@ poetry install
 echo "INSTANCE_NAME=${INSTANCE_NAME}" >> ~/.bashrc
 echo "THREEBOT_NAME=${THREEBOT_NAME}" >> ~/.bashrc
 echo "BACKUP_PASSWORD=${BACKUP_PASSWORD}" >> ~/.bashrc
+echo "BACKUP_TOKEN=${BACKUP_TOKEN}" >> ~/.bashrc
 echo "DOMAIN=${DOMAIN}" >> ~/.bashrc
 
 echo "[*] Starting threebot in background ..."

--- a/jumpscale/packages/threebot_deployer/actors/backup.py
+++ b/jumpscale/packages/threebot_deployer/actors/backup.py
@@ -1,12 +1,15 @@
-from jumpscale.servers.gedis.baseactor import BaseActor, actor_method
-from jumpscale.loader import j
+import binascii
+
+import nacl.encoding
 import nacl.secret
+import nacl.signing
 import nacl.utils
 import requests
-import nacl.signing
-import binascii
 from nacl.public import Box
-import nacl.encoding
+
+from jumpscale.loader import j
+from jumpscale.packages.threebot_deployer.models.backup_tokens_sal import BACKUP_MODEL_FACTORY
+from jumpscale.servers.gedis.baseactor import BaseActor, actor_method
 
 BACKUP_SERVER1 = "backup_server1"
 BACKUP_SERVER2 = "backup_server2"
@@ -23,11 +26,26 @@ class Backup(BaseActor):
         self.pub_key = j.core.identity.me.nacl.public_key.encode(nacl.encoding.Base64Encoder).decode()
 
     @actor_method
-    def init(self, threebot_name: str, passwd: str, new=True) -> list:
+    def init(self, threebot_name: str, passwd: str, new=True, token: str = "") -> list:
         try:
             user = self.explorer.users.get(name=threebot_name)
         except requests.exceptions.HTTPError:
             raise j.exceptions.NotFound(f"3Bot name {threebot_name} is not found")
+
+        # check the user token is valid for new users
+        if new:
+            verified = False
+            for solution_name in BACKUP_MODEL_FACTORY.list_all():
+                backup_data = BACKUP_MODEL_FACTORY.get(solution_name)
+
+                if str(backup_data.token) == str(token):
+                    verified = True
+                    BACKUP_MODEL_FACTORY.delete(solution_name)
+
+            if not verified:
+                raise j.exceptions.Permission(
+                    f"Invalid token, Unauthorized attempt to create a backup user from {threebot_name}."
+                )
 
         verify_key = nacl.signing.VerifyKey(binascii.unhexlify(user.pubkey))
         box = Box(self.PRIVATE_KEY, verify_key.to_curve25519_public_key())

--- a/jumpscale/packages/threebot_deployer/bottle/backup.py
+++ b/jumpscale/packages/threebot_deployer/bottle/backup.py
@@ -6,9 +6,6 @@ from jumpscale.packages.auth.bottle.auth import SESSION_OPTS, login_required, ge
 
 app = Bottle()
 
-ssh_server1 = j.clients.sshclient.get("backup_server1")
-ssh_server2 = j.clients.sshclient.get("backup_server2")
-
 
 @app.route("/backup/destroy", method="POST")
 @login_required
@@ -18,6 +15,8 @@ def destroy():
     * WARNINING: THIS IS A DISTRUCTIVE ACTION. WON'T BE ABLE TO RECOVER FROM *
     --------------------------------------------------------------------------
     """
+    ssh_server1 = j.clients.sshclient.get("backup_server1")
+    ssh_server2 = j.clients.sshclient.get("backup_server2")
     # validiate user
     data = j.data.serializers.json.loads(request.body.read())
     threebot_name = data.get("threebot_name", "")

--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -1,9 +1,11 @@
+import uuid
+
+from jumpscale.data.nacl.jsnacl import NACL
 from jumpscale.loader import j
 from jumpscale.sals.chatflows.chatflows import chatflow_step
 from jumpscale.sals.marketplace import MarketPlaceAppsChatflow, deployer, solutions
-import uuid
-from jumpscale.data.nacl.jsnacl import NACL
-from jumpscale.sals.reservation_chatflow import deployment_context, DeploymentFailed
+from jumpscale.sals.reservation_chatflow import DeploymentFailed, deployment_context
+from jumpscale.packages.threebot_deployer.models.backup_tokens_sal import BACKUP_MODEL_FACTORY
 
 
 class ThreebotDeploy(MarketPlaceAppsChatflow):
@@ -12,6 +14,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
     title = "3Bot"
     steps = [
         "get_solution_name",
+        # "upload_public_key",
         "set_backup_password",
         "solution_expiration",
         "payment_currency",
@@ -50,6 +53,14 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
                     self.md_show("The specified solution name already exists. please choose another name.")
                     break
                 valid = True
+        self.backup_model = BACKUP_MODEL_FACTORY.get(f"{self.solution_name}_{self.threebot_name}")
+
+    # @chatflow_step(title="SSH key")
+    # def upload_public_key(self):
+    #     self.public_key = self.upload_file(
+    #         "Please upload your public ssh key, this will allow you to access your threebot container using ssh",
+    #         required=True,
+    #     ).strip()
 
     def _verify_password(self, password):
         try:
@@ -113,6 +124,12 @@ You will be automatically redirected to the next step once succeeded.
                 f"Failed to create subdomain {self.domain} on gateway {self.gateway.node_id} {self.workload_ids[0]}"
             )
         test_cert = j.config.get("TEST_CERT")
+
+        # Generate a one-time token to create a user for backup
+        backup_token = str(j.data.idgenerator.idgenerator.uuid.uuid4())
+        self.backup_model.token = backup_token
+        self.backup_model.tname = self.solution_metadata["owner"]
+        self.backup_model.save()
         # 3- deploy threebot container
         environment_vars = {
             "SDK_VERSION": self.branch,
@@ -137,7 +154,7 @@ You will be automatically redirected to the next step once succeeded.
                 memory=self.query["mru"] * 1024,
                 disk_size=self.query["sru"] * 1024,
                 entrypoint=entry_point,
-                secret_env={"BACKUP_PASSWORD": self.backup_password},
+                secret_env={"BACKUP_PASSWORD": self.backup_password, "BACKUP_TOKEN": backup_token},
                 interactive=False,
                 solution_uuid=self.solution_id,
                 **self.solution_metadata,

--- a/jumpscale/packages/threebot_deployer/models/backup_tokens.py
+++ b/jumpscale/packages/threebot_deployer/models/backup_tokens.py
@@ -1,0 +1,7 @@
+from jumpscale.core.base import Base, fields
+from jumpscale.loader import j
+
+
+class BackupTokens(Base):
+    tname = fields.String()
+    token = fields.String()

--- a/jumpscale/packages/threebot_deployer/models/backup_tokens_sal.py
+++ b/jumpscale/packages/threebot_deployer/models/backup_tokens_sal.py
@@ -1,0 +1,5 @@
+from jumpscale.core.base import StoredFactory
+from jumpscale.packages.threebot_deployer.models.backup_tokens import BackupTokens
+
+BACKUP_MODEL_FACTORY = StoredFactory(BackupTokens)
+BACKUP_MODEL_FACTORY.always_reload = True


### PR DESCRIPTION
### Description

Updates for 3Bot solution backup

### Changes

- add one time token for threebot to authorize the requests
- Enhance error message if anyone tried to backup locally which is not supported

![Screenshot from 2020-09-07 12-52-03](https://user-images.githubusercontent.com/10658229/92380585-bca2b180-f109-11ea-8e25-6dafc8db48c9.png)

```python
JS-NG> requests.post("https://waleed.threefold.io/threebot_deployer/actors/backup/init", json={"threebot_name":"waleedhammam.3bot", "passwd":"123456"}, headers={"Content-Type": "application/json"})         
2020-09-07 11:07:29.778 | INFO     | jumpscale.servers.gedis.server:_on_connection:269 - Executing method init from actor threebot_deployer_backup to client ('127.0.0.1', 37372)
127.0.0.1 - - [2020-09-07 11:07:29] "POST /threebot_deployer/backup/init HTTP/1.0" 403 230 0.095599
<Response [403]>

JS-NG> _.json()                                                                                                                                                                                               
{'error': 'Invalid token, Unauthorized attempt to create a backup user from waleedhammam.3bot.'}

JS-NG>  

```

### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/1006

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
