### PR TITLE
Added min date option to the datetime picker component

### DIFF
--- a/jumpscale/packages/chatflows/frontend/components/DateTime.vue
+++ b/jumpscale/packages/chatflows/frontend/components/DateTime.vue
@@ -26,7 +26,8 @@
             v-if="tab === 0"
             v-model="date"
             color="primary"
-            @click:date="tab = date ? 1 : 0;"
+            :min="new Date(this.minTime * 1000).toISOString()"
+            @click:date="tab = date ? 1 : 0"
             no-title
             scrollable
           />
@@ -49,13 +50,16 @@
 <script>
 module.exports = {
   mixins: [field],
-  props: { payload: Object },
+  props: {
+    payload: Object,
+  },
   data() {
     return {
       tab: 0,
       menu: false,
       date: null,
       time: null,
+      minTime: this.payload.kwargs.min_time ? Date.now()/1000 + this.payload.kwargs.min_time[0]:null ,
       dateTime: null,
       validators: {
         is_valid: true,
@@ -81,7 +85,7 @@ module.exports = {
     },
     setDateTimeValue() {
       let value = this.val; // value here in seconds
-      this.dateTime = new Date(value * 1000).toLocaleString('en-GB');
+      this.dateTime = new Date(value * 1000).toLocaleString("en-GB");
     },
     update() {
       if (this.date && this.time) this.setValue();

--- a/jumpscale/sals/marketplace/deployer.py
+++ b/jumpscale/sals/marketplace/deployer.py
@@ -483,7 +483,7 @@ class MarketPlaceDeployer(ChatflowDeployer):
 
     def ask_expiration(self, bot, default=None, msg="", min=None, pool_empty_at=None):
         default = default or j.data.time.utcnow().timestamp + 3900
-        min = min or 3600
+        min = min or 3600 * 24
         timestamp_now = j.data.time.utcnow().timestamp
         min_message = f"Date/time should be at least {j.data.time.get(timestamp_now+min).humanize()} from now"
         self.expiration = bot.datetime_picker(


### PR DESCRIPTION
### Changes

- Added min date option to the DateTime picker (previous dates disabled)
- Set a minimum of DateTime picker in the marketplace to be one day.
### Related Issues
- https://github.com/threefoldtech/js-sdk/issues/1581
![image](https://user-images.githubusercontent.com/36021484/98242738-949ec580-1f75-11eb-8398-2e644da6274a.png)
