### PR TITLE
gedis http: reload internal client when installing a package

### DIFF
--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -495,6 +495,7 @@ class PackageManager(Base):
 
         # execute package start method
         package.start()
+        self.threebot.gedis_http.client.reload()
         self.threebot.nginx.reload()
 
     def reload(self, package_name):


### PR DESCRIPTION
### Description

Reload gedis http internal client when installing package.

### Changes

- Update `PackcakgeManager.install` to reload gedis http internal client.

### Related Issues

#1109.

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
