### PR TITLE
Separate mainnet wallet from identity

### DIFF
--- a/jumpscale/entry_points/threebot.py
+++ b/jumpscale/entry_points/threebot.py
@@ -267,11 +267,7 @@ def create_test_wallet(wallet_name):
 def create_main_wallet(wallet_name):
     wallet_actor = Wallet()
     try:
-<<<<<<< HEAD
-        wallet_actor.create_wallet(wallet_name)
-=======
         wallet_actor.create_wallet(wallet_name, "STD")
->>>>>>> Use std instead of default identity for the main wallet
     except Exception as e:
         j.logger.error(str(e))
 

--- a/jumpscale/entry_points/threebot.py
+++ b/jumpscale/entry_points/threebot.py
@@ -267,7 +267,11 @@ def create_test_wallet(wallet_name):
 def create_main_wallet(wallet_name):
     wallet_actor = Wallet()
     try:
+<<<<<<< HEAD
         wallet_actor.create_wallet(wallet_name)
+=======
+        wallet_actor.create_wallet(wallet_name, "STD")
+>>>>>>> Use std instead of default identity for the main wallet
     except Exception as e:
         j.logger.error(str(e))
 

--- a/jumpscale/packages/admin/actors/wallet.py
+++ b/jumpscale/packages/admin/actors/wallet.py
@@ -5,11 +5,13 @@ from jumpscale.clients.stellar.stellar import _NETWORK_KNOWN_TRUSTS
 
 class Wallet(BaseActor):
     @actor_method
-    def create_wallet(self, name: str) -> str:
+    def create_wallet(self, name: str, wallettype: str = None) -> str:
         explorer = j.core.identity.me.explorer
-        wallettype = "STD"
-        if "testnet" in explorer.url or "devnet" in explorer.url:
-            wallettype = "TEST"
+        if wallettype is None:
+            if "testnet" in explorer.url or "devnet" in explorer.url:
+                wallettype = "TEST"
+            else:
+                wallettype = "STD"
 
         # Why while not if?
         while j.clients.stellar.find(name):


### PR DESCRIPTION
### Description

The mainnet wallet network was being determined by the default identity, which incorrectly assumed that is always a mainnet identity. Now it should be independent.