### PR TITLE
Development 3bot zinit

### DIFF
--- a/docs/wiki/threebot_deployer/threebot_deployer.md
+++ b/docs/wiki/threebot_deployer/threebot_deployer.md
@@ -95,9 +95,19 @@ Threebot Deploy package is installed normally like any other package using the a
 
 ```python
 server = j.servers.threebot.get("default")
-server.packages.add("/root/js-sdk/jumpscale/packages/threebot_deployer/")
+server.packages.add("/root/js-sdk/jumpscale/packages/threebot_deployer/", channel_type="redis", channel_host="<remoteRedisHostIP>", channel_port=<remoteHostRedisPort>)
 server.save()
 server.start()
 ```
 
 Now you can start your `3Bot` server and access threebot deploy dashboard on `/threebot_deployer`
+
+## Notes
+
+- channel_type, channel_host, channel_port are for streaming logs to a redis instance, these are need to be a public machine and run a redis server on it using non-protected mode `redis-server --port 6378 --protected-mode no`
+- You can access that logs further using:
+
+```
+redis-cli -h <remoteRedisHostIP> -p <remoteHostRedisPort>
+SUBSCRIBE <solution_name>-stdout <solution_name>-stderr
+```

--- a/jumpscale/install/Dockerfile
+++ b/jumpscale/install/Dockerfile
@@ -1,4 +1,5 @@
 FROM threefoldtech/phusion:19.10
+
 RUN apt-get update && apt-get install wget git python3-pip python3-venv redis-server tmux nginx restic -y
 RUN pip3 install poetry
 RUN mkdir -p /sandbox/code/github/threefoldtech
@@ -8,4 +9,8 @@ RUN poetry config virtualenvs.create false && poetry install
 RUN poetry shell
 RUN /etc/init.d/redis-server start
 RUN python3 jumpscale/install/codeserver-install.py
-ENTRYPOINT ["/sbin/my_init"]
+
+COPY rootfs /
+ADD zinit /sbin/zinit
+
+ENTRYPOINT [ "zinit", "init" ]

--- a/jumpscale/install/rootfs/etc/zinit/init.yaml
+++ b/jumpscale/install/rootfs/etc/zinit/init.yaml
@@ -1,0 +1,3 @@
+exec: sh -c "/bin/bash /sandbox/code/github/threefoldtech/js-sdk/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh"
+test: threebot status | grep running
+log: stdout

--- a/jumpscale/install/rootfs/etc/zinit/init.yaml
+++ b/jumpscale/install/rootfs/etc/zinit/init.yaml
@@ -1,3 +1,3 @@
 exec: sh -c "/bin/bash /sandbox/code/github/threefoldtech/js-sdk/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh"
-test: threebot status | grep running
+oneshot: true
 log: stdout

--- a/jumpscale/install/rootfs/etc/zinit/start.yaml
+++ b/jumpscale/install/rootfs/etc/zinit/start.yaml
@@ -1,4 +1,4 @@
-execute: jsng "j.servers.threebot.start_default(wait=True, local=False)"
+exec: jsng "j.servers.threebot.start_default(wait=True, local=False)"
 test: bash -c "ss -nplt | grep -v grep | grep 16000"
 log: stdout
 after:

--- a/jumpscale/install/rootfs/etc/zinit/start.yaml
+++ b/jumpscale/install/rootfs/etc/zinit/start.yaml
@@ -1,5 +1,5 @@
 execute: jsng "j.servers.threebot.start_default(wait=True, local=False)"
-test: jsng 'j.sals.nettools.wait_connection_test("127.0.0.1", 16000, timeout=1)' | grep True
+test: bash -c "ss -nplt | grep -v grep | grep 16000"
 log: stdout
 after:
   - init

--- a/jumpscale/install/rootfs/etc/zinit/start.yaml
+++ b/jumpscale/install/rootfs/etc/zinit/start.yaml
@@ -1,0 +1,5 @@
+execute: jsng "j.servers.threebot.start_default(wait=True, local=False)"
+test: jsng 'j.sals.nettools.wait_connection_test("127.0.0.1", 16000, timeout=1)' | grep True
+log: stdout
+after:
+  - init

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.py
@@ -28,10 +28,10 @@ def main():
         new = False
 
     j.logger.info("Generating guest identity ...")
-    identity_main = j.core.identity.new(
+    identity_main = j.core.identity.get(
         "main", tname=tname, email=email, words=words, explorer_url="https://explorer.grid.tf/explorer"
     )
-    identity_test = j.core.identity.new(
+    identity_test = j.core.identity.get(
         "test", tname=tname, email=email, words=words, explorer_url="https://explorer.testnet.grid.tf/api/v1"
     )
 

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.py
@@ -44,6 +44,12 @@ def main():
     j.core.identity.set_default("test")
 
     if backup_password:
+        # Seprate the logic of wallet creation in case of stellar failure it still takes the backup
+        try:
+            j.clients.stellar.create_testnet_funded_wallet(f"{threebot_name}_{instance_name}")
+        except Exception as e:
+            j.logger.error(str(e))
+
         try:
             BACKUP_ACTOR.init(backup_password, new=new)
             if not new:
@@ -54,7 +60,6 @@ def main():
             else:
                 j.logger.info("Taking backup ...")
                 # Create a funded wallet to the threebot testnet
-                j.clients.stellar.create_testnet_funded_wallet(f"{threebot_name}_{instance_name}")
                 BACKUP_ACTOR.backup(tags="init")
         except Exception as e:
             j.logger.error(str(e))

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.py
@@ -61,10 +61,11 @@ def main():
 
     j.logger.info("Starting threebot ...")
 
-    if test_cert == "true":
-        j.servers.threebot.start_default(wait=True, local=False)
-    else:
-        j.servers.threebot.start_default(wait=True, local=False, domain=domain, email=email)
+    server = j.servers.threebot.get("default")
+    if test_cert == "false":
+        server.domain = domain
+        server.email = email
+        server.save()
 
 
 if __name__ == "__main__":

--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -252,7 +252,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
         log_config["channel_type"] = "redis"
         log_config["channel_host"] = "192.241.158.21"
         log_config["channel_port"] = 6378
-        log_config["channel_name"] = "newoffice2"
+        log_config["channel_name"] = self.solution_name
 
         self.workload_ids.append(
             deployer.deploy_container(

--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -18,7 +18,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
     steps = [
         "create_or_recover",
         "get_solution_name",
-        "upload_public_key",
+        # "upload_public_key",
         "set_backup_password",
         "solution_expiration",
         "infrastructure_setup",
@@ -154,12 +154,12 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
                 self.md_show("The specified 3Bot name doesn't exist.")
         self.backup_model = BACKUP_MODEL_FACTORY.get(f"{self.solution_name}_{self.threebot_name}")
 
-    @chatflow_step(title="SSH key")
-    def upload_public_key(self):
-        self.public_key = self.upload_file(
-            "Please upload your public ssh key, this will allow you to access your threebot container using ssh",
-            required=True,
-        ).strip()
+    # @chatflow_step(title="SSH key")
+    # def upload_public_key(self):
+    #     self.public_key = self.upload_file(
+    #         "Please upload your public ssh key, this will allow you to access your threebot container using ssh",
+    #         required=True,
+    #     ).strip()
 
     def _existing_3bot(self):
         try:
@@ -241,18 +241,16 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
             "INSTANCE_NAME": self.solution_name,
             "THREEBOT_NAME": self.threebot_name,
             "DOMAIN": self.domain,
-            "SSHKEY": self.public_key,
+            # "SSHKEY": self.public_key,
             "TEST_CERT": "true" if test_cert else "false",
             "MARKETPLACE_URL": f"https://{j.sals.nginx.main.websites.threebot_deployer_threebot_deployer_root_proxy_443.domain}/",
         }
         self.network_view = self.network_view.copy()
 
         ## Container logs
-        log_config = {}
-        log_config["channel_type"] = "redis"
-        log_config["channel_host"] = "192.241.158.21"
-        log_config["channel_port"] = 6378
-        log_config["channel_name"] = self.solution_name
+        log_config = j.config.get("LOGGING_SINK", {})
+        if log_config:
+            log_config["channel_name"] = self.solution_name
 
         self.workload_ids.append(
             deployer.deploy_container(

--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -248,7 +248,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
         self.network_view = self.network_view.copy()
 
         ## Container logs
-        log_config = j.config.get("LOGGING_SINK", {})
+        log_config = j.core.config.get("LOGGING_SINK", {})
         if log_config:
             log_config["channel_name"] = self.solution_name
 

--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -12,7 +12,7 @@ from jumpscale.sals.reservation_chatflow import DeploymentFailed, deployment_con
 
 
 class ThreebotDeploy(MarketPlaceAppsChatflow):
-    FLIST_URL = "https://hub.grid.tf/ahmedelsayed.3bot/threefoldtech-js-sdk-latest.flist"
+    FLIST_URL = "https://hub.grid.tf/waleedhammam.3bot/waleedhammam-js-sdk-latest.flist"
     SOLUTION_TYPE = "threebot"  # chatflow used to deploy the solution
     title = "3Bot"
     steps = [
@@ -246,7 +246,6 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
             "MARKETPLACE_URL": f"https://{j.sals.nginx.main.websites.threebot_deployer_threebot_deployer_root_proxy_443.domain}/",
         }
         self.network_view = self.network_view.copy()
-        entry_point = "/bin/bash jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh"
         self.workload_ids.append(
             deployer.deploy_container(
                 pool_id=self.pool_id,
@@ -258,7 +257,6 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
                 cpu=self.query["cru"],
                 memory=self.query["mru"] * 1024,
                 disk_size=self.query["sru"] * 1024,
-                entrypoint=entry_point,
                 secret_env={"BACKUP_PASSWORD": self.backup_password, "BACKUP_TOKEN": backup_token},
                 interactive=False,
                 solution_uuid=self.solution_id,

--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -246,6 +246,14 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
             "MARKETPLACE_URL": f"https://{j.sals.nginx.main.websites.threebot_deployer_threebot_deployer_root_proxy_443.domain}/",
         }
         self.network_view = self.network_view.copy()
+
+        ## Container logs
+        log_config = {}
+        log_config["channel_type"] = "redis"
+        log_config["channel_host"] = "192.241.158.21"
+        log_config["channel_port"] = 6378
+        log_config["channel_name"] = "newoffice2"
+
         self.workload_ids.append(
             deployer.deploy_container(
                 pool_id=self.pool_id,
@@ -259,6 +267,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
                 disk_size=self.query["sru"] * 1024,
                 secret_env={"BACKUP_PASSWORD": self.backup_password, "BACKUP_TOKEN": backup_token},
                 interactive=False,
+                log_config=log_config,
                 solution_uuid=self.solution_id,
                 **self.solution_metadata,
             )

--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -18,7 +18,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
     steps = [
         "create_or_recover",
         "get_solution_name",
-        # "upload_public_key",
+        "upload_public_key",
         "set_backup_password",
         "solution_expiration",
         "infrastructure_setup",
@@ -154,12 +154,12 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
                 self.md_show("The specified 3Bot name doesn't exist.")
         self.backup_model = BACKUP_MODEL_FACTORY.get(f"{self.solution_name}_{self.threebot_name}")
 
-    # @chatflow_step(title="SSH key")
-    # def upload_public_key(self):
-    #     self.public_key = self.upload_file(
-    #         "Please upload your public ssh key, this will allow you to access your threebot container using ssh",
-    #         required=True,
-    #     ).strip()
+    @chatflow_step(title="SSH key")
+    def upload_public_key(self):
+        self.public_key = self.upload_file(
+            "Please upload your public ssh key, this will allow you to access your threebot container using ssh",
+            required=True,
+        ).strip()
 
     def _existing_3bot(self):
         try:
@@ -241,7 +241,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
             "INSTANCE_NAME": self.solution_name,
             "THREEBOT_NAME": self.threebot_name,
             "DOMAIN": self.domain,
-            # "SSHKEY": self.public_key,
+            "SSHKEY": self.public_key,
             "TEST_CERT": "true" if test_cert else "false",
             "MARKETPLACE_URL": f"https://{j.sals.nginx.main.websites.threebot_deployer_threebot_deployer_root_proxy_443.domain}/",
         }

--- a/jumpscale/packages/threebot_deployer/package.py
+++ b/jumpscale/packages/threebot_deployer/package.py
@@ -10,8 +10,9 @@ class threebot_deployer:
 
         if all([v for v in log_config.values()]):
             j.core.config.set("LOGGING_SINK", log_config)
-        else:
-            j.core.config.set("LOGGING_SINK", {})
+            j.logger.info(
+                f"Added remote redis logs on machine {log_config['channel_host']}:{log_config['channel_port']}"
+            )
 
         location_actors_443 = j.sals.nginx.main.websites.default_443.locations.get(name="threebot_deployer_actors")
         location_actors_443.is_auth = False
@@ -25,9 +26,6 @@ class threebot_deployer:
 
         j.sals.nginx.main.websites.default_443.configure()
         j.sals.nginx.main.websites.default_80.configure()
-
-    def start(self):
-        self.install()
 
     def uninstall(self):
         """Called when package is deleted

--- a/jumpscale/packages/threebot_deployer/package.py
+++ b/jumpscale/packages/threebot_deployer/package.py
@@ -2,7 +2,17 @@ from jumpscale.loader import j
 
 
 class threebot_deployer:
-    def install(self):
+    def install(self, **kwargs):
+        log_config = {}
+        log_config["channel_type"] = kwargs.get("channel_type")
+        log_config["channel_host"] = kwargs.get("channel_host")
+        log_config["channel_port"] = kwargs.get("channel_port")
+
+        if all([v for v in log_config.values()]):
+            j.core.config.set("LOGGING_SINK", log_config)
+        else:
+            j.core.config.set("LOGGING_SINK", {})
+
         location_actors_443 = j.sals.nginx.main.websites.default_443.locations.get(name="threebot_deployer_actors")
         location_actors_443.is_auth = False
         location_actors_443.is_admin = False


### PR DESCRIPTION
### Description

- Use Zinit to start 3Bot flist

### Changes

- Use Zinit to start 3Bot flist
- Clean threebot entrypoint
- Add option/docs to stream logs to remote redis

### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/1174