### PR TITLE
More clear password and recovery messages

### DIFF
--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -65,7 +65,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
             if valid and self.action == "Create" and self._existing_3bot():
                 valid = False
                 self.md_show(
-                    "The specified 3Bot name was deployed before. Please go to the previous step choose recover or enter a new name."
+                    "The specified 3Bot name was deployed before. Please go to the previous step and choose recover or enter a new name."
                 )
 
             if valid and self.action == "Recover" and not self._existing_3bot():


### PR DESCRIPTION
### Description

Describe the changes introduced by this PR and what does it affect

### Changes

1. Step get a 3bot name to 3Bot name (as it can be and old one so he's not getting a new name).
2. Password messages.
3. Name scenarios:
- recover -> name deployed (The specified 3Bot name already exists. please choose another name.) 
- recover -> not deployed and doesn't exist (The specified 3Bot name doesn't exist.)
- recover -> not deployed and exists (correct scenario) 
- create -> name deployed (The specified 3Bot name already exists. please choose another name.)
- create -> not deployed but exists before (The specified 3Bot name was deployed before. Please go to the previous step and choose recover or enter a new name.)
- create -> not deployed and wasn't deployed before (correct scenario)

### Related Issues

#1065