### PR TITLE
Add button to create mnemonics

### DIFF
--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -88,6 +88,29 @@ class Admin(BaseActor):
         else:
             return j.data.serializers.json.dumps({"data": f"{identity_instance_name} doesn't exist"})
 
+    def generate_mnemonic(self) -> str:
+        words = j.data.encryption.generate_mnemonic()
+        return j.data.serializers.json.dumps({"data": words})
+
+    @actor_method
+    def check_tname_exists(self, tname, explorer_type) -> str:
+        explorer_clients = {
+            "main": j.clients.explorer.get("user_checker_mainnet", f"https://{explorers['main']}/api/v1"),
+            "testnet": j.clients.explorer.get("user_checker_testnet", f"https://{explorers['testnet']}/api/v1"),
+        }
+        explorer_client = explorer_clients[explorer_type]
+        try:
+            explorer_client.users.get(name=tname)
+            return j.data.serializers.json.dumps({"data": True})
+        except j.exceptions.NotFound:
+            return j.data.serializers.json.dumps({"data": False})
+
+    @actor_method
+    def check_identity_instance_name(self, name) -> str:
+        if name in j.core.identity.list_all():
+            return j.data.serializers.json.dumps({"data": True})
+        return j.data.serializers.json.dumps({"data": False})
+
     @actor_method
     def add_identity(self, display_name: str, tname: str, email: str, words: str, explorer_type: str) -> str:
         if not display_name.isidentifier() or not display_name.islower():

--- a/jumpscale/packages/admin/frontend/api.js
+++ b/jumpscale/packages/admin/frontend/api.js
@@ -231,6 +231,27 @@ const apiClient = {
                 data: { display_name: display_name, tname: tname, email: email, words: words, explorer_type: explorer_type }
             })
         },
+        generateMnemonic: () => {
+            return axios({
+                url: `${baseURL}/admin/generate_mnemonic`
+            })
+        },
+        checkTNameExists: (tname, explorerType) => {
+            return axios({
+                url: `${baseURL}/admin/check_tname_exists`,
+                method: "post",
+                headers: { 'Content-Type': 'application/json' },
+                data: { tname: tname, explorer_type: explorerType }
+            })
+        },
+        checkInstanceName: (name) => {
+            return axios({
+                url: `${baseURL}/admin/check_identity_instance_name`,
+                method: "post",
+                headers: { 'Content-Type': 'application/json' },
+                data: { name: name }
+            })
+        },
         setIdentity: (identity_instance_name) => {
             return axios({
                 url: `${baseURL}/admin/set_identity`,

--- a/jumpscale/packages/admin/frontend/components/base/Dialog.vue
+++ b/jumpscale/packages/admin/frontend/components/base/Dialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" width="1000">
+  <v-dialog v-model="dialog" width="1000" :persistent="persistent">
     <v-card :loading="loading" :disabled="loading">
       <v-card-title class="headline">{{title}}</v-card-title>
       <v-card-text class="pa-5">
@@ -29,6 +29,10 @@ module.exports = {
     info: String,
     warning: String,
     loading: Boolean,
+    persistent: {
+      type: Boolean,
+      default: false
+    },
   },
   computed: {
     dialog: {

--- a/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/AddIdentity.vue
@@ -1,26 +1,37 @@
 <template>
-  <base-dialog title="Add identity" v-model="dialog" :error="error" :loading="loading">
+  <base-dialog title="Add identity" v-model="dialog" :error="error" :info="info" :loading="loading" :persistent="true">
     <template #default>
       <v-form>
-        <v-text-field v-model="form.display_name" label="Display name" dense>
+        <v-text-field v-model="form.display_name" label="Display name" @blur="checkInstanceName(form.display_name)" dense>
         <v-tooltip slot="append" left>
             <template v-slot:activator="{ on, attrs }">
-              <v-btn icon v-bind="attrs" v-on="on">
+              <v-btn icon v-bind="attrs" v-on="on" :tabindex="10">
                 <v-icon color="grey lighten-1"> mdi-help-circle </v-icon>
               </v-btn>
             </template>
             <span>The display name is used to reference the registered identity on TFGrid across the 3Bot.</span>
         </v-tooltip>
         </v-text-field>
-        <v-text-field v-model="form.tname" label="3Bot name" dense></v-text-field>
+        <v-text-field v-model="form.tname" label="3Bot name" @blur="checkTNameExists(form.tname)" dense></v-text-field>
         <v-text-field v-model="form.email" label="Email" dense></v-text-field>
-        <v-text-field v-model="form.words" label="Words" dense></v-text-field>
-        <v-select v-model="selected_explorer" label="Explorer type" :items="Object.keys(explorers)" dense></v-select>
+        <v-text-field v-model="words" label="Words" dense>
+          <template v-slot:append>
+              <v-btn
+                v-if="allowCreatMnemonics"
+                color="info"
+                class="mx-2 mb-2"
+                :tabindex="10"
+                @click="getMnemonics()">
+                create Words
+              </v-btn>
+          </template>
+        </v-text-field>
+        <v-select v-model="selected_explorer" label="Explorer type" @change="checkTNameExists(form.tname)" :items="Object.keys(explorers)" dense></v-select>
       </v-form>
     </template>
     <template #actions>
-      <v-btn text @click="close">Close</v-btn>
-      <v-btn text @click="submit">Add</v-btn>
+      <v-btn text color="red" @click="closeDialog()">Close</v-btn>
+      <v-btn text color="green" :disabled="disable" @click="submit">Add</v-btn>
     </template>
   </base-dialog>
 </template>
@@ -29,39 +40,82 @@
 
 module.exports = {
   mixins: [dialog],
-    data () {
-      return {
-        explorers: {
-          "Main Network": {url: "https://explorer.grid.tf", type: "main"},
-          "Test Network": {url: "https://explorer.testnet.grid.tf", type: "testnet"}
-        },
-        selected_explorer: "Main Network",
+  data () {
+    return {
+      explorers: {
+        "Main Network": {url: "https://explorer.grid.tf", type: "main"},
+        "Test Network": {url: "https://explorer.testnet.grid.tf", type: "testnet"}
+      },
+      selected_explorer: "Main Network",
+      display_name:"",
+      words: "",
+      allowCreatMnemonics: false,
+    }
+  },
+  computed: {
+    disable() {
+      if(!this.form.display_name || !this.form.tname || !this.form.email || !this.words || !this.selected_explorer || this.error !== ""){
+        return true;
+      }
+      return false;
+    },
+  },
+  methods: {
+    submit () {
+        this.loading = true
+        this.error = null
+        this.$api.identities.add(this.form.display_name, this.form.tname, this.form.email, this.words, this.explorers[this.selected_explorer].type).then((response) => {
+            this.done("New Identity added", "success")
+        }).catch((error) => {
+            this.error = error.response.data.error
+        }).finally(() => {
+            this.loading = false
+        })
+    },
+    getMnemonics(){
+      this.$api.identities.generateMnemonic().then((response) => {
+        mnemonics = JSON.parse(response.data).data
+        this.allowCreatMnemonics = false;
+        this.words = mnemonics;
+      })
+    },
+    checkTNameExists(tname){
+      if(tname){
+        this.$api.identities.checkTNameExists(tname, this.explorers[this.selected_explorer].type).then((response) => {
+          res = JSON.parse(response.data).data
+          if(res){
+              this.allowCreatMnemonics = false;
+              this.words = "";
+              this.info = "This 3Bot name existed in the explorer, you have to enter the right words";
+          }
+          else{
+            this.info = "";
+            this.allowCreatMnemonics = true;
+          }
+        })
+      }
+      else {
+        this.allowCreatMnemonics = false;
       }
     },
-    methods: {
-        submit () {
-            this.loading = true
-            this.error = null
-            if(!this.form.display_name || !this.form.tname || !this.form.email || !this.form.words || !this.selected_explorer){
-                this.error = "All fields required"
-                this.loading = false
-            }
-            else{
-                this.$api.identities.add(this.form.display_name, this.form.tname, this.form.email, this.form.words, this.explorers[this.selected_explorer].type).then((response) => {
-                    responseMessage = JSON.parse(response.data).data
-                    if(responseMessage == "Identity with the same instance name already exists"){
-                        this.error = responseMessage
-                    }
-                    else{
-                        this.done("New Identity added", "success")
-                    }
-                }).catch((error) => {
-                    this.error = error.response.data.error
-                }).finally(() => {
-                    this.loading = false
-                })
-            }
-        }
+    checkInstanceName(instance_name){
+      if(instance_name){
+        this.$api.identities.checkInstanceName(instance_name).then((response) => {
+          res = JSON.parse(response.data).data
+          if(res){
+            this.error = "This instance name is existed, Enter anther one.";
+          }
+          else{
+            this.error = "";
+          }
+        })
+      }
+    },
+    closeDialog(){
+      this.close()
+      // clear dialog
+      this.display_name = this.tname = this.email = this.words = "";
     }
+  }
 }
 </script>


### PR DESCRIPTION
### Changes
1.  Added button to create mnemonics
2. More checks in adding a new identity before submit:
    - added instance name duplicated check
    - added tname check in the explorer
    - disable submit button until all fields pass checks
![image](https://user-images.githubusercontent.com/36021484/97456676-bf6b9700-1941-11eb-9ef4-4edead65692b.png)
![image](https://user-images.githubusercontent.com/36021484/97456841-e1651980-1941-11eb-95d7-54ebe035623c.png)

### Related Issues
- [Add button to generate mnemonics in Add Identity view](https://github.com/threefoldtech/js-sdk/issues/1243)

