### PR TITLE
Fix services naming to be passed on package installation

### DIFF
--- a/docs/wiki/threebot/threebot.md
+++ b/docs/wiki/threebot/threebot.md
@@ -202,11 +202,11 @@ Some components will be defined by default based on the parent package classes i
         from jumpscale.tools.servicemanager.servicemanager import BackgroundService
 
         class TestService(BackgroundService):
-          def __init__(self, name="packagename_test", interval=20, *args, **kwargs):
+          def __init__(self, interval=20, *args, **kwargs):
             """
                 Test service that runs every 1 hour
             """
-            super().__init__(name, interval, *args, **kwargs)
+            super().__init__(interval, *args, **kwargs)
 
           def job(self):
             print("[Packagename - Test Service] Done")

--- a/jumpscale/packages/admin/services/diskcheck.py
+++ b/jumpscale/packages/admin/services/diskcheck.py
@@ -4,11 +4,11 @@ from jumpscale.tools.notificationsqueue.queue import LEVEL
 
 
 class DiskCheckService(BackgroundService):
-    def __init__(self, name="admin_diskcheck", interval="* * * * *", *args, **kwargs):
+    def __init__(self, interval="* * * * *", *args, **kwargs):
         """
             Check disk space every 1 minute
         """
-        super().__init__(name, interval, *args, **kwargs)
+        super().__init__(interval, *args, **kwargs)
 
     def job(self):
         disk_obj = j.sals.fs.shutil.disk_usage("/")

--- a/jumpscale/packages/admin/services/heartbeat.py
+++ b/jumpscale/packages/admin/services/heartbeat.py
@@ -12,12 +12,12 @@ MONITORING_SERVER_URL = os.environ.get("MONITORING_SERVER_URL")
 
 
 class HeartBeatService(BackgroundService):
-    # def __init__(self, name="heartbeat_service", interval=60 * 10, *args, **kwargs):
-    def __init__(self, name="heartbeat_service", interval=10, *args, **kwargs):
+    # def __init__(self, interval=60 * 10, *args, **kwargs):
+    def __init__(self, interval=10, *args, **kwargs):
         """
-        Check disk space every 12 hours
+        Check disk space every 10 seconds
         """
-        super().__init__(name, interval, *args, **kwargs)
+        super().__init__(interval, *args, **kwargs)
 
     def _encode_data(self, data):
         keys = [

--- a/jumpscale/packages/admin/services/stellar.py
+++ b/jumpscale/packages/admin/services/stellar.py
@@ -5,11 +5,11 @@ from crontab import CronTab
 
 
 class StellarService(BackgroundService):
-    def __init__(self, name="admin_stellar", interval=CronTab("* * * * *"), *args, **kwargs):
+    def __init__(self, interval=CronTab("* * * * *"), *args, **kwargs):
         """
             Check stellar service state every 1 min
         """
-        super().__init__(name, interval, *args, **kwargs)
+        super().__init__(interval, *args, **kwargs)
         self.stellar_state = True
 
     def job(self):

--- a/jumpscale/packages/billing/services/billing.py
+++ b/jumpscale/packages/billing/services/billing.py
@@ -4,8 +4,8 @@ import gevent
 
 
 class BillingService(BackgroundService):
-    def __init__(self, name="billing", interval=1, *args, **kwargs):
-        super().__init__(name, interval, *args, **kwargs)
+    def __init__(self, interval=1, *args, **kwargs):
+        super().__init__(interval, *args, **kwargs)
 
     def job(self):
         j.sals.billing.process_payments()

--- a/jumpscale/packages/tfgrid_solutions/services/auto_extend_pools.py
+++ b/jumpscale/packages/tfgrid_solutions/services/auto_extend_pools.py
@@ -4,11 +4,11 @@ from jumpscale.loader import j
 
 
 class AutoExtendPoolService(BackgroundService):
-    def __init__(self, name="threebot_deployer_auto_extend_pools", interval=60 * 60 * 24, *args, **kwargs):
+    def __init__(self, interval=60 * 60 * 24, *args, **kwargs):
         """
         Test service that runs every 1 day
         """
-        super().__init__(name, interval, *args, **kwargs)
+        super().__init__(interval, *args, **kwargs)
 
     def job(self):
         auto_extend_pools()

--- a/jumpscale/packages/vdc_dashboard/services/provision_wallet_billing.py
+++ b/jumpscale/packages/vdc_dashboard/services/provision_wallet_billing.py
@@ -4,10 +4,10 @@ from jumpscale.tools.servicemanager.servicemanager import BackgroundService
 
 
 class AutoExtendbillingService(BackgroundService):
-    def __init__(self, name="auto_extend_billing_service", interval=60 * 60, *args, **kwargs):
+    def __init__(self, interval=60 * 60, *args, **kwargs):
         """Provisioning wallet service that will run every hour to extend the VDC pool
         """
-        super().__init__(name, interval, *args, **kwargs)
+        super().__init__(interval, *args, **kwargs)
 
     def job(self):
         auto_extend_billing()

--- a/jumpscale/packages/vdc_dashboard/services/s3_auto_topup.py
+++ b/jumpscale/packages/vdc_dashboard/services/s3_auto_topup.py
@@ -35,8 +35,8 @@ S3_AUTO_TOP_SOLUTIONS: dict {
 
 
 class S3AutoTopUp(BackgroundService):
-    def __init__(self, name="s3_auto_topup", interval=60 * 60 * 2, *args, **kwargs):
-        super().__init__(name, interval, *args, **kwargs)
+    def __init__(self, interval=60 * 60 * 2, *args, **kwargs):
+        super().__init__(interval, *args, **kwargs)
 
     def job(self):
         """

--- a/jumpscale/packages/vdc_dashboard/services/transaction_from_prepaid_to_provision_wallet.py
+++ b/jumpscale/packages/vdc_dashboard/services/transaction_from_prepaid_to_provision_wallet.py
@@ -4,11 +4,11 @@ from jumpscale.tools.servicemanager.servicemanager import BackgroundService
 
 
 class TransferPrepaidToProvisionWallet(BackgroundService):
-    def __init__(self, name="auto_transfer_funds_from_prepaid_provision_wallet", interval=60 * 60, *args, **kwargs):
+    def __init__(self, interval=60 * 60, *args, **kwargs):
         """Provisioning wallet service that will run every hour to transfer
         funds from prepaid to provision wallet
         """
-        super().__init__(name, interval, *args, **kwargs)
+        super().__init__(interval, *args, **kwargs)
 
     def job(self):
         tranfer_prepaid_to_provision_wallet()

--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -584,7 +584,7 @@ class PackageManager(Base):
         # start background services
         if package.services_dir:
             for service in package.services:
-                self.threebot.services.add_service(service["path"])
+                self.threebot.services.add_service(service["name"], service["path"])
 
         # start servers
         self.threebot.rack.start()

--- a/jumpscale/tools/servicemanager/servicemanager.py
+++ b/jumpscale/tools/servicemanager/servicemanager.py
@@ -5,16 +5,16 @@ Service manager is the service that monitors and manages background services thr
 Each service defines an interval to define the period of the service and defines also a job method that is run each period.
 Any service should:
 - Inherit from `BackgroundService` class defined here: `from jumpscale.tools.servicemanager.servicemanager import BackgroundService`
-- Define a name and interval in the constructor
+- Define an interval in the constructor
 - Implement the abtsract `job` method of the `BackgroundService` base class.
 
 ### How it schedules services
 
 The service manager uses gevent greenlets to run jobs. It spawns the job in a greenlet after its interval period.
 Rescheduling the service job is done in by linking a callback to the greenlet which is run after the greenlet finishes.
-After the greenlet finishes execution the callback is fired which schedules the job to be run again after anothre interval.
+After the greenlet finishes execution the callback is fired which schedules the job to be run again after another interval.
 
-To add a service  to the service manager you should call the `add_service` method which takes the package path as a parameter.
+To add a service to the service manager you should call the `add_service` method which takes the package name and package path as parameters.
 It loads the file in this path as a module and gets the service object defined in the service.py file.
 
 ### Example service

--- a/jumpscale/tools/servicemanager/servicemanager.py
+++ b/jumpscale/tools/servicemanager/servicemanager.py
@@ -179,7 +179,7 @@ class ServiceManager(Base):
         service.name = service_name
 
         if service in self.services.values():
-            j.logger.debug(f"Service {service.name} is running. Reloading..")
+            j.logger.debug(f"Service {service.name} is already running. Reloading...")
             self.stop_service(service.name)
 
         next_start = ceil(self.seconds_to_next_interval(service.interval))

--- a/jumpscale/tools/servicemanager/servicemanager.py
+++ b/jumpscale/tools/servicemanager/servicemanager.py
@@ -23,11 +23,11 @@ It loads the file in this path as a module and gets the service object defined i
 from jumpscale.tools.servicemanager.servicemanager import BackgroundService
 
 class TestService(BackgroundService):
-    def __init__(self, name="test", interval="* * * * *", *args, **kwargs):
+    def __init__(self, interval="* * * * *", *args, **kwargs):
         '''
             Test service that runs every 1 minute
         '''
-        super().__init__(name, interval, *args, **kwargs)
+        super().__init__(interval, *args, **kwargs)
 
     def job(self):
         print("[Test Service] Done")
@@ -48,14 +48,12 @@ from jumpscale.core.base import Base
 
 
 class BackgroundService(ABC):
-    def __init__(self, service_name, interval=60, *args, **kwargs):
+    def __init__(self, interval=60, *args, **kwargs):
         """Abstract base class for background services managed by the service manager
 
         Arguments:
-            service_name (str): identifier of the service
             interval (int | CronTab object | str): scheduled job is executed every interval in seconds / CronTab object / CronTab-formatted string
         """
-        self.name = service_name
         self.interval = interval
 
     @abstractmethod
@@ -170,7 +168,7 @@ class ServiceManager(Base):
         for service in list(self.services.keys()):
             self.stop_service(service)
 
-    def add_service(self, service_path):
+    def add_service(self, service_name, service_path):
         """Add a new background service to be managed and scheduled by the service manager
 
         Arguments:
@@ -178,6 +176,7 @@ class ServiceManager(Base):
         """
 
         service = self._load_service(service_path)
+        service.name = service_name
 
         if service in self.services.values():
             j.logger.debug(f"Service {service.name} is running. Reloading..")


### PR DESCRIPTION
### Description

Removed service name attribute to be passed on package installation. The current convention for the packages services naming is packagename_servicefilename e.g: admin_healthcheck, threebot_auto_extend_pool, ...

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/1815

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
