### PR TITLE
Development 3botdeployer escalation emails

### DIFF
--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -155,12 +155,12 @@ class Admin(BaseActor):
 
     @actor_method
     def list_escalation_emails(self) -> str:
-        escalation_emails = j.core.config.get("ESCALATION_EMAILS")
+        escalation_emails = j.core.config.get("ESCALATION_EMAILS", [])
         return j.data.serializers.json.dumps({"data": escalation_emails})
 
     @actor_method
     def add_escalation_email(self, email) -> str:
-        escalation_emails = j.core.config.get("ESCALATION_EMAILS")
+        escalation_emails = j.core.config.get("ESCALATION_EMAILS", [])
         if email not in escalation_emails:
             escalation_emails.append(email)
             j.core.config.set("ESCALATION_EMAILS", escalation_emails)
@@ -168,7 +168,7 @@ class Admin(BaseActor):
 
     @actor_method
     def delete_escalation_email(self, email) -> str:
-        escalation_emails = j.core.config.get("ESCALATION_EMAILS")
+        escalation_emails = j.core.config.get("ESCALATION_EMAILS", [])
         if email in escalation_emails:
             escalation_emails.remove(email)
             j.core.config.set("ESCALATION_EMAILS", escalation_emails)

--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -117,17 +117,35 @@ class Admin(BaseActor):
         test_cert = j.core.config.set_default("TEST_CERT", False)
         over_provision = j.core.config.set_default("OVER_PROVISIONING", False)
         explorer_logs = j.core.config.set_default("EXPLORER_LOGS", False)
+        escalation_emails = j.core.config.set_default("ESCALATION_EMAILS", False)
         return j.data.serializers.json.dumps(
-            {"data": {"test_cert": test_cert, "over_provision": over_provision, "explorer_logs": explorer_logs}}
+            {
+                "data": {
+                    "test_cert": test_cert,
+                    "over_provision": over_provision,
+                    "explorer_logs": explorer_logs,
+                    "escalation_emails": escalation_emails,
+                }
+            }
         )
 
     @actor_method
-    def set_developer_options(self, test_cert: bool, over_provision: bool, explorer_logs: bool) -> str:
+    def set_developer_options(
+        self, test_cert: bool, over_provision: bool, explorer_logs: bool, escalation_emails: bool
+    ) -> str:
         j.core.config.set("TEST_CERT", test_cert)
         j.core.config.set("OVER_PROVISIONING", over_provision)
         j.core.config.set("EXPLORER_LOGS", explorer_logs)
+        j.core.config.set("ESCALATION_EMAILS", escalation_emails)
         return j.data.serializers.json.dumps(
-            {"data": {"test_cert": test_cert, "over_provision": over_provision, "explorer_logs": explorer_logs}}
+            {
+                "data": {
+                    "test_cert": test_cert,
+                    "over_provision": over_provision,
+                    "explorer_logs": explorer_logs,
+                    "escalation_emails": escalation_emails,
+                }
+            }
         )
 
     @actor_method

--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -117,7 +117,7 @@ class Admin(BaseActor):
         test_cert = j.core.config.set_default("TEST_CERT", False)
         over_provision = j.core.config.set_default("OVER_PROVISIONING", False)
         explorer_logs = j.core.config.set_default("EXPLORER_LOGS", False)
-        escalation_emails = j.core.config.set_default("ESCALATION_EMAILS", False)
+        escalation_emails = j.core.config.set_default("ESCALATION_EMAILS_ENABLED", False)
         return j.data.serializers.json.dumps(
             {
                 "data": {
@@ -136,7 +136,7 @@ class Admin(BaseActor):
         j.core.config.set("TEST_CERT", test_cert)
         j.core.config.set("OVER_PROVISIONING", over_provision)
         j.core.config.set("EXPLORER_LOGS", explorer_logs)
-        j.core.config.set("ESCALATION_EMAILS", escalation_emails)
+        j.core.config.set("ESCALATION_EMAILS_ENABLED", escalation_emails)
         return j.data.serializers.json.dumps(
             {
                 "data": {
@@ -152,6 +152,27 @@ class Admin(BaseActor):
     def clear_blocked_nodes(self) -> str:
         j.sals.reservation_chatflow.reservation_chatflow.clear_blocked_nodes()
         return j.data.serializers.json.dumps({"data": "blocked nodes got cleared successfully."})
+
+    @actor_method
+    def list_escalation_emails(self) -> str:
+        escalation_emails = j.core.config.get("ESCALATION_EMAILS")
+        return j.data.serializers.json.dumps({"data": escalation_emails})
+
+    @actor_method
+    def add_escalation_email(self, email) -> str:
+        escalation_emails = j.core.config.get("ESCALATION_EMAILS")
+        if email not in escalation_emails:
+            escalation_emails.append(email)
+            j.core.config.set("ESCALATION_EMAILS", escalation_emails)
+        return j.data.serializers.json.dumps({"data": escalation_emails})
+
+    @actor_method
+    def delete_escalation_email(self, email) -> str:
+        escalation_emails = j.core.config.get("ESCALATION_EMAILS")
+        if email in escalation_emails:
+            escalation_emails.remove(email)
+            j.core.config.set("ESCALATION_EMAILS", escalation_emails)
+        return j.data.serializers.json.dumps({"data": escalation_emails})
 
 
 Actor = Admin

--- a/jumpscale/packages/admin/frontend/api.js
+++ b/jumpscale/packages/admin/frontend/api.js
@@ -182,6 +182,30 @@ const apiClient = {
             })
         }
     },
+    escalationEmails:{
+        list: () => {
+            return axios({
+                url: `${baseURL}/admin/list_escalation_emails`
+            })
+        },
+        add: (email) => {
+            return axios({
+                url: `${baseURL}/admin/add_escalation_email`,
+                method: "post",
+                headers: { 'Content-Type': 'application/json' },
+                data: { email: email }
+            })
+        },
+        delete: (email) => {
+            return axios({
+                url: `${baseURL}/admin/delete_escalation_email`,
+                method: "post",
+                headers: { 'Content-Type': 'application/json' },
+                data: { email: email }
+            })
+        }
+
+    },
     explorers: {
         get: () => {
             return axios({

--- a/jumpscale/packages/admin/frontend/api.js
+++ b/jumpscale/packages/admin/frontend/api.js
@@ -168,12 +168,12 @@ const apiClient = {
                 url: `${baseURL}/admin/get_developer_options`
             })
         },
-        setDeveloperOptions: (testCert, overProvision, explorerLogs) => {
+        setDeveloperOptions: (testCert, overProvision, explorerLogs, escalationEmails) => {
             return axios({
                 url: `${baseURL}/admin/set_developer_options`,
                 method: "post",
                 headers: { 'Content-Type': 'application/json' },
-                data: { test_cert: testCert, over_provision: overProvision, explorer_logs: explorerLogs }
+                data: { test_cert: testCert, over_provision: overProvision, explorer_logs: explorerLogs, escalation_emails:escalationEmails }
             })
         },
         clearBlockedNodes: () => {

--- a/jumpscale/packages/admin/frontend/components/settings/AddEscalationEmail.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/AddEscalationEmail.vue
@@ -1,0 +1,41 @@
+<template>
+  <base-dialog
+    title="Add escalation email"
+    v-model="dialog"
+    :error="error"
+    :loading="loading"
+  >
+    <template #default>
+      <v-form>
+        <v-text-field v-model="form.email" label="email" dense></v-text-field>
+      </v-form>
+    </template>
+    <template #actions>
+      <v-btn text @click="close">Close</v-btn>
+      <v-btn text @click="submit">Add</v-btn>
+    </template>
+  </base-dialog>
+</template>
+
+<script>
+module.exports = {
+  mixins: [dialog],
+  methods: {
+    submit() {
+      this.loading = true;
+      this.error = null;
+      this.$api.escalationEmails
+        .add(this.form.email)
+        .then((response) => {
+          this.done("Email is added");
+        })
+        .catch((error) => {
+          this.error = error.response.data.error;
+        })
+        .finally(() => {
+          this.loading = false;
+        });
+    },
+  },
+};
+</script>

--- a/jumpscale/packages/admin/frontend/components/settings/Settings.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/Settings.vue
@@ -83,6 +83,13 @@
                 :label="`Enable explorer logs`"
                 @click.stop="setDeveloperOptions()"
               ></v-switch>
+              <v-switch
+                hide-details
+                class="my-2 pl-2"
+                v-model="escalationEmails"
+                :label="`Enable sending escalation emails`"
+                @click.stop="setDeveloperOptions()"
+              ></v-switch>
               <v-btn
                 hide-details
                 class="my-2 ml-2"
@@ -144,6 +151,7 @@ module.exports = {
       testCert: false,
       overProvision: false,
       explorerLogs: false,
+      escalationEmails: false,
     };
   },
   methods: {
@@ -215,6 +223,7 @@ module.exports = {
           this.testCert = developerOptions["test_cert"];
           this.overProvision = developerOptions["over_provision"];
           this.explorerLogs = developerOptions["explorer_logs"];
+          this.escalationEmails = developerOptions["escalation_emails"];
         })
         .finally(() => {
           this.loading.developerOptions = false;
@@ -225,7 +234,8 @@ module.exports = {
         .setDeveloperOptions(
           this.testCert,
           this.overProvision,
-          this.explorerLogs
+          this.explorerLogs,
+          this.escalationEmails
         )
         .then((response) => {
           this.alert("Developer options updated", "success");

--- a/jumpscale/packages/admin/frontend/components/settings/Settings.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/Settings.vue
@@ -6,6 +6,7 @@
       <template #default>
         <v-row align="start" justify="start">
           <v-col class="mt-0 pt-0" cols="12" md="4">
+            <!-- List-Admins -->
             <base-section
               title="Admins"
               icon="mdi-account-lock"
@@ -29,6 +30,33 @@
                 close
                 close-icon="mdi-close-circle-outline"
                 >{{ admin }}</v-chip
+              >
+            </base-section>
+            <!-- List-Escalation-Emails -->
+            <base-section
+              class="mt-3"
+              title="Escalation Emails"
+              icon="mdi-account-lock"
+              :loading="loading.escalationEmails"
+            >
+              <template #actions>
+                <v-btn text @click.stop="dialogs.escalationEmail = true">
+                  <v-icon left>mdi-plus</v-icon>Add
+                </v-btn>
+              </template>
+
+              <v-chip
+                class="ma-2"
+                color="primary"
+                min-width="50"
+                v-for="email in escalationEmails"
+                :key="email"
+                @click:close="removeEscalationEmail(email)"
+                outlined
+                label
+                close
+                close-icon="mdi-close-circle-outline"
+                >{{ email }}</v-chip
               >
             </base-section>
           </v-col>
@@ -86,7 +114,7 @@
               <v-switch
                 hide-details
                 class="my-2 pl-2"
-                v-model="escalationEmails"
+                v-model="escalationEmailsEnabled"
                 :label="`Enable sending escalation emails`"
                 @click.stop="setDeveloperOptions()"
               ></v-switch>
@@ -105,6 +133,10 @@
     </base-component>
 
     <add-admin v-model="dialogs.addAdmin" @done="listAdmins"></add-admin>
+    <add-escaltion-email
+      v-model="dialogs.escalationEmail"
+      @done="listEscaltionEmails"
+    ></add-escaltion-email>
     <remove-admin
       v-model="dialogs.removeAdmin"
       :name="selectedAdmin"
@@ -126,6 +158,7 @@
 module.exports = {
   components: {
     "add-admin": httpVueLoader("./AddAdmin.vue"),
+    "add-escaltion-email": httpVueLoader("./AddEscalationEmail.vue"),
     "remove-admin": httpVueLoader("./RemoveAdmin.vue"),
     "identity-info": httpVueLoader("./IdentityInfo.vue"),
     "add-identity": httpVueLoader("./AddIdentity.vue"),
@@ -136,6 +169,7 @@ module.exports = {
         admins: false,
         identities: false,
         developerOptions: false,
+        escalationEmails: false,
       },
       selectedAdmin: null,
       dialogs: {
@@ -143,15 +177,17 @@ module.exports = {
         removeAdmin: false,
         identityInfo: false,
         addIdentity: false,
+        escalationEmail: false,
       },
       admins: [],
+      escalationEmails: [],
       identity: null,
       selectedIdentity: null,
       identities: [],
       testCert: false,
       overProvision: false,
       explorerLogs: false,
-      escalationEmails: false,
+      escalationEmailsEnabled: false,
     };
   },
   methods: {
@@ -164,6 +200,29 @@ module.exports = {
         })
         .finally(() => {
           this.loading.admins = false;
+        });
+    },
+    listEscaltionEmails() {
+      this.loading.escalationEmails = true;
+      this.$api.escalationEmails
+        .list()
+        .then((response) => {
+          this.escalationEmails = JSON.parse(response.data).data;
+        })
+        .finally(() => {
+          this.loading.escalationEmails = false;
+        });
+    },
+    removeEscalationEmail(email) {
+      console.log("this email should be removed", email);
+      this.loading.escalationEmails = true;
+      this.$api.escalationEmails
+        .delete(email)
+        .then((response) => {
+          this.escalationEmails = JSON.parse(response.data).data;
+        })
+        .finally(() => {
+          this.loading.escalationEmails = false;
         });
     },
     removeAdmin(name) {
@@ -223,7 +282,7 @@ module.exports = {
           this.testCert = developerOptions["test_cert"];
           this.overProvision = developerOptions["over_provision"];
           this.explorerLogs = developerOptions["explorer_logs"];
-          this.escalationEmails = developerOptions["escalation_emails"];
+          this.escalationEmailsEnabled = developerOptions["escalation_emails"];
         })
         .finally(() => {
           this.loading.developerOptions = false;
@@ -235,7 +294,7 @@ module.exports = {
           this.testCert,
           this.overProvision,
           this.explorerLogs,
-          this.escalationEmails
+          this.escalationEmailsEnabled
         )
         .then((response) => {
           this.alert("Developer options updated", "success");
@@ -260,6 +319,7 @@ module.exports = {
     this.getCurrentIdentity();
     this.listIdentities();
     this.getDeveloperOptions();
+    this.listEscaltionEmails();
   },
 };
 </script>


### PR DESCRIPTION
### Description
- Update the front-end and back-end for escalating emails.
- Add toggle bottom to enable escalating emails.

### Changes
jumpscale/packages/admin/actors/admin.py
jumpscale/packages/admin/frontend/api.js
jumpscale/packages/admin/frontend/components/settings/AddEscalationEmail.vue
jumpscale/packages/admin/frontend/components/settings/Settings.vue

### Related Issues
https://github.com/threefoldtech/js-sdk/issues/1413

![image](https://user-images.githubusercontent.com/46320202/96698502-7b025900-138d-11eb-9d73-3bed7aa635d9.png)

