### PR TITLE
add new tools to compute how much cloud units is used by a workload

### DIFF
--- a/jumpscale/clients/explorer/models.py
+++ b/jumpscale/clients/explorer/models.py
@@ -116,7 +116,7 @@ class CloudUnits(Base):
 
 
 class ResourceUnitAmount(Base):
-    cru = fields.Float()
+    cru = fields.Integer()
     mru = fields.Float()
     hru = fields.Float()
     sru = fields.Float()
@@ -491,7 +491,7 @@ class Container(Base):
         cap = self.capacity
         resource_units = ResourceUnitAmount()
         resource_units.cru = cap.cpu
-        resource_units.mru = round(cap.memory / 1024)
+        resource_units.mru = round(cap.memory / 1024 * 10000) / 10000
         storage_size = round(cap.disk_size / 1024 * 10000) / 10000
         storage_size = max(0, storage_size - 50)  # we offer the 50 first GB of storage for container root filesystem
         if cap.disk_type == DiskType.HDD:

--- a/jumpscale/clients/explorer/models.py
+++ b/jumpscale/clients/explorer/models.py
@@ -104,8 +104,8 @@ class CloudUnits(Base):
         compute the total cost
 
         Args:
-            cu_price (float): number of compute unit
-            su_price (float): number of storage unit
+            cu_price (float): price of compute unit per second
+            su_price (float): price of storage unit per second
             duration (int): duration in second
 
         Returns:

--- a/jumpscale/clients/explorer/models.py
+++ b/jumpscale/clients/explorer/models.py
@@ -408,15 +408,31 @@ class K8s(Base):
     info = fields.Object(ReservationInfo)
 
     def resource_units(self):
+        size_table = {
+            1: {"cru": 1, "mru": 2, "sru": 50},
+            2: {"cru": 2, "mru": 4, "sru": 100},
+            3: {"cru": 2, "mru": 8, "sru": 25},
+            4: {"cru": 2, "mru": 5, "sru": 50},
+            5: {"cru": 2, "mru": 8, "sru": 200},
+            6: {"cru": 4, "mru": 16, "sru": 50},
+            7: {"cru": 4, "mru": 16, "sru": 100},
+            8: {"cru": 4, "mru": 16, "sru": 400},
+            9: {"cru": 8, "mru": 32, "sru": 100},
+            10: {"cru": 8, "mru": 32, "sru": 200},
+            11: {"cru": 8, "mru": 32, "sru": 800},
+            12: {"cru": 1, "mru": 64, "sru": 200},
+            13: {"cru": 1, "mru": 64, "sru": 400},
+            14: {"cru": 1, "mru": 64, "sru": 800},
+        }
+
         resource_units = ResourceUnitAmount()
-        if self.size == 1:
-            resource_units.cru += 1
-            resource_units.mru += 2
-            resource_units.sru += 50
-        elif self.size == 2:
-            resource_units.cru += 2
-            resource_units.mru += 4
-            resource_units.sru += 100
+        size = size_table.get(self.size)
+        if not size:
+            raise j.exceptions.Input(f"k8s size {self.sizes} not supported")
+
+        resource_units.cru += size["cru"]
+        resource_units.mru += size["mru"]
+        resource_units.sru += size["sru"]
         return resource_units
 
 

--- a/jumpscale/tools/zos/consumption/__init__.py
+++ b/jumpscale/tools/zos/consumption/__init__.py
@@ -1,1 +1,1 @@
-from .usage import cloud_units
+from .usage import cloud_units, cost

--- a/jumpscale/tools/zos/consumption/__init__.py
+++ b/jumpscale/tools/zos/consumption/__init__.py
@@ -1,0 +1,1 @@
+from .usage import cloud_units

--- a/jumpscale/tools/zos/consumption/readme.md
+++ b/jumpscale/tools/zos/consumption/readme.md
@@ -1,0 +1,16 @@
+# Example how to compute the cost of a workload for a period of time
+
+``` python
+zos = j.sals.zos.get()
+# define your workload
+container = zos.container.create('HT9yNvHRQs65dyRJeztAdEnXKweCX2bhgvD9i1WFPUNs', 'my_network', '172.26.10.40', 'https://hub.grid.tf/zaibon/zaibon-ubuntu-ssh-0.0.5.flist',2,entrypoint='/sbin/asdasd', cpu=2, memory=4096, disk_size=12040)
+
+# use the zos tools to compute how much cloud units is comsumed
+cloud_units = j.tools.zos.consumption.cloud_units(container)
+print(f"compute units: {cloud_units.cu} storage units: {cloud_units.su}")
+
+# compute the cost of the workload over a period of time
+duration = 3600 * 24 * 30 # for 30 days
+cost = j.tools.zos.consumption.cost(container, duration)
+print(f"cost {cost} TFT")
+```

--- a/jumpscale/tools/zos/consumption/usage.py
+++ b/jumpscale/tools/zos/consumption/usage.py
@@ -42,3 +42,39 @@ def cloud_units(
     """
     ru = workload.resource_units()
     return ru.cloud_units()
+
+
+def cost(
+    workload: Union[
+        Container,
+        Gateway4to6,
+        GatewayDelegate,
+        GatewayProxy,
+        GatewayReverseProxy,
+        GatewaySubdomain,
+        K8s,
+        NetworkResource,
+        Volume,
+        ZdbNamespace,
+    ],
+    duration,
+) -> float:
+    """
+        compute the cost of a workload over a certain period
+
+        Args:
+            workload (Union[ Container, Gateway4to6, GatewayDelegate, GatewayProxy, GatewayReverseProxy, GatewaySubdomain, K8s, NetworkResource, Volume, ZdbNamespace, ]): the workload to analyse
+            duration ([int]): duration of deployment in seconds
+
+        Returns:
+            float: price in TFT
+        """
+    # tft_price = 0.15$
+    # su_price = 10$
+    # month = 3600*24*30
+    # (su_prince/tft_price) / month  = 0.00002572
+    compute_unit_TFT_cost_second = 0.00002572
+    storage_unit_TFT_cost_second = 0.00002572
+    cu = cloud_units(workload)
+    price = cu.cost(compute_unit_TFT_cost_second, storage_unit_TFT_cost_second, duration)
+    return price

--- a/jumpscale/tools/zos/consumption/usage.py
+++ b/jumpscale/tools/zos/consumption/usage.py
@@ -1,0 +1,44 @@
+from typing import Union
+
+from jumpscale.clients.explorer.models import (
+    CloudUnits,
+    Container,
+    Gateway4to6,
+    GatewayDelegate,
+    GatewayProxy,
+    GatewayReverseProxy,
+    GatewaySubdomain,
+    K8s,
+    NetworkResource,
+    NextAction,
+    ResourceUnitAmount,
+    Volume,
+    ZdbNamespace,
+)
+
+
+def cloud_units(
+    workload: Union[
+        Container,
+        Gateway4to6,
+        GatewayDelegate,
+        GatewayProxy,
+        GatewayReverseProxy,
+        GatewaySubdomain,
+        K8s,
+        NetworkResource,
+        Volume,
+        ZdbNamespace,
+    ]
+) -> CloudUnits:
+    """
+    Compute the amount of cloud units consumed by second  workload
+
+    Args:
+        workload (Union[ Container, Gateway4to6, GatewayDelegate, GatewayProxy, GatewayReverseProxy, GatewaySubdomain, K8s, NetworkResource, Volume, ZdbNamespace, ]): [description]
+
+    Returns:
+        CloudUnits: the amount of cloud units consumed by second by the workload
+    """
+    ru = workload.resource_units()
+    return ru.cloud_units()

--- a/tests/clients/explorer/test_models.py
+++ b/tests/clients/explorer/test_models.py
@@ -1,0 +1,73 @@
+from jumpscale.clients.explorer.models import DiskType, Container, Volume, ZdbNamespace, K8s
+
+
+def test_container_ru():
+    c = Container()
+    tt = [
+        {"cpu": 1, "memory": 2048, "type": DiskType.SSD, "size": 10240, "cru": 1, "mru": 2, "sru": 0, "hru": 0},
+        {"cpu": 1, "memory": 2048, "type": DiskType.HDD, "size": 10240, "cru": 1, "mru": 2, "sru": 0, "hru": 0},
+        {"cpu": 4, "memory": 4096, "type": DiskType.SSD, "size": 10240, "cru": 4, "mru": 4, "sru": 0, "hru": 0},
+        {"cpu": 4, "memory": 4096, "type": DiskType.SSD, "size": 51200, "cru": 4, "mru": 4, "sru": 0, "hru": 0},
+        {"cpu": 4, "memory": 4096, "type": DiskType.SSD, "size": 52224, "cru": 4, "mru": 4, "sru": 1, "hru": 0},
+        {"cpu": 1, "memory": 1000, "type": DiskType.SSD, "size": 10000, "cru": 1, "mru": 1, "sru": 0, "hru": 0,},
+    ]
+    for tc in tt:
+        c.capacity.cpu = tc["cpu"]
+        c.capacity.memory = tc["memory"]
+        c.capacity.disk_type = tc["type"]
+        c.capacity.disk_size = tc["size"]
+
+        ru = c.resource_units()
+        assert ru.cru == tc["cru"]
+        assert ru.mru == tc["mru"]
+        assert ru.sru == tc["sru"]
+        assert ru.hru == tc["hru"]
+
+
+def test_volume_ru():
+    v = Volume()
+    tt = [
+        {"size": 1, "type": DiskType.SSD, "cru": 0, "mru": 0, "sru": 1, "hru": 0},
+        {"size": 1, "type": DiskType.HDD, "cru": 0, "mru": 0, "sru": 0, "hru": 1},
+        {"size": 12, "type": DiskType.SSD, "cru": 0, "mru": 0, "sru": 12, "hru": 0},
+    ]
+    for tc in tt:
+        v.size = tc["size"]
+        v.type = tc["type"]
+
+        ru = v.resource_units()
+        assert ru.cru == tc["cru"]
+        assert ru.mru == tc["mru"]
+        assert ru.sru == tc["sru"]
+        assert ru.hru == tc["hru"]
+
+
+def test_zdb_ru():
+    z = ZdbNamespace()
+    tt = [
+        {"size": 1, "type": DiskType.SSD, "cru": 0, "mru": 0, "sru": 1, "hru": 0},
+        {"size": 1, "type": DiskType.HDD, "cru": 0, "mru": 0, "sru": 0, "hru": 1},
+        {"size": 12, "type": DiskType.SSD, "cru": 0, "mru": 0, "sru": 12, "hru": 0},
+    ]
+    for tc in tt:
+        z.size = tc["size"]
+        z.disk_type = tc["type"]
+
+        ru = z.resource_units()
+        assert ru.cru == tc["cru"]
+        assert ru.mru == tc["mru"]
+        assert ru.sru == tc["sru"]
+        assert ru.hru == tc["hru"]
+
+
+def test_k8s_ru():
+    z = K8s()
+    tt = [{"size": 1, "cru": 1, "mru": 2, "sru": 50, "hru": 0}, {"size": 2, "cru": 2, "mru": 4, "sru": 100, "hru": 0}]
+    for tc in tt:
+        z.size = tc["size"]
+
+        ru = z.resource_units()
+        assert ru.cru == tc["cru"]
+        assert ru.mru == tc["mru"]
+        assert ru.sru == tc["sru"]
+        assert ru.hru == tc["hru"]

--- a/tests/clients/explorer/test_models.py
+++ b/tests/clients/explorer/test_models.py
@@ -9,7 +9,7 @@ def test_container_ru():
         {"cpu": 4, "memory": 4096, "type": DiskType.SSD, "size": 10240, "cru": 4, "mru": 4, "sru": 0, "hru": 0},
         {"cpu": 4, "memory": 4096, "type": DiskType.SSD, "size": 51200, "cru": 4, "mru": 4, "sru": 0, "hru": 0},
         {"cpu": 4, "memory": 4096, "type": DiskType.SSD, "size": 52224, "cru": 4, "mru": 4, "sru": 1, "hru": 0},
-        {"cpu": 1, "memory": 1000, "type": DiskType.SSD, "size": 10000, "cru": 1, "mru": 1, "sru": 0, "hru": 0,},
+        {"cpu": 1, "memory": 1024, "type": DiskType.SSD, "size": 10000, "cru": 1, "mru": 1, "sru": 0, "hru": 0,},
     ]
     for tc in tt:
         c.capacity.cpu = tc["cpu"]


### PR DESCRIPTION
### Description

Add a new `consumption` section in `j.tools.zos` which allow to compute how much cloud units are consumed by a workload object

### Changes

- Add new module in j.tools.zos
- Add `resource_units` methods on all the workloads model

### Related Issues

fixes #1423

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
