### PR TITLE
Move alert handler from the entrypoint to server start

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
@@ -98,10 +98,6 @@ j.core.config.set(
     },
 )
 
-from monitoring_alert_handler import send_alert
-
-j.tools.alerthandler.register_handler(send_alert)
-
 from register_dashboard import register_dashboard
 
 register_dashboard()

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
@@ -98,6 +98,8 @@ j.core.config.set(
     },
 )
 
+j.config.set("SEND_REMOTE_ALERTS", True)
+
 from register_dashboard import register_dashboard
 
 register_dashboard()

--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -751,7 +751,8 @@ class ThreebotServer(Base):
         self.nginx.start()
         self.rack.start()
         j.logger.register(f"threebot_{self.instance_name}")
-        j.tools.alerthandler.register_handler(send_alert)
+        if j.config.get("SEND_REMOTE_ALERTS", False):
+            j.tools.alerthandler.register_handler(send_alert)
 
         # add default packages
         for package_name in DEFAULT_PACKAGES:

--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -12,6 +12,7 @@ from gevent.pywsgi import WSGIServer
 from jumpscale.core.base import Base, fields
 from jumpscale import packages as pkgnamespace
 from jumpscale.sals.nginx.nginx import LocationType, PORTS
+from jumpscale.packages.tfgrid_solutions.scripts.threebot.monitoring_alert_handler import send_alert
 
 
 GEDIS = "gedis"
@@ -750,6 +751,7 @@ class ThreebotServer(Base):
         self.nginx.start()
         self.rack.start()
         j.logger.register(f"threebot_{self.instance_name}")
+        j.tools.alerthandler.register_handler(send_alert)
 
         # add default packages
         for package_name in DEFAULT_PACKAGES:


### PR DESCRIPTION
### Description

zinit starts executes the entrypoint then starts the 3bot server as a different service. So the registered handler doesn't apply to the new process.

Should be merged after poetry dependency is updated with the register_handler commit (currently, it fails).