### PR TITLE
force reloading actors when adding a package

### DIFF
--- a/docs/wiki/threebot/threebot.md
+++ b/docs/wiki/threebot/threebot.md
@@ -273,6 +273,9 @@ Basic Package functionalities and properties
   "hello from foo's actor"%
   ```
 
+
+**Note** that adding a package will reload python modules for all chats and actors.
+
 ## ssl
 
 - If you to generate certificates to your website/package you can specify it in the package.toml explicitly.

--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -539,7 +539,7 @@ class PackageManager(Base):
         # register gedis actors
         if package.actors_dir:
             for actor in package.actors:
-                self.threebot.gedis._system_actor.register_actor(actor["name"], actor["path"])
+                self.threebot.gedis._system_actor.register_actor(actor["name"], actor["path"], force_reload=True)
 
         # add chatflows actors
         if package.chats_dir:


### PR DESCRIPTION
### Description

gedis server now supports reloading actors in the new js-ng version.

### Changes

* Pass `force_reload=True` when registering package actors.

### Related Issues

#888

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
