### PR TITLE
exclude workloads on deleted nodes when building a network view

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/actors/solutions.py
+++ b/jumpscale/packages/tfgrid_solutions/actors/solutions.py
@@ -78,11 +78,12 @@ class Solutions(BaseActor):
             pool_dict["hidden"] = hidden
             pool_dict["explorer_url"] = j.core.identity.me.explorer_url
             farm_id = deployer.get_pool_farm_id(pool.pool_id)
-            farm = farm_names.get(farm_id)
-            if not farm:
-                farm = deployer._explorer.farms.get(farm_id)
-                farm_names[farm_id] = farm
-            pool_dict["farm"] = farm.name
+            if farm_id >= 0:
+                farm = farm_names.get(farm_id)
+                if not farm:
+                    farm = deployer._explorer.farms.get(farm_id)
+                    farm_names[farm_id] = farm
+                pool_dict["farm"] = farm.name
             for i, wid in enumerate(pool_dict["active_workload_ids"]):
                 if wid in workloads_dict:
                     pool_dict["active_workload_ids"][i] = f"{workloads_dict[wid].info.workload_type.name} - {wid}"

--- a/jumpscale/sals/reservation_chatflow/deployer.py
+++ b/jumpscale/sals/reservation_chatflow/deployer.py
@@ -34,22 +34,29 @@ class NetworkView:
         self.workloads = workloads
         self.used_ips = []
         self.network_workloads = []
-        self._fill_used_ips(self.workloads)
-        self._init_network_workloads(self.workloads)
+        nodes = {node.node_id for node in j.sals.zos._explorer.nodes.list()}
+        self._fill_used_ips(self.workloads, nodes)
+        self._init_network_workloads(self.workloads, nodes)
         if self.network_workloads:
             self.iprange = self.network_workloads[0].network_iprange
         else:
             self.iprange = "can't be retrieved"
 
-    def _init_network_workloads(self, workloads):
+    def _init_network_workloads(self, workloads, nodes=None):
+        nodes = nodes or {node.node_id for node in j.sals.zos._explorer.nodes.list()}
         for workload in workloads:
+            if workload.info.node_id not in nodes:
+                continue
             if workload.info.next_action != NextAction.DEPLOY:
                 continue
             if workload.info.workload_type == WorkloadType.Network_resource and workload.name == self.name:
                 self.network_workloads.append(workload)
 
-    def _fill_used_ips(self, workloads):
+    def _fill_used_ips(self, workloads, nodes=None):
+        nodes = nodes or {node.node_id for node in j.sals.zos._explorer.nodes.list()}
         for workload in workloads:
+            if workload.info.node_id not in nodes:
+                continue
             if workload.info.next_action != NextAction.DEPLOY:
                 continue
             if workload.info.workload_type == WorkloadType.Kubernetes:

--- a/jumpscale/sals/reservation_chatflow/deployer.py
+++ b/jumpscale/sals/reservation_chatflow/deployer.py
@@ -505,6 +505,7 @@ As an example, if you want to be able to run some workloads that consumes `5CU` 
                     break
                 except requests.exceptions.HTTPError:
                     continue
+            farm_id = farm_id or "CANNOT_BE_RETRIEVED"
 
         return farm_id
 

--- a/jumpscale/sals/reservation_chatflow/deployer.py
+++ b/jumpscale/sals/reservation_chatflow/deployer.py
@@ -27,14 +27,14 @@ GATEWAY_WORKLOAD_TYPES = [
 
 
 class NetworkView:
-    def __init__(self, name, workloads=None):
+    def __init__(self, name, workloads=None, nodes=None):
         self.name = name
         if not workloads:
             workloads = j.sals.zos.workloads.list(j.core.identity.me.tid, NextAction.DEPLOY)
         self.workloads = workloads
         self.used_ips = []
         self.network_workloads = []
-        nodes = {node.node_id for node in j.sals.zos._explorer.nodes.list()}
+        nodes = nodes or {node.node_id for node in j.sals.zos._explorer.nodes.list()}
         self._fill_used_ips(self.workloads, nodes)
         self._init_network_workloads(self.workloads, nodes)
         if self.network_workloads:
@@ -260,8 +260,9 @@ class ChatflowDeployer:
             for pool_id, workload_list in pools_workloads.items():
                 all_workloads += workload_list
         network_views = {}
+        nodes = {node.node_id for node in j.sals.zos._explorer.nodes.list()}
         for network_name in networks:
-            network_views[network_name] = NetworkView(network_name, all_workloads)
+            network_views[network_name] = NetworkView(network_name, all_workloads, nodes)
         return network_views
 
     def _pool_form(self, bot):


### PR DESCRIPTION
### Description

exclude the workloads deployed on deleted nodes when building the network view.
replace farm_id remaining in node selection with pool_id