### PR TITLE
added optional url to the title in base component and use to back hom…

### DIFF
--- a/jumpscale/packages/marketplace/frontend/components/base/Component.vue
+++ b/jumpscale/packages/marketplace/frontend/components/base/Component.vue
@@ -1,10 +1,16 @@
 <template>
   <div style="padding: 40px; padding-top:20px">
     <v-toolbar color="transparent" flat>
-      <v-toolbar-title class="primary--text">
-        <v-icon color="primary" large left>{{icon}}</v-icon> {{title}}
+      <v-toolbar-title v-if="url" class="primary--text">
+        <router-link :to="url" style="text-decoration: none;">
+          <v-icon color="primary" x-large left>{{icon}}</v-icon>
+          {{title}}
+        </router-link>
       </v-toolbar-title>
-
+      <v-toolbar-title v-else class="primary--text">
+        <v-icon color="primary" x-large left>{{icon}}</v-icon>
+        {{title}}
+      </v-toolbar-title>
       <v-spacer></v-spacer>
       <slot name="search"></slot>
 
@@ -12,17 +18,19 @@
       <slot name="actions"></slot>
     </v-toolbar>
 
-    <v-divider></v-divider><br>
+    <v-divider></v-divider>
+    <br />
     <slot name="default"></slot>
   </div>
 </template>
 
 <script>
-  module.exports = {
-    props: {
-      title: String,
-      icon: String,
-      loading: Boolean
-    }
-  }
+module.exports = {
+  props: {
+    title: String,
+    icon: String,
+    loading: Boolean,
+    url: String,
+  },
+};
 </script>

--- a/jumpscale/packages/marketplace/frontend/components/solutions/Solution.vue
+++ b/jumpscale/packages/marketplace/frontend/components/solutions/Solution.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <base-component title="Solutions" icon="mdi-apps" :loading="loading">
+    <base-component title="Apps Menu" icon="mdi-menu-left" url="/" :loading="loading">
       <template #default>
         <v-card class="pa-3 ml-3">
           <v-card-title class="headline">


### PR DESCRIPTION
#### suggestion from Essam to add a clear sign to back home in the marketplace workload page.
- I changed the base component to able to accept URL and changed the confusing icon `menu` to back icon and title to `Apps menu`
- before
![image](https://user-images.githubusercontent.com/36021484/93484286-06f21280-f902-11ea-9bc5-f11b7dc9de15.png)


- after

![image_2020-09-17_16-02-18](https://user-images.githubusercontent.com/36021484/93484202-eb870780-f901-11ea-894f-2c4b035766ca.png)
