### PR TITLE
Enable showing the words of the identities in the admin dashboard

### DIFF
--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -66,6 +66,7 @@ class Admin(BaseActor):
                         "email": identity.email,
                         "tid": identity.tid,
                         "explorer_url": identity.explorer_url,
+                        "words": identity.words,
                     }
                 }
             )

--- a/jumpscale/packages/admin/frontend/components/settings/IdentityInfo.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/IdentityInfo.vue
@@ -24,6 +24,19 @@
               <td>Explorer URL</td>
               <td>{{ identity.explorer_url }}</td>
             </tr>
+            <tr>
+              <td>Words</td>
+              <td>
+                <v-text-field
+                  hide-details
+                  :value="identity.words"
+                  readonly solo flat
+                  :append-icon="showWords ? 'mdi-eye' : 'mdi-eye-off'"
+                  :type="showWords ? 'text' : 'password'"
+                  @click:append="showWords = !showWords"
+                ></v-text-field>
+              </td>
+            </tr>
           </tbody>
         </template>
       </v-simple-table>
@@ -46,6 +59,7 @@ module.exports = {
   data () {
     return {
       identity: null,
+      showWords: false
     }
   },
   watch: {


### PR DESCRIPTION

### Changes

- Enable showing the words of the identities in the admin dashboard
### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/1099
![image](https://user-images.githubusercontent.com/36021484/92728006-510e4d80-f370-11ea-842f-11c285823606.png)


