### PR TITLE
add tool to calculate vdc price

### DIFF
--- a/jumpscale/tools/zos/consumption/__init__.py
+++ b/jumpscale/tools/zos/consumption/__init__.py
@@ -1,1 +1,1 @@
-from .usage import cloud_units, cost
+from .usage import cloud_units, cost, calculate_vdc_price

--- a/jumpscale/tools/zos/consumption/usage.py
+++ b/jumpscale/tools/zos/consumption/usage.py
@@ -1,8 +1,10 @@
+from decimal import Decimal
 from typing import Union
 
 from jumpscale.clients.explorer.models import (
     CloudUnits,
     Container,
+    DiskType,
     Gateway4to6,
     GatewayDelegate,
     GatewayProxy,
@@ -15,6 +17,8 @@ from jumpscale.clients.explorer.models import (
     Volume,
     ZdbNamespace,
 )
+from jumpscale.loader import j
+from jumpscale.sals.vdc.size import THREEBOT_CPU, THREEBOT_DISK, THREEBOT_MEMORY, VDC_SIZE
 
 
 def cloud_units(
@@ -75,6 +79,83 @@ def cost(
     # (su_prince/tft_price) / month  = 0.00002572
     compute_unit_TFT_cost_second = 0.00002572
     storage_unit_TFT_cost_second = 0.00002572
+    ipv4_unit_TFT_cost_second = 0.00002572
     cu = cloud_units(workload)
-    price = cu.cost(compute_unit_TFT_cost_second, storage_unit_TFT_cost_second, duration)
+    price = cu.cost(compute_unit_TFT_cost_second, storage_unit_TFT_cost_second, ipv4_unit_TFT_cost_second, duration)
     return price
+
+
+def calculate_vdc_price(flavor):
+    """calculate the workloads price for vdcs in TFT
+
+    Args:
+        flavor (str): vdc flavor in [silver, gold, platinum, diamond]
+
+    Returns:
+        str: vdc price
+    """
+    all_cus = 0
+    all_sus = 0
+    all_ipv4us = 0
+
+    # get the flavor enum
+    for item in VDC_SIZE.VDC_FLAVORS.keys():
+        if flavor == item.value:
+            flavor = item
+
+    # calculate cloud units enough for a month
+    def get_cloud_units(workload):
+        ru = workload.resource_units()
+        cloud_units = ru.cloud_units()
+        return (
+            cloud_units.cu * 60 * 60 * 24 * 30,
+            cloud_units.su * 60 * 60 * 24 * 30,
+            cloud_units.ipv4u * 60 * 60 * 24 * 30,
+        )
+
+    # get zdbs usage
+    zdb = ZdbNamespace()
+    zdb.size = VDC_SIZE.S3_ZDB_SIZES[VDC_SIZE.VDC_FLAVORS[flavor]["s3"]["size"]]["sru"]
+    zdb.disk_type = DiskType.HDD
+    _, sus, _ = get_cloud_units(zdb)
+    all_cus += sus
+
+    # get kubernetes controller usage
+    master_size = VDC_SIZE.VDC_FLAVORS[flavor]["k8s"]["controller_size"]
+    k8s = K8s()
+    k8s.size = master_size.value
+    cus, sus, ipv4us = get_cloud_units(k8s)
+
+    all_cus += cus
+    all_sus += sus
+    all_ipv4us += ipv4us
+
+    # get kubernetes workers usage
+    no_nodes = VDC_SIZE.VDC_FLAVORS[flavor]["k8s"]["no_nodes"]
+    worker_size = VDC_SIZE.VDC_FLAVORS[flavor]["k8s"]["size"]
+    k8s = K8s()
+    k8s.size = worker_size.value
+    cus, sus, ipv4us = get_cloud_units(k8s)
+
+    all_cus += cus * (no_nodes + 1)
+    all_sus += sus * (no_nodes + 1)
+
+    # get 3bot container usage
+    cont2 = Container()
+    cont2.capacity.cpu = THREEBOT_CPU
+    cont2.capacity.memory = THREEBOT_MEMORY
+    cont2.capacity.disk_size = THREEBOT_DISK
+    cont2.capacity.disk_type = DiskType.SSD
+    n_cus, n_sus, _ = get_cloud_units(cont2)
+
+    all_cus += n_cus
+    all_sus += n_sus
+
+    # create empty pool and get the payment amount
+    zos = j.sals.zos.get()
+    pool = zos.pools.create(round(all_cus), round(all_sus), round(all_ipv4us), "freefarm")
+    amount = pool.escrow_information.amount
+    total_amount_dec = Decimal(amount) / Decimal(1e7)
+    total_amount = "{0:f}".format(total_amount_dec)
+
+    return f"{float(total_amount)} TFT"


### PR DESCRIPTION
### Description

```
(.venv) ➜  js-sdk git:(development_vdc_prices) ✗ jsng
JS-NG> j.tools.zos.consumption.calculate_vdc_price("silver")                                         
'256.2518592 TFT'

JS-NG> j.tools.zos.consumption.calculate_vdc_price("gold")                                           
'751.2634656 TFT'

JS-NG> j.tools.zos.consumption.calculate_vdc_price("platinum")                                       
'2498.1102432 TFT'

JS-NG> j.tools.zos.consumption.calculate_vdc_price("gold")                                           
'751.2634656 TFT'
```

### Changes

- Add tool to calculate VDC price which contains (Kubernetes cluster, ZDB storage, 3Bot container)

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
