### PR TITLE
add option to use csfarmer or name.com

### DIFF
--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -125,6 +125,9 @@ class SolutionsChatflowDeploy(GedisChatBot):
             for domain in gateway.managed_domains:
                 self.addresses = []
                 is_managed_domains = True
+                # vdc 3bot to be vdctest.grid.tf, solutions to be webg1test.grid.tf or alike
+                if domain.startswith("vdc") or domain.startswith("3bot"):
+                    continue
                 if domain in blocked_domains:
                     continue
                 success = deployer.test_managed_domain(

--- a/jumpscale/sals/vdc/namemanager.py
+++ b/jumpscale/sals/vdc/namemanager.py
@@ -1,0 +1,31 @@
+import os
+from jumpscale.loader import j
+
+
+class NameManager:
+    def __init__(self, domain_type="namecom", pool_id=None, gateway=None, proxy_instance=None, exposed_wid=None):
+        self.domain_type = domain_type
+        self.gateway = gateway
+        self.proxy_instance = proxy_instance
+        self.pool_id = pool_id
+
+    def create_subdomain(self, parent_domain=None, prefix=None, ip_addresses=None, vdc_uuid=None):
+        if self.domain_type == "namecom":
+            nc = j.clients.name.get("VDC")
+            nc.username = os.environ.get("VDC_NAME_USER")
+            nc.token = os.environ.get("VDC_NAME_TOKEN")
+            existing_records = nc.nameclient.list_records_for_host(parent_domain, prefix)
+            if existing_records:
+                for record_dict in existing_records:
+                    nc.nameclient.delete_record(record_dict["fqdn"][:-1], record_dict["id"])
+
+            for address in ip_addresses:
+                nc.nameclient.create_record(parent_domain, prefix, "A", address)
+            return f"{prefix}.{parent_domain}", None
+        else:
+            prefix = prefix.rstrip(".vdc")
+            domain_generator = self.proxy_instance.reserve_subdomain(
+                self.gateway, prefix, vdc_uuid, pool_id=self.pool_id, ip_address=ip_addresses[0]
+            )
+            subdomain, subdomain_id = next(domain_generator)
+            return subdomain, subdomain_id

--- a/jumpscale/sals/vdc/proxy.py
+++ b/jumpscale/sals/vdc/proxy.py
@@ -219,9 +219,11 @@ class VDCProxy(VDCBaseComponent):
         if not pool_id:
             return None
 
-        random.shuffle(gateway.managed_domains)
         for managed_domain in gateway.managed_domains:
             self.vdc_deployer.info(f"reserving subdomain of {managed_domain}")
+            # vdc 3bot to be vdctest.grid.tf, solutions to be webg1test.grid.tf or alike
+            if not managed_domain.startswith("vdc"):
+                continue
             subdomain = f"{prefix}.{managed_domain}"
             addresses = None
 

--- a/jumpscale/sals/vdc/size.py
+++ b/jumpscale/sals/vdc/size.py
@@ -48,9 +48,9 @@ class NETWORK_FARM(FarmConfigBase):
 
 
 class PROXY_FARM(FarmConfigBase):
-    devnet = "lochristi_dev_lab"
-    testnet = "freefarm"
-    mainnet = "freefarm"
+    devnet = "csfarmer"
+    testnet = "csfarmer"
+    mainnet = "csfarmer"
 
 
 def get_explorer_network():


### PR DESCRIPTION
### Description

to use set it in the config manager

gateway: `j.config.set("VDC_DOMAIN_SOURCE", "gateway")`
name.com: `j.config.set("VDC_DOMAIN_SOURCE", "namecom")`

default value will be using `gateway` which defaults to `csfarmer`, to make development locally easier