### PR TITLE
Add units to k8s and s3 disk size in ui

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/base/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/base/Kubernetes.vue
@@ -27,7 +27,7 @@
       </template>
 
       <template v-slot:item.size="{ item }">
-        <div>{{ item.size }}</div>
+        <div>{{ item.size }} GB</div>
       </template>
       <template v-slot:item.actions="{ item }">
         <v-tooltip top>
@@ -86,7 +86,7 @@ module.exports = {
         { text: "WID", value: "wid" },
         { text: "IP Address", value: "ip" },
         { text: "Role", value: "role" },
-        { text: "Size", value: "size" },
+        { text: "Disk Size", value: "size" },
         { text: "Actions", value: "actions", sortable: false },
       ],
     };

--- a/jumpscale/packages/vdc_dashboard/frontend/components/base/S3.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/base/S3.vue
@@ -18,7 +18,7 @@
       </template>
 
       <template v-slot:item.size="{ item }">
-        <div>{{ item.size }}</div>
+        <div>{{ item.size }} GB</div>
       </template>
 
       <template v-slot:item.actions="{ item }">
@@ -59,7 +59,7 @@ module.exports = {
       headers: [
         { text: "WID", value: "wid" },
         { text: "Node", value: "node" },
-        { text: "Size", value: "size" },
+        { text: "Disk Size", value: "size" },
         { text: "Actions", value: "actions", sortable: false },
       ],
     };


### PR DESCRIPTION
### Description
The size in the k8s and s3 tables don't indicate what it is.

### Changes
- Change column title to Disk Size
- Add the unit to the size value
![Screenshot from 2020-12-09 15-51-29](https://user-images.githubusercontent.com/17128393/101643360-bab7f980-3a3c-11eb-9ff1-20efc0c5cbfa.png)
![Screenshot from 2020-12-09 16-22-56](https://user-images.githubusercontent.com/17128393/101643366-bc81bd00-3a3c-11eb-839c-ce7085c80547.png)


### Related Issues

https://github.com/threefoldtech/vdc/issues/66
https://github.com/threefoldtech/vdc/issues/63


### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
