### PR TITLE
Activate threebot testnet wallets through the testnet activation service

### DIFF
--- a/jumpscale/clients/stellar/__init__.py
+++ b/jumpscale/clients/stellar/__init__.py
@@ -1,5 +1,3 @@
-import requests
-
 from jumpscale.loader import j
 from jumpscale.core.base import StoredFactory
 from stellar_sdk import Keypair
@@ -50,45 +48,6 @@ class StellarFactory(StoredFactory):
             services_status = False
 
         return services_status
-
-    def create_testnet_funded_wallet(self, name: str) -> bool:
-        """This method will create a testnet wallet and fund it from the facuet
-
-        Args:
-            name (str): name of the wallet
-
-        """
-        wallet = self.new(name)
-        try:
-            wallet.network = "TEST"
-            wallet.activate_through_friendbot()
-            wallet.add_known_trustline("TFT")
-            wallet.save()
-        except Exception as e:
-            self.delete(name)
-            raise j.exceptions.Runtime(f"Failed to create the wallet due to token service")
-
-        headers = {"Content-Type": "application/json"}
-        url = "https://gettft.testnet.grid.tf/tft_faucet/api/transfer"
-        data = {"destination": wallet.address}
-
-        try:
-            response = requests.post(url, json=data, headers=headers)
-        except requests.exceptions.HTTPError:
-            self.delete(name)
-            raise j.exceptions.Runtime(
-                f"Failed to fund wallet can't reach {url} due to connection error. Changes will be reverted."
-            )
-
-        if response.status_code != 200:
-            self.delete(name)
-            raise j.exceptions.Runtime(
-                f"Failed to fund the wallet due to to facuet server error. Changes will be reverted."
-            )
-
-        j.logger.info("Wallet created successfully")
-        return True
-
 
 def export_module_as():
 

--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -104,15 +104,9 @@ class Stellar(Client):
         resp.raise_for_status()
         return resp.json()
 
-    def _create_activation_code(self):
+    def _activate_account(self):
         data = {"address": self.address}
         resp = j.tools.http.post(self._get_url("CREATE_ACTIVATION_CODE"), json={"args": data})
-        resp.raise_for_status()
-        return resp.json()
-
-    def _activation_account(self, activation_code):
-        data = {"activation_code": activation_code}
-        resp = j.tools.http.post(self._get_url("ACTIVATE_ACCOUNT"), json={"args": data})
         resp.raise_for_status()
         return resp.json()
 
@@ -229,7 +223,7 @@ class Stellar(Client):
         server.submit_transaction(transaction)
 
     def activate_through_friendbot(self):
-        """Activates and funds a testnet account using riendbot
+        """Activates and funds a testnet account using friendbot
         """
         if self.network.value != "TEST":
             raise Exception("Account activation through friendbot is only available on testnet")
@@ -240,10 +234,9 @@ class Stellar(Client):
 
     def activate_through_threefold_service(self):
         """
-        Activate your weallet through threefold services
+        Activate your wallet through the threefold activation service
         """
-        activationdata = self._create_activation_code()
-        self._activation_account(activationdata["activation_code"])
+        self._activate_account()
 
     def activate_account(self, destination_address, starting_balance="12.50"):
         """Activates another account

--- a/jumpscale/packages/admin/actors/wallet.py
+++ b/jumpscale/packages/admin/actors/wallet.py
@@ -19,15 +19,11 @@ class Wallet(BaseActor):
         wallet = j.clients.stellar.new(name=name, network=wallettype)
 
         try:
-            if wallettype == "TEST":
-                wallet.activate_through_friendbot()
-            else:
-                wallet.activate_through_threefold_service()
+            wallet.activate_through_threefold_service()
         except Exception:
             j.clients.stellar.delete(name=name)
             raise j.exceptions.JSException("Error on wallet activation")
 
-        trustlines = _NETWORK_KNOWN_TRUSTS[str(wallet.network.name)].copy()
         try:
             wallet.add_known_trustline("TFT")
         except Exception:


### PR DESCRIPTION
Fixes issue #1584 
I also moved the funding of the testnet 3bot wallet to the 3bot code since it belongs there, it's not generic wallet functionality.
