### PR TITLE
fetch remote branches before diffing poetry.lock

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
@@ -14,13 +14,15 @@ echo $SSHKEY > /root/.ssh/authorized_keys
 echo "[*] Switching to the correct version (${SDK_VERSION}) ..."
 cd ${SDK_PATH}
 
+git fetch --all
+
 poetry_install=false
 if ! git diff --quiet `git branch --show-current` origin/$SDK_VERSION -- poetry.lock; then
   # They are differnet
   poetry_install=true
 fi
 
-git fetch --all
+
 git reset --hard origin/${SDK_VERSION}
 
 if $poetry_install; then


### PR DESCRIPTION
### Description

When specifying a branch that is added after the development image build, the `poetry.lock` check fails with this error.
![Screenshot from 2020-12-03 14-55-51](https://user-images.githubusercontent.com/13040543/101020762-a759e980-3577-11eb-8325-ea6451afe4b1.png)
