### PR TITLE
check test cert before certificate limit

### DIFF
--- a/jumpscale/sals/marketplace/apps_chatflow.py
+++ b/jumpscale/sals/marketplace/apps_chatflow.py
@@ -316,7 +316,7 @@ class MarketPlaceAppsChatflow(MarketPlaceChatflow):
                 else:
                     deployer.unblock_managed_domain(domain)
                 try:
-                    if j.sals.crtsh.has_reached_limit(domain):
+                    if not j.core.config.get("TEST_CERT") and j.sals.crtsh.has_reached_limit(domain):
                         continue
                 except requests.exceptions.HTTPError:
                     is_http_failure = True


### PR DESCRIPTION
### Description

don't check certificate limit if test_cert is enabled


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/1672

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
