### PR TITLE
return a copy of threebot package keys in list_all()

### DIFF
--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -366,7 +366,7 @@ class PackageManager(Base):
         return all_packages
 
     def list_all(self):
-        return self.packages.keys()
+        return list(self.packages.keys())
 
     def add(self, path: str = None, giturl: str = None, **kwargs):
         # TODO: Check if package already exists


### PR DESCRIPTION
### Description

Return a copy when listing packages.

### Changes

- PackageManager.list_all()

### Related Issues

#1097

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
