### PR TITLE
Replace private ip to public ip in k8s list of vdc ui

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/base/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/base/Kubernetes.vue
@@ -18,7 +18,8 @@
       </template>
 
       <template v-slot:item.ip="{ item }">
-        <div>{{ item.ip_address }}</div>
+        <div v-if="item.ip_address != '::/128'">{{ item.ip_address }}</div>
+        <div v-else></div>
       </template>
 
       <template v-slot:item.role="{ item }">


### PR DESCRIPTION
### Description

The list of nodes in kubernetes shows the private ip of the node in the network when it should be the public ip that is accessible

### Changes

Replace private ip to public ip in k8s list of vdc ui

### Related Issues

https://github.com/threefoldtech/vdc/issues/65

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
