### PR TITLE
retry deploymemts on dry run failures

### DIFF
--- a/jumpscale/sals/reservation_chatflow/deployer.py
+++ b/jumpscale/sals/reservation_chatflow/deployer.py
@@ -306,8 +306,8 @@ class NetworkView:
                 if workload.info.node_id not in breaking_node_ids:
                     continue
                 j.sals.reservation_chatflow.reservation_chatflow.block_node(network.network_resources[idx].info.node_id)
-                raise StopChatFlow(
-                    "Network nodes dry run failed on node" f" {network.network_resources[idx].info.node_id}"
+                raise DeploymentFailed(
+                    "Network nodes dry run failed on node" f" {network.network_resources[idx].info.node_id}", wid=wid
                 )
 
 


### PR DESCRIPTION
### Description

retry deployment when network dry run fails

### Changes

raise DeploymentFailed on dry run failure instead of StopChatflow

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/1642

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
