### PR TITLE
use display name only

### DIFF
--- a/jumpscale/core/identity/__init__.py
+++ b/jumpscale/core/identity/__init__.py
@@ -154,7 +154,7 @@ class Identity(Base):
 
             resp = requests.post(f"{self.explorer_url}/users", json=user.to_dict())
             if resp.status_code == 409:  # conflict
-                raise Input("A user with same name or email exists om TFGrid phonebook.")
+                raise Input("A user with same name or email exists on TFGrid phonebook.")
             if resp.status_code != 201:
                 resp.raise_for_status()
 

--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -1,7 +1,7 @@
 from jumpscale.loader import j
 from jumpscale.servers.gedis.baseactor import BaseActor, actor_method
 from jumpscale.core.exceptions import JSException
-
+from requests import HTTPError
 
 explorers = {"main": "explorer.grid.tf", "testnet": "explorer.testnet.grid.tf"}
 
@@ -88,19 +88,28 @@ class Admin(BaseActor):
             return j.data.serializers.json.dumps({"data": f"{identity_instance_name} doesn't exist"})
 
     @actor_method
-    def add_identity(self, identity_instance_name: str, tname: str, email: str, words: str, explorer_type: str) -> str:
+    def add_identity(self, display_name: str, email: str, words: str, explorer_type: str) -> str:
+        tname = display_name
+        if not tname.isidentifier() or not tname.islower():
+            raise j.exceptions.Value(
+                "The display name must be a lowercase valid python identitifier (English letters, underscores, and numbers not starting with a number)."
+            )
+        identity_instance_name = f"{tname}_{explorer_type}"
         explorer_url = f"https://{explorers[explorer_type]}/api/v1"
         if identity_instance_name in j.core.identity.list_all():
-            return j.data.serializers.json.dumps({"data": "Identity with the same instance name already exists"})
+            raise j.exceptions.Value("Identity with the same name already exists")
         try:
             new_identity = j.core.identity.new(
                 name=identity_instance_name, tname=tname, email=email, words=words, explorer_url=explorer_url
             )
             new_identity.register()
             new_identity.save()
-        except Exception as e:
+        except HTTPError as e:
             j.core.identity.delete(identity_instance_name)
-            raise j.exceptions.Value(str(e))
+            try:
+                raise j.exceptions.Value(j.data.serializers.json.loads(e.response.content)["error"])
+            except Exception as e:
+                raise j.exceptions.Value(str(e))
         return j.data.serializers.json.dumps({"data": "New identity successfully created and registered"})
 
     @actor_method

--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -94,7 +94,7 @@ class Admin(BaseActor):
             raise j.exceptions.Value(
                 "The display name must be a lowercase valid python identitifier (English letters, underscores, and numbers not starting with a number)."
             )
-        identity_instance_name = f"{tname}_{explorer_type}"
+        identity_instance_name = f"{tname}"
         explorer_url = f"https://{explorers[explorer_type]}/api/v1"
         if identity_instance_name in j.core.identity.list_all():
             raise j.exceptions.Value("Identity with the same name already exists")

--- a/jumpscale/packages/admin/frontend/api.js
+++ b/jumpscale/packages/admin/frontend/api.js
@@ -223,12 +223,12 @@ const apiClient = {
                 url: `${baseURL}/admin/list_identities`
             })
         },
-        add: (identity_instance_name, tname, email, words, explorer_type) => {
+        add: (display_name, email, words, explorer_type) => {
             return axios({
                 url: `${baseURL}/admin/add_identity`,
                 method: "post",
                 headers: { 'Content-Type': 'application/json' },
-                data: { identity_instance_name: identity_instance_name, tname: tname, email: email, words: words, explorer_type: explorer_type }
+                data: { display_name: display_name, email: email, words: words, explorer_type: explorer_type }
             })
         },
         setIdentity: (identity_instance_name) => {

--- a/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
@@ -2,8 +2,16 @@
   <base-dialog title="Add identity" v-model="dialog" :error="error" :loading="loading">
     <template #default>
       <v-form>
-        <v-text-field v-model="form.instance_name" label="Identity name" dense></v-text-field>
-        <v-text-field v-model="form.tname" label="3Bot name" dense></v-text-field>
+        <v-text-field v-model="form.display_name" label="Display name" dense>
+        <v-tooltip slot="append" left>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn icon v-bind="attrs" v-on="on">
+                <v-icon color="grey lighten-1"> mdi-help-circle </v-icon>
+              </v-btn>
+            </template>
+            <span>The name to be registered on TFGrid, used to reference your created 3Bot identity.</span>
+        </v-tooltip>
+        </v-text-field>
         <v-text-field v-model="form.email" label="Email" dense></v-text-field>
         <v-text-field v-model="form.words" label="Words" dense></v-text-field>
         <v-select v-model="selected_explorer" label="Explorer type" :items="Object.keys(explorers)" dense></v-select>
@@ -33,12 +41,12 @@ module.exports = {
         submit () {
             this.loading = true
             this.error = null
-            if(!this.form.instance_name || !this.form.tname || !this.form.email || !this.form.words || !this.selected_explorer){
+            if(!this.form.display_name || !this.form.email || !this.form.words || !this.selected_explorer){
                 this.error = "All fields required"
                 this.loading = false
             }
             else{
-                this.$api.identities.add(this.form.instance_name, this.form.tname, this.form.email, this.form.words, this.explorers[this.selected_explorer].type).then((response) => {
+                this.$api.identities.add(this.form.display_name, this.form.email, this.form.words, this.explorers[this.selected_explorer].type).then((response) => {
                     responseMessage = JSON.parse(response.data).data
                     if(responseMessage == "Identity with the same instance name already exists"){
                         this.error = responseMessage

--- a/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
@@ -9,7 +9,7 @@
                 <v-icon color="grey lighten-1"> mdi-help-circle </v-icon>
               </v-btn>
             </template>
-            <span>The name to be registered on TFGrid, used to reference your created 3Bot identity.</span>
+            <span>The display name is used to reference the registered 3bot identity on TFGrid across the 3Bot.</span>
         </v-tooltip>
         </v-text-field>
         <v-text-field v-model="form.email" label="Email" dense></v-text-field>


### PR DESCRIPTION
### Description

Replace instance name and tname with display_name 
### Changes

1. Create identity with instance name "{display_name}_{network used}" to allow registering the same tname on testnet and mainnet.
2. Tooltip with message "The name to be registered on TFGrid, used to reference your created 3Bot identity.". 

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/1445
