### PR TITLE
shuffle managed domains as well

### DIFF
--- a/jumpscale/sals/marketplace/apps_chatflow.py
+++ b/jumpscale/sals/marketplace/apps_chatflow.py
@@ -282,6 +282,7 @@ class MarketPlaceAppsChatflow(MarketPlaceChatflow):
         blocked_domains = deployer.list_blocked_managed_domains()
         for gw_dict in gateway_values:
             gateway = gw_dict["gateway"]
+            random.shuffle(gateway.managed_domains)
             for domain in gateway.managed_domains:
                 self.addresses = []
                 is_managed_domains = True


### PR DESCRIPTION
### Description

fix managed domain selection. should be shuffled to avoid hitting letsencrypt rate limit fast and to have varity of domains

