### PR TITLE
use curl instead of wget

### DIFF
--- a/jumpscale/packages/codeserver/codeserver-install.sh
+++ b/jumpscale/packages/codeserver/codeserver-install.sh
@@ -1,6 +1,6 @@
 
 cd /tmp/
-wget -c https://github.com/cdr/code-server/releases/download/2.1698/code-server2.1698-vsc1.41.1-linux-x86_64.tar.gz
+curl -JLO https://github.com/cdr/code-server/releases/download/2.1698/code-server2.1698-vsc1.41.1-linux-x86_64.tar.gz
 tar -xvzf code-server2.1698-vsc1.41.1-linux-x86_64.tar.gz
 mkdir -p ~/sandbox/bin/
 cp code-server2.1698-vsc1.41.1-linux-x86_64/code-server ~/sandbox/bin/


### PR DESCRIPTION
### Description

Use curl instead of wget. for some reason wget doesn't work.

### Related issues

https://github.com/threefoldtech/js-sdk/issues/1599
