### PR TITLE
add set_default on identity object

### DIFF
--- a/jumpscale/core/identity/__init__.py
+++ b/jumpscale/core/identity/__init__.py
@@ -171,6 +171,11 @@ class Identity(Base):
         self.save()
         return tid
 
+    def set_default(self):
+        from jumpscale.loader import j
+
+        return j.core.identity.set_default(self.instance_name)
+
 
 def get_identity():
     return IdentityFactory(Identity).me


### PR DESCRIPTION
instead of creating identity and then  go to `j.core.identity.set_default("newme")` we can `identityobj.set_default()`