### PR TITLE
add button to download kubeconfig file

### DIFF
--- a/jumpscale/packages/vdc/chats/new_vdc.py
+++ b/jumpscale/packages/vdc/chats/new_vdc.py
@@ -136,6 +136,8 @@ class VDCDeploy(GedisChatBot):
         Please download the config file to `~/.kube/config` to start using your cluster with [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
         Kubernetes controller public IP: {self.public_ip}
+        <br />\n
+        `WARINING: Please keep the kubeconfig file safe and secure. Anyone who has this file can access the kubernetes cluster`
         """
         )
 

--- a/jumpscale/packages/vdc_dashboard/bottle/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/deployments.py
@@ -18,6 +18,21 @@ from jumpscale.packages.vdc_dashboard.sals.vdc_dashboard_sals import get_all_dep
 app = Bottle()
 
 
+@app.route("/api/kube/get")
+@package_authorized("vdc_dashboard")
+def get_kubeconfig() -> str:
+    file_path = j.sals.fs.expanduser("~/.kube/config")
+    if not j.sals.fs.exists(file_path):
+        return HTTPResponse(status=404, headers={"Content-Type": "application/json"})
+
+    file_content = j.sals.fs.read_file(file_path)
+
+    if not file_content:
+        return HTTPResponse(status=400, message="Invalid file!", headers={"Content-Type": "application/json"})
+
+    return j.data.serializers.json.dumps({"data": file_content})
+
+
 @app.route("/api/s3/expose")
 @package_authorized("vdc_dashboard")
 def expose_s3() -> str:

--- a/jumpscale/packages/vdc_dashboard/frontend/api.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/api.js
@@ -45,6 +45,13 @@ const apiClient = {
         method: "get"
       })
     },
+    getKubeConfig: () => {
+      return axios({
+        url: `${baseURL}/kube/get`,
+        headers: { 'Content-Type': 'application/json' },
+        method: "get"
+      })
+    }
   },
   license: {
     accept: () => {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/base/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/base/Kubernetes.vue
@@ -6,6 +6,14 @@
         class="float-right p-4"
         color="primary"
         text
+        @click.stop="downloadKubeConfigFile()"
+      >
+        <v-icon left>mdi-download</v-icon>KubeConfig
+      </v-btn>
+      <v-btn
+        class="float-right p-4"
+        color="primary"
+        text
         @click.stop="openChatflow('add_k3s_node')"
       >
         <v-icon left>mdi-plus</v-icon>Add node
@@ -76,6 +84,7 @@
       v-model="dialogs.cancelWorkload"
       :data="selected"
     ></cancel-workload>
+    <download-kubeconfig v-model="dialogs.downloadKube"></download-kubeconfig>
   </div>
 </template>
 
@@ -85,6 +94,7 @@ module.exports = {
   components: {
     "solution-info": httpVueLoader("../solutions/Info.vue"),
     "cancel-workload": httpVueLoader("../solutions/Delete.vue"),
+    "download-kubeconfig": httpVueLoader("../solutions/DownloadKubeconfig.vue"),
   },
   props: ["vdc"],
 
@@ -94,6 +104,7 @@ module.exports = {
       dialogs: {
         info: false,
         cancelWorkload: false,
+        downloadKube: false,
       },
       headers: [
         { text: "WID", value: "wid" },
@@ -121,6 +132,10 @@ module.exports = {
     deleteNode(record) {
       this.selected = record;
       this.dialogs.cancelWorkload = true;
+    },
+
+    downloadKubeConfigFile() {
+      this.dialogs.downloadKube = true;
     },
   },
   computed: {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/solutions/DownloadKubeconfig.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/solutions/DownloadKubeconfig.vue
@@ -1,0 +1,40 @@
+<template>
+  <base-dialog title="Download kubeconfig file" v-model="dialog">
+    <template #default>
+      WARINING: Please keep the kubeconfig file safe and secure. Anyone who has
+      this file can access the kubernetes cluster Are you sure to continue
+      downloading?
+    </template>
+    <template #actions>
+      <v-btn text @click="close">Cancel</v-btn>
+      <v-btn text color="error" @click="submit">Download</v-btn>
+    </template>
+  </base-dialog>
+</template>
+
+<script>
+module.exports = {
+  mixins: [dialog],
+  methods: {
+    submit() {
+      this.$api.solutions
+        .getKubeConfig()
+        .then((response) => {
+          const blob = new Blob([response.data.data]);
+          const url = window.URL.createObjectURL(blob);
+          const link = document.createElement("a");
+          link.href = url;
+          link.setAttribute("download", "config.yaml");
+          document.body.appendChild(link);
+          link.click();
+          link.parentNode.removeChild(link);
+          this.close();
+        })
+        .catch((err) => {
+          console.log("failed");
+          this.close();
+        });
+    },
+  },
+};
+</script>


### PR DESCRIPTION
### Description

- Add button to download kubeconfig file
- Add warning in the chatflow

### Changes

![Screenshot from 2020-12-15 12-29-22](https://user-images.githubusercontent.com/10658229/102208650-5a133b80-3ed8-11eb-90a0-4bc00ada94b3.png)

![Screenshot from 2020-12-15 13-18-36](https://user-images.githubusercontent.com/10658229/102208674-60a1b300-3ed8-11eb-8984-a0a959521879.png)


### Related Issues

- https://github.com/threefoldtech/vdc/issues/80

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [] Documentation
- [x] Code format and docstrings
