### PR TITLE
Update kubernetess vm sizes in ui

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/base/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/base/Kubernetes.vue
@@ -26,8 +26,16 @@
         <div>{{ item.role }}</div>
       </template>
 
-      <template v-slot:item.size="{ item }">
-        <div>{{ item.size }} GB</div>
+      <template v-slot:item.vcpu="{ item }">
+        <div>{{ kubernetesSizeMap[item.size].vcpu }}</div>
+      </template>
+
+      <template v-slot:item.memory="{ item }">
+        <div>{{ kubernetesSizeMap[item.size].memory }} GB</div>
+      </template>
+
+      <template v-slot:item.storage="{ item }">
+        <div>{{ kubernetesSizeMap[item.size].storage }} GB</div>
       </template>
       <template v-slot:item.actions="{ item }">
         <v-tooltip top>
@@ -86,9 +94,12 @@ module.exports = {
         { text: "WID", value: "wid" },
         { text: "IP Address", value: "ip" },
         { text: "Role", value: "role" },
-        { text: "Disk Size", value: "size" },
+        { text: "vCPU", value: "vcpu" },
+        { text: "Memory", value: "memory" },
+        { text: "Disk Size", value: "storage" },
         { text: "Actions", value: "actions", sortable: false },
       ],
+      kubernetesSizeMap: KUBERNETES_VM_SIZE_MAP,
     };
   },
   methods: {

--- a/jumpscale/packages/vdc_dashboard/frontend/data.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/data.js
@@ -249,3 +249,23 @@ const SECTIONS = {
     "Decentralized Developer": DECENTRALIZED_DEV,
     "Blockchain Solutions": BC_SOLUTIONS,
 }
+const KUBERNETES_VM_SIZE_MAP =
+{
+    1: { "vcpu": 1, "memory": 2, "storage": 50 },
+    2: { "vcpu": 2, "memory": 4, "storage": 100 },
+    3: { "vcpu": 2, "memory": 8, "storage": 25 },
+    4: { "vcpu": 2, "memory": 8, "storage": 50 },
+    5: { "vcpu": 2, "memory": 8, "storage": 200 },
+    6: { "vcpu": 4, "memory": 16, "storage": 50 },
+    7: { "vcpu": 4, "memory": 16, "storage": 100 },
+    8: { "vcpu": 4, "memory": 16, "storage": 400 },
+    9: { "vcpu": 8, "memory": 32, "storage": 100 },
+    10: { "vcpu": 8, "memory": 32, "storage": 200 },
+    11: { "vcpu": 8, "memory": 32, "storage": 800 },
+    12: { "vcpu": 16, "memory": 64, "storage": 200 },
+    13: { "vcpu": 16, "memory": 64, "storage": 400 },
+    14: { "vcpu": 16, "memory": 64, "storage": 800 },
+    15: { "vcpu": 1, "memory": 2, "storage": 25 },
+    16: { "vcpu": 2, "memory": 4, "storage": 50 },
+    17: { "vcpu": 4, "memory": 8, "storage": 50 },
+}


### PR DESCRIPTION
### Description

Sizes are represented as a map that maps to vCPU,memory and storage. The key is not an indication of the actual size in the UI of kubernetes table in vdc UI

### Changes

Size is divided into vCPU, memory and storage in the UI instad of a single size colomn
![Screenshot from 2020-12-13 14-18-51](https://user-images.githubusercontent.com/17128393/102011718-c8c48d80-3d4e-11eb-93b6-a79098f44e2f.png)


### Related Issues

https://github.com/threefoldtech/vdc/issues/66

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
