### PR TITLE
do hash the shared secret generated to decrypt workloads sensitive in formation

### DIFF
--- a/jumpscale/sals/zos/container.py
+++ b/jumpscale/sals/zos/container.py
@@ -98,9 +98,9 @@ class ContainerGenerator:
           str: encrypted string
         """
         bkey = base58.b58decode(node_id)
-        node_public = binascii.hexlify(bkey)
+        node_public_hex = binascii.hexlify(bkey)
 
-        encrypted = encrypt_for_node(self._identity, node_public, value)
+        encrypted = encrypt_for_node(self._identity, node_public_hex, value)
         return encrypted.decode()
 
     def add_logs(

--- a/jumpscale/sals/zos/container.py
+++ b/jumpscale/sals/zos/container.py
@@ -14,9 +14,12 @@ from jumpscale.clients.explorer.models import (
 )
 from jumpscale.core.exceptions import Input
 
+from .crypto import encrypt_for_node
+
 
 class ContainerGenerator:
-    """ """
+    def __init__(self, identity):
+        self._identity = identity
 
     def create(
         self,
@@ -93,16 +96,12 @@ class ContainerGenerator:
 
         Returns:
           str: encrypted string
-
         """
-        key = base58.b58decode(node_id)
-        pk = signing.VerifyKey(key)
-        encryption_key = pk.to_curve25519_public_key()
+        bkey = base58.b58decode(node_id)
+        node_public = binascii.hexlify(bkey)
 
-        box = public.SealedBox(encryption_key)
-        result = box.encrypt(value.encode())
-
-        return binascii.hexlify(result).decode()
+        encrypted = encrypt_for_node(self._identity, node_public, value)
+        return encrypted.decode()
 
     def add_logs(
         self, container: Container, channel_type: str, channel_host: str, channel_port: str, channel_name: str

--- a/jumpscale/sals/zos/crypto.py
+++ b/jumpscale/sals/zos/crypto.py
@@ -1,18 +1,20 @@
 import binascii
+from hashlib import blake2b
 from typing import Union
 
 from jumpscale.core.identity import Identity
 from jumpscale.loader import j
 from nacl.bindings import crypto_scalarmult
-from nacl.public import SealedBox
+from nacl.secret import SecretBox
 from nacl.signing import VerifyKey
 
 
 def encrypt_for_node(identity: Identity, public_key: str, payload: Union[str, bytes]) -> str:
-    """encrypt payload with the public key of a node so only the node itself can decrypt it
-    use this if you have sensitive data to send in a reservation
+    """
+    encrypt payload using a nacl.SecretBox with a shared key derived from the public key of the node and private key of the user
 
     Args:
+      identity(Identity): the identity object that contains the key pair of the user
       public_key(str): public key of the node, hex-encoded
       payload(Union[str, bytes]): any data you want to encrypt
 
@@ -27,9 +29,12 @@ def encrypt_for_node(identity: Identity, public_key: str, payload: Union[str, by
     node_public = node_public.encode()
 
     shared_secret = crypto_scalarmult(user_private, node_public)
+    h = blake2b(shared_secret, digest_size=32)
+    key = h.digest()
 
     if isinstance(payload, str):
         payload = payload.encode()
 
+    box = SecretBox(key)
     encrypted = box.encrypt(payload)
     return binascii.hexlify(encrypted)

--- a/jumpscale/sals/zos/crypto.py
+++ b/jumpscale/sals/zos/crypto.py
@@ -1,11 +1,14 @@
 import binascii
 from typing import Union
 
+from jumpscale.core.identity import Identity
+from jumpscale.loader import j
+from nacl.bindings import crypto_scalarmult
 from nacl.public import SealedBox
 from nacl.signing import VerifyKey
 
 
-def encrypt_for_node(public_key: str, payload: Union[str, bytes]) -> str:
+def encrypt_for_node(identity: Identity, public_key: str, payload: Union[str, bytes]) -> str:
     """encrypt payload with the public key of a node so only the node itself can decrypt it
     use this if you have sensitive data to send in a reservation
 
@@ -17,9 +20,13 @@ def encrypt_for_node(public_key: str, payload: Union[str, bytes]) -> str:
       str: hex-encoded encrypted data. you can use this safely into your reservation data
 
     """
-    node_public_bin = binascii.unhexlify(public_key)
-    node_public = VerifyKey(node_public_bin)
-    box = SealedBox(node_public.to_curve25519_public_key())
+    user_private = identity.nacl.signing_key.to_curve25519_private_key().encode()
+
+    node_verify_bin = binascii.unhexlify(public_key)
+    node_public = VerifyKey(node_verify_bin).to_curve25519_public_key()
+    node_public = node_public.encode()
+
+    shared_secret = crypto_scalarmult(user_private, node_public)
 
     if isinstance(payload, str):
         payload = payload.encode()

--- a/jumpscale/sals/zos/gateway.py
+++ b/jumpscale/sals/zos/gateway.py
@@ -140,7 +140,7 @@ class GatewayGenerator:
         p.info.workload_type = WorkloadType.Reverse_proxy
         p.domain = domain
         node = self._gateways.get(gateway_id)
-        p.secret = encrypt_for_node(node.public_key_hex, secret).decode()
+        p.secret = encrypt_for_node(self._identity, node.public_key_hex, secret).decode()
         return p
 
     def gateway_4to6(self, gateway_id: str, public_key: str, pool_id: int) -> Gateway4to6:

--- a/jumpscale/sals/zos/kubernetes.py
+++ b/jumpscale/sals/zos/kubernetes.py
@@ -51,7 +51,7 @@ class KubernetesGenerator:
         master.info.pool_id = pool_id
 
         node = self._nodes.get(node_id)
-        master.cluster_secret = encrypt_for_node(node.public_key_hex, cluster_secret).decode()
+        master.cluster_secret = encrypt_for_node(self._identity, node.public_key_hex, cluster_secret).decode()
         master.network_id = network_name
         master.ipaddress = ip_address
         master.size = size

--- a/jumpscale/sals/zos/zdb.py
+++ b/jumpscale/sals/zos/zdb.py
@@ -49,6 +49,6 @@ class ZDBGenerator:
         zdb.mode = mode
         if password:
             node = self._nodes.get(node_id)
-            zdb.password = encrypt_for_node(node.public_key_hex, password).decode()
+            zdb.password = encrypt_for_node(self._identity, node.public_key_hex, password).decode()
         zdb.disk_type = disk_type
         return zdb

--- a/jumpscale/sals/zos/zos.py
+++ b/jumpscale/sals/zos/zos.py
@@ -21,8 +21,6 @@ from .zdb import ZDBGenerator
 
 
 class Zosv2:
-    """ """
-
     def __init__(self, identity):
         self.__identity = identity
 
@@ -40,7 +38,7 @@ class Zosv2:
 
     @property
     def container(self):
-        return ContainerGenerator()
+        return ContainerGenerator(self._identity)
 
     @property
     def volume(self):


### PR DESCRIPTION
Extract from https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman#Key_establishment_protocol:
> While the shared secret may be used directly as a key, it can be desirable to hash the secret to remove weak bits due to the Diffie–Hellman exchange.

DO NOT MERGE YET.