### PR TITLE
Update vdc wallet dialog width to be bigger

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/base/Sidebar.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/base/Sidebar.vue
@@ -4,7 +4,7 @@
       <v-list-item>
         <v-list-item-content>
           <v-list-item-title class="title">
-            <v-dialog v-model="dialog" persistent max-width="290">
+            <v-dialog v-model="dialog" persistent max-width="500">
               <template v-slot:activator="{ on, attrs }">
                 <v-btn v-bind="attrs" v-on="on">
                   <v-icon left color="primary">mdi-wallet</v-icon> {{ name }}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/36021484/101629091-766f2e00-3a29-11eb-9e8b-a0932acf17e3.png)

### Changes

Update vdc wallet dialog width to be bigger
### Related Issues

[VDC wallet information popup is too small](https://github.com/threefoldtech/vdc/issues/61)
### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
