### PR TITLE
add hostname so gevent can resolve it

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
@@ -3,6 +3,7 @@ SDK_PATH="/sandbox/code/github/threefoldtech/js-sdk"
 echo "[*] Enabling ssh access ..."
 ssh-keygen -A
 echo "127.0.0.1       localhost" > /etc/hosts
+echo "127.0.0.1       $(hostname)" >> /etc/hosts
 echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
 chmod -R 500 /etc/ssh
 service ssh restart


### PR DESCRIPTION
### Description

Flists doesn't contain the hosts so it have to be added so that the well known hosts becode resolvable.