### PR TITLE
Workaround to make the datatable go to page with entries after filtering

### DIFF
--- a/jumpscale/packages/admin/frontend/components/workloads/Workloads.vue
+++ b/jumpscale/packages/admin/frontend/components/workloads/Workloads.vue
@@ -13,6 +13,7 @@
           :headers="headers"
           :items="data.reverse()"
           @click:row="open"
+          :page.sync="page"
         >
           <template slot="no-data">No workloads available</p></template>
           <template v-slot:item.epoch="{ item }">{{ new Date(item.epoch * 1000).toLocaleString() }}</template>
@@ -79,6 +80,7 @@ module.exports = {
       types: [],
       pools: [],
       actions: [],
+      page: 1,
       filters: {
         id: null,
         pool_id: null,


### PR DESCRIPTION
### Description

Apparently, adding page.sync attribute makes the data table return to a page with entries after filtering. But it's mainly an issue in Vuetify https://github.com/vuetifyjs/vuetify/issues/10949.

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/835
