### PR TITLE
3Bot deployer action dialogs hardening

### DIFF
--- a/jumpscale/packages/threebot_deployer/bottle/solutions.py
+++ b/jumpscale/packages/threebot_deployer/bottle/solutions.py
@@ -36,7 +36,7 @@ def stop_threebot() -> str:
         )
     try:
         stop_threebot_solution(owner=user_info["username"], solution_uuid=data["uuid"], password=data["password"])
-    except exceptions.Validation:
+    except (exceptions.Permission, exceptions.Validation):
         return HTTPResponse(
             j.data.serializers.json.dumps({"error": "invalid secret"}),
             status=401,
@@ -58,7 +58,7 @@ def destroy_threebot() -> str:
         )
     try:
         delete_threebot_solution(owner=user_info["username"], solution_uuid=data["uuid"], password=data["password"])
-    except exceptions.Validation:
+    except (exceptions.Permission, exceptions.Validation):
         return HTTPResponse(
             j.data.serializers.json.dumps({"error": "invalid secret"}),
             status=401,

--- a/jumpscale/packages/threebot_deployer/frontend/components/base/Dialog.vue
+++ b/jumpscale/packages/threebot_deployer/frontend/components/base/Dialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" width="700">
+  <v-dialog v-model="dialog" width="700" :persistent="persistent">
     <v-card :loading="loading" :disabled="loading">
       <v-card-title class="headline">{{title}}</v-card-title>
       <v-card-text class="pa-5">
@@ -35,7 +35,11 @@
       error: String,
       info: String,
       warning:String,
-      loading: Boolean
+      loading: Boolean,
+      persistent: {
+        type: Boolean,
+        default: false
+      },
     },
     computed: {
       dialog: {

--- a/jumpscale/packages/threebot_deployer/frontend/components/solutions/ActionConfirmation.vue
+++ b/jumpscale/packages/threebot_deployer/frontend/components/solutions/ActionConfirmation.vue
@@ -1,0 +1,67 @@
+<template>
+  <base-dialog
+    v-if="data"
+    :title="title"
+    v-model="dialog"
+    :error="error"
+    :info="info"
+    :warning="warning"
+    :loading="loading"
+    :persistent="true"
+  >
+    <template #default>
+      Please enter the password of <b class="font-weight-black">{{ data.name }}</b>. This will stop your running 3Bot and delete all backups.
+      <v-form @submit="submit">
+        <v-text-field :type="'password'" v-model="form.password" dense></v-text-field>
+      </v-form>
+    </template>
+    <template #actions>
+      <v-btn text @click="close">Close</v-btn>
+      <v-btn text color="error" @click="submit">Confirm</v-btn>
+    </template>
+  </base-dialog>
+</template>
+
+<script>
+module.exports = {
+  mixins: [dialog],
+  data() {
+    return {
+      lastThreebotSelected: "",
+    };
+  },
+  props:{
+    title: String,
+    api: String,
+    data: Object,
+  },
+  methods: {
+    submit() {
+      if (!this.form.password) {
+        this.error = "Password required";
+      } else {
+        this.loading = true;
+        this.error = null;
+        this.$api.solutions
+          [this.api](this.data.solution_uuid, this.form.password)
+          .then((response) => {
+            this.alert("3bot Destroyed", "success");
+            this.$router.go(0);
+          }).catch((err) => {
+            this.error = err.response.data["error"];
+            this.alert(this.error , "error");
+            this.form.password = "";
+          }).finally(() => {
+            this.loading = false;
+          });
+      }
+    },
+  },
+  updated() {
+    if (this.lastThreebotSelected !== this.data.name) {
+      this.warning = "";
+      this.lastThreebotSelected = this.data.name;
+    }
+  },
+};
+</script>

--- a/jumpscale/packages/threebot_deployer/frontend/components/solutions/Delete.vue
+++ b/jumpscale/packages/threebot_deployer/frontend/components/solutions/Delete.vue
@@ -1,60 +1,13 @@
 <template>
-  <base-dialog
-    v-if="data"
-    title="Destroy Workload"
-    v-model="dialog"
-    :error="error"
-    :info="info"
-    :warning="warning"
-    :loading="loading"
-  >
-    <template #default>
-      Please enter the password of {{ data.name }}. This will stop your running 3Bot and delete all backups.
-      <v-form>
-        <v-text-field :type="'password'" v-model="form.password" dense></v-text-field>
-      </v-form>
-    </template>
-    <template #actions>
-      <v-btn text @click="close">Close</v-btn>
-      <v-btn text color="error" @click="submit">Confirm</v-btn>
-    </template>
-  </base-dialog>
+  <action-confirmation v-model="dialog" title="Destroy 3Bot" api="destroyThreebot" :data="data"></action-confirmation>
 </template>
 
 <script>
 module.exports = {
+  components: {
+    "action-confirmation": httpVueLoader("./ActionConfirmation.vue"),
+  },
   mixins: [dialog],
-  data() {
-    return {
-      lastThreebotSelected: "",
-    };
-  },
   props: { data: Object },
-  methods: {
-    submit() {
-      if (!this.form.password) {
-        this.error = "Password required";
-      } else {
-        this.loading = true;
-        this.error = null;
-        this.$api.solutions
-          .destroyThreebot(this.data.solution_uuid, this.form.password)
-          .then((response) => {
-            this.alert("3bot Destroyed", "success");
-            this.$router.go(0);
-          })
-          .catch((err) => {
-            this.alert("Failed to destroy 3Bot", "error");
-            this.close();
-          });
-      }
-    },
-  },
-  updated() {
-    if (this.lastThreebotSelected !== this.data.name) {
-      this.warning = "";
-      this.lastThreebotSelected = this.data.name;
-    }
-  },
 };
 </script>

--- a/jumpscale/packages/threebot_deployer/frontend/components/solutions/Stop.vue
+++ b/jumpscale/packages/threebot_deployer/frontend/components/solutions/Stop.vue
@@ -1,56 +1,13 @@
 <template>
-  <base-dialog
-    v-if="data"
-    title="Stop Workload"
-    v-model="dialog"
-    :error="error"
-    :info="info"
-    :warning="warning"
-    :loading="loading"
-  >
-    <template #default>
-      Please enter the password of {{ data.name }}. This will stop your running 3Bot.
-      <v-form>
-        <v-text-field :type="'password'" v-model="form.password" dense></v-text-field>
-      </v-form>
-    </template>
-    <template #actions>
-      <v-btn text @click="close">Close</v-btn>
-      <v-btn text color="error" @click="submit">Confirm</v-btn>
-    </template>
-  </base-dialog>
+  <action-confirmation v-model="dialog" title="Stop 3Bot" api="stopThreebot" :data="data"></action-confirmation>
 </template>
 
 <script>
 module.exports = {
+  components: {
+    "action-confirmation": httpVueLoader("./ActionConfirmation.vue"),
+  },
   mixins: [dialog],
-  data() {
-    return {
-      lastThreebotSelected: "",
-    };
-  },
   props: { data: Object },
-  methods: {
-    submit() {
-      this.loading = true;
-      this.error = null;
-      this.$api.solutions
-        .stopThreebot(this.data.solution_uuid, this.form.password)
-        .then((response) => {
-          this.alert("Stopped 3Bot", "success");
-          this.$router.go(0);
-        })
-        .catch((err) => {
-          this.alert("Failed to Stop 3Bot", "error");
-          this.close();
-        });
-    },
-  },
-  updated() {
-    if (this.lastThreebotSelected !== this.data.name) {
-      this.warning = "";
-      this.lastThreebotSelected = this.data.name;
-    }
-  },
 };
 </script>


### PR DESCRIPTION
### Changes
- Added new action confirmation component
- Use `Enter` key to submitted action.
- use the base action component in stop and delete actions
- Added persistent option to the base dialog
- handle permission exception in stop and destroy threebot
### Related Issues

[3Bot Deployer on testnet: can not destroy 3Bot](https://github.com/threefoldtech/js-sdk/issues/1659)

![image](https://user-images.githubusercontent.com/36021484/98812547-5ef15500-242b-11eb-9955-29c6f6e3636a.png)
