### PR TITLE
changed the loading to be on the table not on base-component

### DIFF
--- a/jumpscale/packages/admin/frontend/components/pools/Pools.vue
+++ b/jumpscale/packages/admin/frontend/components/pools/Pools.vue
@@ -11,7 +11,7 @@
       </template>
 
       <template #default>
-        <v-data-table :headers="headers" :loading="loading" :items="pools" @click:row="open">
+        <v-data-table :headers="headers" :loading="loading" :items="pools.reverse()" @click:row="open">
           <template slot="no-data">No pools available</p></template>
           <template v-slot:item.node_ids="{ item }">{{ item.node_ids.length }}</template>
           <template v-slot:item.active_workload_ids="{ item }">{{ item.active_workload_ids.length }}</template>

--- a/jumpscale/packages/admin/frontend/components/pools/Pools.vue
+++ b/jumpscale/packages/admin/frontend/components/pools/Pools.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <base-component title="Capacity Pools" icon="mdi-cloud" :loading="loading">
+    <base-component title="Capacity Pools" icon="mdi-cloud">
       <template #actions>
         <v-btn color="primary" text to="/solutions/pools">
           <v-icon left>mdi-cloud</v-icon>Create/Extend Pool
@@ -11,7 +11,7 @@
       </template>
 
       <template #default>
-        <v-data-table :headers="headers" :items="pools" @click:row="open">
+        <v-data-table :headers="headers" :loading="loading" :items="pools" @click:row="open">
           <template slot="no-data">No pools available</p></template>
           <template v-slot:item.node_ids="{ item }">{{ item.node_ids.length }}</template>
           <template v-slot:item.active_workload_ids="{ item }">{{ item.active_workload_ids.length }}</template>

--- a/jumpscale/packages/admin/frontend/components/workloads/Workloads.vue
+++ b/jumpscale/packages/admin/frontend/components/workloads/Workloads.vue
@@ -11,7 +11,7 @@
           v-model="selected_rows"
           show-select
           :headers="headers"
-          :items="data"
+          :items="data.reverse()"
           @click:row="open"
         >
           <template slot="no-data">No workloads available</p></template>


### PR DESCRIPTION
### Changes

- changed the loading to be on the table not on base-component
- reverse workloads ans pools table to show newest first
### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/1133
![image_2020-09-13_12-25-57](https://user-images.githubusercontent.com/36021484/93015898-76dc6200-f5bd-11ea-9b59-677fd5b2f84b.png)

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
