### PR TITLE
use default identity instead of the logged in one

### DIFF
--- a/jumpscale/packages/farmmanagement/frontend/services/farmmanagementServices.js
+++ b/jumpscale/packages/farmmanagement/frontend/services/farmmanagementServices.js
@@ -5,7 +5,7 @@ export default {
     return axios.get("/admin/actors/identity/get_explorer_url");
   },
   getUser() {
-    return axios.get("/auth/authenticated");
+    return axios.get("/admin/actors/identity/get_identity");
   },
   getFarms(tfgridUrl, user_id) {
     return axios.get(`${tfgridUrl}/farms`, {

--- a/jumpscale/packages/farmmanagement/frontend/store/farmmanagement.js
+++ b/jumpscale/packages/farmmanagement/frontend/store/farmmanagement.js
@@ -28,8 +28,9 @@ export default {
     },
     getUser: async context => {
       var response = await tfService.getUser();
-      if (response.data.username.length > 0) {
-        context.commit("setUser", response.data);
+      var user = JSON.parse(response.data)
+      if (user.name.length > 0) {
+        context.commit("setUser", user);
       }
     },
     getNodes(context, farm_id) {
@@ -42,7 +43,7 @@ export default {
       return tfService.setNodeFree(node_id, free)
     },
     getFarms: context => {
-      tfService.getFarms(context.getters.tfgridUrl, context.getters.user.tid).then(response => {
+      tfService.getFarms(context.getters.tfgridUrl, context.getters.user.id).then(response => {
         context.commit("setFarms", response.data);
       });
     },

--- a/jumpscale/packages/farmmanagement/frontend/views/farmmanagement/farmmanagement.js
+++ b/jumpscale/packages/farmmanagement/frontend/views/farmmanagement/farmmanagement.js
@@ -271,7 +271,7 @@ module.exports = new Promise(async (resolve, reject) => {
             await this.getUser();
             this.getFarms();
             this.initialiseRefresh()
-            this.newFarm.threebot_id = this.user.tid;
+            this.newFarm.threebot_id = this.user.id;
         },
         methods: {
             ...vuex.mapActions("farmmanagement", [
@@ -289,7 +289,7 @@ module.exports = new Promise(async (resolve, reject) => {
                 }, 60000)
             },
             isLoggedIn() {
-                return Boolean(this.user.tid)
+                return Boolean(this.user.id)
             },
             refreshFarms() {
                 clearInterval(this.refreshInterval);


### PR DESCRIPTION
### Description

use the server's default identity in farm management instead of the logged in user

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/1043


