### PR TITLE
fetch user info at the beginning

### DIFF
--- a/jumpscale/packages/marketplace/chats/blog.py
+++ b/jumpscale/packages/marketplace/chats/blog.py
@@ -9,12 +9,12 @@ class BlogDeploy(Publisher):
 
     @chatflow_step(title="blog Setup")
     def configuration(self):
+        self.user_email = self.user_info()["email"]
         form = self.new_form()
         title = form.string_ask("Title", required=True)
         url = form.string_ask("Repository URL", required=True, is_git_url=True)
         branch = form.string_ask("Branch", required=True)
         form.ask(Publisher.MD_CONFIG_MSG, md=True)
-        self.user_email = self.user_info()["email"]
         self.envars = {
             "TYPE": "blog",
             "NAME": "entrypoint",

--- a/jumpscale/packages/marketplace/chats/discourse.py
+++ b/jumpscale/packages/marketplace/chats/discourse.py
@@ -22,6 +22,9 @@ class Discourse(MarketPlaceAppsChatflow):
 
     @chatflow_step(title="Discourse Setup")
     def discourse_smtp_info(self):
+        user_info = self.user_info()
+        self.user_email = user_info["email"]
+        self.username = user_info["username"]
         form = self.new_form()
         self.smtp_server = form.string_ask("Please add the host e-mail address for your solution", required=True)
         self.smtp_username = form.string_ask(
@@ -33,8 +36,6 @@ class Discourse(MarketPlaceAppsChatflow):
         self.smtp_server = self.smtp_server.value
         self.smtp_username = self.smtp_username.value
         self.smtp_password = self.smtp_password.value
-        self.user_email = self.user_info()["email"]
-        self.username = self.user_info()["username"]
 
     @chatflow_step(title="Reservation", disable_previous=True)
     @deployment_context()

--- a/jumpscale/packages/marketplace/chats/mattermost.py
+++ b/jumpscale/packages/marketplace/chats/mattermost.py
@@ -20,10 +20,10 @@ class MattermostDeploy(MarketPlaceAppsChatflow):
 
     @chatflow_step(title="Mattermost Information")
     def mattermost_info(self):
+        self.user_email = self.user_info()["email"]
         self._choose_flavor()
         self.vol_size = self.flavor_resources["sru"]
         self.query["sru"] += self.vol_size
-        self.user_email = self.user_info()["email"]
 
     @chatflow_step(title="Reservation", disable_previous=True)
     @deployment_context()

--- a/jumpscale/packages/marketplace/chats/peertube.py
+++ b/jumpscale/packages/marketplace/chats/peertube.py
@@ -20,11 +20,11 @@ class Peertube(MarketPlaceAppsChatflow):
 
     @chatflow_step(title="Volume details")
     def volume_details(self):
+        self.user_email = self.user_info()["email"]
         self._choose_flavor()
         self.vol_size = self.flavor_resources["sru"]
         self.vol_mount_point = "/var/www/peertube/storage/"
         self.query["sru"] += self.vol_size
-        self.user_email = self.user_info()["email"]
 
     @chatflow_step(title="Reservation", disable_previous=True)
     @deployment_context()

--- a/jumpscale/packages/marketplace/chats/publisher.py
+++ b/jumpscale/packages/marketplace/chats/publisher.py
@@ -34,6 +34,9 @@ class Publisher(MarketPlaceAppsChatflow):
 
     @chatflow_step(title="Solution Settings")
     def configuration(self):
+        user_info = self.user_info()
+        self.username = user_info["username"]
+        self.user_email = user_info["email"]
         form = self.new_form()
         ttype = form.single_choice(
             "Choose the publication type", options=["wiki", "www", "blog"], default="wiki", required=True
@@ -42,8 +45,6 @@ class Publisher(MarketPlaceAppsChatflow):
         url = form.string_ask("Repository URL", required=True, is_git_url=True)
         branch = form.string_ask("Branch", required=True)
         form.ask(self.MD_CONFIG_MSG, md=True)
-        self.username = self.user_info()["username"]
-        self.user_email = self.user_info()["email"]
         self.envars = {
             "TYPE": ttype.value,
             "NAME": "entrypoint",

--- a/jumpscale/packages/marketplace/chats/taiga.py
+++ b/jumpscale/packages/marketplace/chats/taiga.py
@@ -24,6 +24,9 @@ class TaigaDeploy(MarketPlaceAppsChatflow):
 
     @chatflow_step(title="Taiga Setup")
     def taiga_credentials(self):
+        user_info = self.user_info()
+        self.user_email = user_info["email"]
+        self.username = user_info["username"]
         form = self.new_form()
         EMAIL_HOST_USER = form.string_ask("Please add the host e-mail address for your solution", required=True)
         EMAIL_HOST = form.string_ask(
@@ -38,8 +41,6 @@ class TaigaDeploy(MarketPlaceAppsChatflow):
         self.EMAIL_HOST = EMAIL_HOST.value
         self.EMAIL_HOST_PASSWORD = EMAIL_HOST_PASSWORD.value
         self.SECRET_KEY = SECRET_KEY.value
-        self.user_email = self.user_info()["email"]
-        self.username = self.user_info()["username"]
 
     @chatflow_step(title="Reservation", disable_previous=True)
     @deployment_context()

--- a/jumpscale/packages/marketplace/chats/website.py
+++ b/jumpscale/packages/marketplace/chats/website.py
@@ -9,12 +9,12 @@ class WebsiteDeploy(Publisher):
 
     @chatflow_step(title="Website Setup")
     def configuration(self):
+        self.user_email = self.user_info()["email"]
         form = self.new_form()
         title = form.string_ask("Title", required=True)
         url = form.string_ask("Repository URL", required=True, is_git_url=True)
         branch = form.string_ask("Branch", required=True)
         form.ask(Publisher.MD_CONFIG_MSG, md=True)
-        self.user_email = self.user_info()["email"]
         self.envars = {
             "TYPE": "www",
             "NAME": "entrypoint",

--- a/jumpscale/packages/marketplace/chats/wiki.py
+++ b/jumpscale/packages/marketplace/chats/wiki.py
@@ -9,12 +9,12 @@ class WikiDeploy(Publisher):
 
     @chatflow_step(title="Wiki Setup")
     def configuration(self):
+        self.user_email = self.user_info()["email"]
         form = self.new_form()
         title = form.string_ask("Title", required=True)
         url = form.string_ask("Repository URL", required=True, is_git_url=True)
         branch = form.string_ask("Branch", required=True)
         form.ask(Publisher.MD_CONFIG_MSG, md=True)
-        self.user_email = self.user_info()["email"]
         self.envars = {
             "TYPE": "wiki",
             "NAME": "entrypoint",


### PR DESCRIPTION
### Description

The chatflow listens for payloads from the backend and depending on their type, it disables or enables the next button. The issue is that calling self.user_info is a method that sends a payload to the chatflow with a type for which the next button is enabled. If the user clicks on the next again, it registers two transitions and that causes the step to come to be skipped. I moved it to the beginning of the step so that the next button don't get re-enabled.

### Related Issues

#1171