### PR TITLE
update js-ng to v11.0b7

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -604,7 +604,7 @@ description = "system automation, configuration management and RPC framework"
 name = "js-ng"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "11.0b4"
+version = "11.0b7"
 
 [package.dependencies]
 GitPython = ">=3.0,<4.0"
@@ -1525,7 +1525,7 @@ docs = ["sphinx", "repoze.sphinx.autointerface"]
 test = ["zope.security", "zope.testrunner"]
 
 [metadata]
-content-hash = "9b88c2c3bc1fed4abfbe013386adf3fdce5d733cf1c0f9d025c23d27eb325cc4"
+content-hash = "4a7d75675bd2bd47335241bdcfcbfa80877afb6962e8fbfd71a9570341b67d2f"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1818,8 +1818,8 @@ josepy = [
     {file = "josepy-1.4.0.tar.gz", hash = "sha256:c37ff4b93606e6a452b72cdb992da5e0544be12912fac01b31ddbdd61f6d5bd0"},
 ]
 js-ng = [
-    {file = "js-ng-11.0b4.tar.gz", hash = "sha256:4550e487c32689e70acca1f8137fa1b118dcd520e0ee4c9795ba35db8df99128"},
-    {file = "js_ng-11.0b4-py3-none-any.whl", hash = "sha256:e274ddefdca5019cf5913199b27e1dbeab21b7fb94fbaf9be156c17384f21d6e"},
+    {file = "js-ng-11.0b7.tar.gz", hash = "sha256:f3ed46ff2d8a3e2304d9255565813f2cbe0822858d5d63d36c4cbf5112eb4f5c"},
+    {file = "js_ng-11.0b7-py3-none-any.whl", hash = "sha256:203b271f11a8b77b25ff8f28bbc91a4149920f93711f37a22e67c399a15c2317"},
 ]
 jsonpickle = [
     {file = "jsonpickle-1.4.1-py2.py3-none-any.whl", hash = "sha256:8919c166bac0574e3d74425c7559434062002d9dfc0ac2afa6dc746ba4a19439"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 cryptography = "3.0"
-js-ng = "11.0b4"
+js-ng = "11.0b7"
 greenlet = "0.4.16"
 python = "^3.6"
 pillow = "^6.1"


### PR DESCRIPTION
### Description

Update js-ng to v11.0b7, which contains some needed features and fixes.

### Changes

* `pyproject.toml`
* `poetry.lock`


Needs `poetry install` locally.
