### PR TITLE
add wallet according to the source of deployment in 3bot deployer

### DIFF
--- a/jumpscale/entry_points/threebot.py
+++ b/jumpscale/entry_points/threebot.py
@@ -274,9 +274,9 @@ def create_main_wallet(wallet_name):
 
 def create_wallets_if_not_exists():
     test, main = have_wallets()
-    if not test:
+    if not test and "testnet" in j.core.identity.me.explorer_url:
         create_test_wallet("test")
-    if not main:
+    if not main and "explorer.grid.tf" in j.core.identity.me.explorer_url:
         create_main_wallet("main")
 
 


### PR DESCRIPTION
### Description

- Create test wallet for testnet and std wallet for mainnet

### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/1572

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
