### PR TITLE
remove ipv6 check for farms selection

### DIFF
--- a/jumpscale/packages/marketplace/chats/gitea.py
+++ b/jumpscale/packages/marketplace/chats/gitea.py
@@ -71,7 +71,6 @@ class GiteaDeploy(MarketPlaceAppsChatflow):
             env=var_dict,
             interactive=False,
             entrypoint="/start_gitea.sh",
-            public_ipv6=True,
             disk_size=self.container_resources["sru"] * 1024,
             secret_env={"POSTGRES_PASSWORD": self.database_password},
             solution_uuid=self.solution_id,

--- a/jumpscale/packages/marketplace/chats/mattermost.py
+++ b/jumpscale/packages/marketplace/chats/mattermost.py
@@ -98,7 +98,6 @@ class MattermostDeploy(MarketPlaceAppsChatflow):
             interactive=False,
             entrypoint="/start_mattermost.sh",
             volumes=volume_config,
-            public_ipv6=True,
             solution_uuid=self.solution_id,
             **self.solution_metadata,
         )

--- a/jumpscale/packages/marketplace/chats/meetings.py
+++ b/jumpscale/packages/marketplace/chats/meetings.py
@@ -69,7 +69,6 @@ class MeetingsDeploy(MarketPlaceAppsChatflow):
             disk_size=self.resources["sru"] * 1024,
             interactive=False,
             entrypoint="/entrypoint.sh",
-            public_ipv6=True,
             solution_uuid=self.solution_id,
             **self.solution_metadata,
         )

--- a/jumpscale/packages/marketplace/chats/publisher.py
+++ b/jumpscale/packages/marketplace/chats/publisher.py
@@ -145,7 +145,6 @@ class Publisher(MarketPlaceAppsChatflow):
                 secret_env=secret_env,
                 interactive=False,
                 solution_uuid=self.solution_id,
-                public_ipv6=True,
                 **self.solution_metadata,
             )
         )

--- a/jumpscale/packages/marketplace/chats/taiga.py
+++ b/jumpscale/packages/marketplace/chats/taiga.py
@@ -86,7 +86,6 @@ class TaigaDeploy(MarketPlaceAppsChatflow):
             env=var_dict,
             interactive=False,
             entrypoint="/start_taiga.sh",
-            public_ipv6=True,
             secret_env={
                 "EMAIL_HOST_PASSWORD": self.EMAIL_HOST_PASSWORD,
                 "PRIVATE_KEY": private_key,

--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -67,7 +67,6 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
         self.query = {"cru": 2, "mru": 2, "sru": 2.25}
         self.container_resources = {"cru": 1, "mru": 1, "sru": 2}
         self.expiration = 60 * 60  # 60 minutes for 3bot
-        self.ip_version = "IPv6"
         self.retries = 3
         self.allow_custom_domain = False
         self.custom_domain = False
@@ -232,7 +231,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
 
     @chatflow_step(title="Deployment location policy")
     def choose_location(self):
-        self._get_available_farms()
+        self._get_available_farms(only_one=False)
         self.farms_by_continent = deployer.group_farms_by_continent(self.available_farms)
         choices = ["Automatic", "Farm", "Specific node"]
         if self.farms_by_continent:

--- a/jumpscale/sals/marketplace/apps_chatflow.py
+++ b/jumpscale/sals/marketplace/apps_chatflow.py
@@ -33,7 +33,6 @@ class MarketPlaceAppsChatflow(MarketPlaceChatflow):
         self.username = self.user_info()["username"]
         self.solution_metadata["owner"] = self.username
         self.threebot_name = j.data.text.removesuffix(self.username, ".3bot")
-        self.ip_version = "IPv6"
         self.expiration = 60 * 60 * 3  # expiration 3 hours
         self.retries = 3
         self.custom_domain = False
@@ -159,7 +158,7 @@ class MarketPlaceAppsChatflow(MarketPlaceChatflow):
         return self.pool_id
 
     def _select_node(self):
-        self.selected_node = deployer.schedule_container(self.pool_id, ip_version=self.ip_version, **self.query)
+        self.selected_node = deployer.schedule_container(self.pool_id, **self.query)
 
     @chatflow_step(title="New Expiration")
     def set_expiration(self):
@@ -439,12 +438,9 @@ class MarketPlaceAppsChatflow(MarketPlaceChatflow):
         for farm in farms:
             farm_name = farm.name
             available_ipv4, _, _, _, _ = deployer.check_farm_capacity(
-                farm_name, currencies=[self.currency], ip_version="IPv4"
+                farm_name, currencies=[self.currency], ip_version="IPv4", **self.query
             )
-            available_ipv6, _, _, _, _ = deployer.check_farm_capacity(
-                farm_name, currencies=[self.currency], ip_version="IPv6", **self.query
-            )
-            if available_ipv4 and available_ipv6:
+            if available_ipv4:
                 self.available_farms.append(farm)
                 if only_one:
                     return


### PR DESCRIPTION
only ipv4 is required

### Description

Change farm selection to choose farms with ipv4
![Screenshot from 2020-11-19 15-02-50](https://user-images.githubusercontent.com/10658229/99670165-c5ecba80-2a78-11eb-9ed8-7b52e9a8374a.png)


### Changes

- Remove public_ipv6 from container deployment in apps and threebot
- Change threebot deployer farm selector to include all farms

```
 jumpscale/packages/marketplace/chats/gitea.py          |  1 -
 jumpscale/packages/marketplace/chats/mattermost.py     |  1 -
 jumpscale/packages/marketplace/chats/meetings.py       |  1 -
 jumpscale/packages/marketplace/chats/publisher.py      |  1 -
 jumpscale/packages/marketplace/chats/taiga.py          |  1 -
 jumpscale/packages/threebot_deployer/chats/threebot.py |  3 +--
 jumpscale/sals/marketplace/apps_chatflow.py            | 10 +++-------
 7 files changed, 4 insertions(+), 14 deletions(-)
```
