### PR TITLE
Fix authentication error to the explorer API

### DIFF
--- a/jumpscale/clients/explorer/auth.py
+++ b/jumpscale/clients/explorer/auth.py
@@ -52,6 +52,8 @@ class HeaderSigner(Signer):
         required_headers = self.headers or ["date"]
         created = time.time()
         expires = created + 60
+        dt = datetime.fromtimestamp(created)
+        headers["date"] = formatdate(timeval=time.mktime(dt.timetuple()), localtime=False, usegmt=True)
         signable = generate_message(required_headers, headers, created, expires, host, method, path)
         signature = super().sign(signable)
         headers[self.sign_header] = self.signature_template % (signature, created, expires)

--- a/jumpscale/clients/explorer/conversion.py
+++ b/jumpscale/clients/explorer/conversion.py
@@ -17,11 +17,7 @@ class Conversion:
 
         url = self._client.url + "/reservations/convert"
 
-        secret = me.nacl.signing_key.encode(Base64Encoder)
-        auth = HTTPSignatureAuth(key_id=str(me.tid), secret=secret, headers=["(created)", "date", "threebot-id"])
-        headers = {"threebot-id": str(me.tid)}
-
-        resp = self._session.get(url, auth=auth, headers=headers)
+        resp = self._session.get(url)
 
         if resp.status_code == 204:
             raise AlreadyConvertedError(f"convertion for user {me.tid} has already been done")
@@ -33,12 +29,8 @@ class Conversion:
 
         url = self._client.url + "/reservations/convert"
 
-        secret = me.nacl.signing_key.encode(Base64Encoder)
-        auth = HTTPSignatureAuth(key_id=str(me.tid), secret=secret, headers=["(created)", "date", "threebot-id"])
-        headers = {"threebot-id": str(me.tid)}
-
         for w in workloads:
             print(w["result"])
 
-        resp = self._session.post(url, json=workloads, auth=auth, headers=headers)
+        resp = self._session.post(url, json=workloads)
         return resp.json()

--- a/jumpscale/clients/explorer/farms.py
+++ b/jumpscale/clients/explorer/farms.py
@@ -117,11 +117,5 @@ class Farms(BaseResource):
         return True
 
     def delete(self, farm_id, node_id):
-        me = identity.get_identity()
-        secret = me.nacl.signing_key.encode(Base64Encoder)
-
-        auth = HTTPSignatureAuth(key_id=str(me.tid), secret=secret, headers=["(created)", "date", "threebot-id"])
-        headers = {"threebot-id": str(me.tid)}
-
-        self._session.delete(f"{self._url}/{farm_id}/{node_id}", auth=auth, headers=headers)
+        self._session.delete(f"{self._url}/{farm_id}/{node_id}")
         return True


### PR DESCRIPTION
### Description

The client was not sending the date used to generated the signature of
the request to the server. This lead to the server using its own local
time to verify the signature which can lead to errors if both client and
server are not perfectly synchronized and/or the network is slow

### Changes

Send the date used to generate the request signature to the server

### Related Issues

fixes #1123