### PR TITLE
Hide farm management item from the sidebar if not installed

### DIFF
--- a/jumpscale/packages/admin/frontend/App.vue
+++ b/jumpscale/packages/admin/frontend/App.vue
@@ -132,7 +132,7 @@
     </v-navigation-drawer>
 
     <v-main>
-      <router-view></router-view>
+      <router-view @updatesidebarlist="isFarmManagementInstalled()"></router-view>
       <identities v-model="dialogs.identity"></identities>
       <popup></popup>
     </v-main>
@@ -200,7 +200,8 @@ module.exports = {
       dialogs: {
         identity: false,
       },
-      announced: true
+      announced: true,
+      pages: this.$router.options.routes.filter(page => page.meta.listed)
     };
   },
   components: {
@@ -210,11 +211,6 @@ module.exports = {
   computed: {
     announcement_dialog() {
       return !this.announced
-    },
-    pages() {
-      return this.$router.options.routes.filter((page) => {
-        return page.meta.listed;
-      });
     },
   },
   watch: {
@@ -234,6 +230,16 @@ module.exports = {
         console.log(response.data)
         this.announced = response.data["announced"];
         this.$api.announcement.announce();
+      });
+    },
+    isFarmManagementInstalled() {
+      this.$api.packages.getInstalled().then(response => {
+        let installed = JSON.parse(response.data).data.includes("farmmanagement");
+        if (!installed){
+          this.pages = this.pages.filter(item => item.name != "Farm Management");
+        }else{
+          this.pages = this.$router.options.routes.filter(page => page.meta.listed);
+        }
       });
     },
     getIdentity() {
@@ -286,6 +292,7 @@ module.exports = {
     this.getAnnouncementStatus();
     this.setTimeLocal();
     this.getSDKVersion();
+    this.isFarmManagementInstalled();
     this.clockInterval = setInterval(() => {
       this.setTimeLocal();
     }, 1000);

--- a/jumpscale/packages/admin/frontend/components/external/FarmManagement.vue
+++ b/jumpscale/packages/admin/frontend/components/external/FarmManagement.vue
@@ -8,8 +8,9 @@
       return {
         package: true,
         name: "farmmanagement",
-        url: "/farmmanagement/"
+        url: "/farmmanagement/",
+        giturl: null
       }
-    }
+    },
   }
 </script>

--- a/jumpscale/packages/admin/frontend/components/packages/Packages.vue
+++ b/jumpscale/packages/admin/frontend/components/packages/Packages.vue
@@ -65,6 +65,7 @@
     methods: {
       listPackages () {
         this.loading = true
+        this.$emit("updatesidebarlist");
         this.$api.packages.list().then((response) => {
           this.packages = JSON.parse(response.data).data
         }).finally (() => {


### PR DESCRIPTION
### Changes

- Hide farm management item from the sidebar if not installed
-  Fix `github` key error.


### Related Issues

- [Farm mgmt in main 3bot menu while irrelevant for non farmers](https://github.com/threefoldtech/js-sdk/issues/1824)
### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
