### PR TITLE
move init logic out of the entrypoint

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
@@ -27,16 +27,26 @@ if $poetry_install; then
   poetry install
 fi
 
-echo "INSTANCE_NAME=${INSTANCE_NAME}" >> ~/.bashrc
-echo "THREEBOT_NAME=${THREEBOT_NAME}" >> ~/.bashrc
-echo "BACKUP_PASSWORD=${BACKUP_PASSWORD}" >> ~/.bashrc
-echo "BACKUP_TOKEN=${BACKUP_TOKEN}" >> ~/.bashrc
-echo "DOMAIN=${DOMAIN}" >> ~/.bashrc
+# Execute the initialization script from the newly fetched branch
+[ -f ./initialize.sh ] && bash ./initialize.sh
 
-echo "EMAIL_HOST=${EMAIL_HOST}" >> ~/.bashrc
-echo "EMAIL_HOST_USER=${EMAIL_HOST_USER}" >> ~/.bashrc
-echo "EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}" >> ~/.bashrc
-echo "ESCALATION_MAIL=${ESCALATION_MAIL}" >> ~/.bashrc
 
-echo "[*] Starting threebot in background ..."
-python3 jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.py
+# If the initialization script doesn't exist,
+# this branch is not updated with this script.
+# So we'll execute the original logic of the development
+# branch to keep them working without any changes
+if ! [ -f ./initialize.sh ]; then
+  echo "INSTANCE_NAME=${INSTANCE_NAME}" >> ~/.bashrc
+  echo "THREEBOT_NAME=${THREEBOT_NAME}" >> ~/.bashrc
+  echo "BACKUP_PASSWORD=${BACKUP_PASSWORD}" >> ~/.bashrc
+  echo "BACKUP_TOKEN=${BACKUP_TOKEN}" >> ~/.bashrc
+  echo "DOMAIN=${DOMAIN}" >> ~/.bashrc
+
+  echo "EMAIL_HOST=${EMAIL_HOST}" >> ~/.bashrc
+  echo "EMAIL_HOST_USER=${EMAIL_HOST_USER}" >> ~/.bashrc
+  echo "EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}" >> ~/.bashrc
+  echo "ESCALATION_MAIL=${ESCALATION_MAIL}" >> ~/.bashrc
+
+  echo "[*] Starting threebot in background ..."
+  python3 jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.py
+fi

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/initialize.sh
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/initialize.sh
@@ -1,0 +1,15 @@
+
+
+echo "INSTANCE_NAME=${INSTANCE_NAME}" >> ~/.bashrc
+echo "THREEBOT_NAME=${THREEBOT_NAME}" >> ~/.bashrc
+echo "BACKUP_PASSWORD=${BACKUP_PASSWORD}" >> ~/.bashrc
+echo "BACKUP_TOKEN=${BACKUP_TOKEN}" >> ~/.bashrc
+echo "DOMAIN=${DOMAIN}" >> ~/.bashrc
+
+echo "EMAIL_HOST=${EMAIL_HOST}" >> ~/.bashrc
+echo "EMAIL_HOST_USER=${EMAIL_HOST_USER}" >> ~/.bashrc
+echo "EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}" >> ~/.bashrc
+echo "ESCALATION_MAIL=${ESCALATION_MAIL}" >> ~/.bashrc
+
+echo "[*] Starting threebot in background ..."
+python3 jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.py


### PR DESCRIPTION
### Description

Putting `SDK_VERSiON=development_vdc` to the development image doesn't execute the development_vdc code since it had begun already executing entrypoint script. So in this PR, the logic is moved to a new file, and a couple of checks is added to make sure all the current branches will work without any changes.