### PR TITLE
remove email from the sidebar topleft

### DIFF
--- a/jumpscale/packages/admin/frontend/App.vue
+++ b/jumpscale/packages/admin/frontend/App.vue
@@ -94,7 +94,6 @@
           <v-list-item v-if="identity">
             <v-list-item-content>
               <v-list-item-title>{{identity.name}} ({{identity.id}})</v-list-item-title>
-              <v-list-item-subtitle>{{identity.email}}</v-list-item-subtitle>
               <v-list-item-subtitle>
                 <v-chip class="mt-2" outlined>{{ identity.network }} Network</v-chip>
               </v-list-item-subtitle>


### PR DESCRIPTION
Removes email of the subidentity showing up on the topleft for #1616 
![image](https://user-images.githubusercontent.com/64129/98247876-ded77500-1f7c-11eb-835d-f0f99b4ec307.png)
