### PR TITLE
check if the owner is the same as the pool owner

### DIFF
--- a/jumpscale/sals/marketplace/models.py
+++ b/jumpscale/sals/marketplace/models.py
@@ -4,3 +4,4 @@ from jumpscale.core.base import Base, fields
 class UserPool(Base):
     pool_id = fields.Integer()
     owner = fields.String()
+    explorer_url = fields.String()


### PR DESCRIPTION
### Description

The gateway pool is identified only by the farm name. This causes issues when switching identities, since the pool owner changes and the gateways available on mainnet are different from testnet. In this PR, a check is added for the owner and a new pool is created in case of mismatch.


![Screenshot from 2020-10-12 12-48-42](https://user-images.githubusercontent.com/13040543/95746636-693afa80-0c97-11eb-8c9e-3ac3d479b235.png)