### PR TITLE
add sendgrid converate tests

### DIFF
--- a/tests/clients/sendgrid/env_var.sh
+++ b/tests/clients/sendgrid/env_var.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export SEND_GRID_API_KEY_TOKEN="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"

--- a/tests/clients/sendgrid/test_sendgrid.py
+++ b/tests/clients/sendgrid/test_sendgrid.py
@@ -1,0 +1,33 @@
+import os
+import string
+from unittest import TestCase
+from jumpscale.loader import j
+
+
+class Sendgrid(TestCase):
+    def setUp(self):
+        self.sendgird_client_name = j.data.idgenerator.nfromchoices(10, string.ascii_letters)
+        self.test = j.clients.sendgrid.get(name=self.sendgird_client_name)
+        self.test.apikey = os.environ.get("SEND_GRID_API_KEY_TOKEN")
+        self.sender_mail = j.data.fake.email()
+        self.recipient_mail = j.data.fake.email()
+        self.subject = j.data.fake.sentence()
+        file_name = j.data.idgenerator.nfromchoices(10, string.ascii_letters)
+        self.attachment_path = f"/tmp/{file_name}.pdf"
+        # Writing pdf to be used in attachemt
+        j.sals.fs.write_file(path=self.attachment_path, data="i am testing")
+
+    def test01_test_sendgrid_send_mail(self):
+        res = self.test.send(sender=self.sender_mail, subject=self.subject, recipients=[self.recipient_mail])
+        self.assertIsNone(res)
+
+    def test02_test_sendgrid_send_mail_with_attachment(self):
+        attach = self.test.build_attachment(filepath=self.attachment_path)
+        res = self.test.send(
+            sender=self.sender_mail, subject=self.subject, recipients=[self.recipient_mail], attachments=[attach]
+        )
+        self.assertIsNone(res)
+
+    def tearDown(self):
+        j.clients.sendgrid.delete(self.sendgird_client_name)
+        os.remove(self.attachment_path)

--- a/tests/clients/sendgrid/test_sendgrid.py
+++ b/tests/clients/sendgrid/test_sendgrid.py
@@ -1,5 +1,6 @@
 import os
 import string
+import pytest
 from unittest import TestCase
 from jumpscale.loader import j
 
@@ -17,10 +18,12 @@ class Sendgrid(TestCase):
         # Writing pdf to be used in attachemt
         j.sals.fs.write_file(path=self.attachment_path, data="i am testing")
 
+    @pytest.mark.integration
     def test01_test_sendgrid_send_mail(self):
         res = self.test.send(sender=self.sender_mail, subject=self.subject, recipients=[self.recipient_mail])
         self.assertIsNone(res)
 
+    @pytest.mark.integration
     def test02_test_sendgrid_send_mail_with_attachment(self):
         attach = self.test.build_attachment(filepath=self.attachment_path)
         res = self.test.send(


### PR DESCRIPTION
### Description

Adding tests for sendgrid

### Changes

`tests/clients/sendgrid/test_sendgrid.py`

### Related Issues

List of related issues
https://github.com/threefoldtech/js-sdk/issues/1329

![image](https://user-images.githubusercontent.com/46320202/94682856-e1173580-0325-11eb-89e0-7f2d840221c1.png)
