### PR TITLE
remove secret key from taiga inputs and generate it

### DIFF
--- a/jumpscale/packages/marketplace/chats/taiga.py
+++ b/jumpscale/packages/marketplace/chats/taiga.py
@@ -11,14 +11,7 @@ class TaigaDeploy(MarketPlaceAppsChatflow):
     FLIST_URL = "https://hub.grid.tf/waleedhammam.3bot/waleedhammam-taiga-restic-latest.flist"
     SOLUTION_TYPE = "taiga"
     title = "Taiga"
-    steps = [
-        "get_solution_name",
-        "taiga_credentials",
-        "infrastructure_setup",
-        "reservation",
-        "initializing",
-        "success",
-    ]
+    steps = ["get_solution_name", "taiga_credentials", "infrastructure_setup", "reservation", "initializing", "success"]
 
     container_resources = {"cru": 1, "mru": 1, "sru": 4}
     # main container + nginx container
@@ -36,13 +29,11 @@ class TaigaDeploy(MarketPlaceAppsChatflow):
         )
         EMAIL_HOST_PASSWORD = form.secret_ask("Please add the host e-mail password", required=True)
 
-        SECRET_KEY = form.secret_ask("Please add a secret key for your solution", required=True)
-
         form.ask()
         self.EMAIL_HOST_USER = EMAIL_HOST_USER.value
         self.EMAIL_HOST = EMAIL_HOST.value
         self.EMAIL_HOST_PASSWORD = EMAIL_HOST_PASSWORD.value
-        self.SECRET_KEY = SECRET_KEY.value
+        self.SECRET_KEY = j.data.idgenerator.idgenerator.chars(15)
 
     @deployment_context()
     def _deploy(self):


### PR DESCRIPTION
### Description
Remove secret key from user inputs in taiga deployment  chatflow and generate it

### Changes
generate the secret key of 15 randomly generated characters

### Related Issues

Remove secret key from user inputs in taiga deployment  chatflow and generate it

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
