### PR TITLE
Fail if chart didn't deploy because of low resources

### DIFF
--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -327,7 +327,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
         while time() - start_time <= POD_INITIALIZING_TIMEOUT:
             if not self.doesnt_contain_resources():
                 break
-                gevent.sleep(1)
+            gevent.sleep(1)
 
         if self.doesnt_contain_resources():
             stop_message = error_message_template.format(

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -10,6 +10,7 @@ from jumpscale.sals.reservation_chatflow import deployment_context, DeploymentFa
 from jumpscale.sals.marketplace import deployer, solutions
 from jumpscale.clients.explorer.models import WorkloadType
 from jumpscale.sals.vdc.models import KubernetesRole
+import gevent
 
 CHART_LIMITS = {
     "Silver": {"cpu": "1000m", "memory": "1024Mi"},
@@ -326,6 +327,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
         while time() - start_time <= POD_INITIALIZING_TIMEOUT:
             if not self.doesnt_contain_resources():
                 break
+                gevent.sleep(1)
 
         if self.doesnt_contain_resources():
             stop_message = error_message_template.format(

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -334,7 +334,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
                 break
             gevent.sleep(1)
 
-        if self.chart_pods_started() and self.chart_resource_failure():
+        if not self.chart_pods_started() and self.chart_resource_failure():
             stop_message = error_message_template.format(
                 reason="Couldn't find resources in the cluster for the solution"
             )

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -4,6 +4,7 @@ import requests
 import uuid
 import os
 from textwrap import dedent
+from time import time
 
 from jumpscale.loader import j
 from jumpscale.sals.chatflows.chatflows import GedisChatBot, StopChatFlow, chatflow_step
@@ -21,7 +22,6 @@ RESOURCE_VALUE_TEMPLATE = {"cpu": "CPU {}", "memory": "Memory {}"}
 HELM_REPOS = {"marketplace": {"name": "marketplace", "url": "https://threefoldtech.github.io/vdc-solutions-charts/"}}
 VDC_ENDPOINT = "/vdc"
 PREFERRED_FARM = "csfarmer"
-from time import time
 
 
 class SolutionsChatflowDeploy(GedisChatBot):

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -323,7 +323,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
                 Reason: {{reason}}
                 """
         start_time = time()
-        POD_INITIALIZING_TIMEOUT = 60
+        POD_INITIALIZING_TIMEOUT = 120
         while time() - start_time <= POD_INITIALIZING_TIMEOUT:
             if not self.doesnt_contain_resources():
                 break

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -22,6 +22,7 @@ RESOURCE_VALUE_TEMPLATE = {"cpu": "CPU {}", "memory": "Memory {}"}
 HELM_REPOS = {"marketplace": {"name": "marketplace", "url": "https://threefoldtech.github.io/vdc-solutions-charts/"}}
 VDC_ENDPOINT = "/vdc"
 PREFERRED_FARM = "csfarmer"
+POD_INITIALIZING_TIMEOUT = 120
 
 
 class SolutionsChatflowDeploy(GedisChatBot):
@@ -323,7 +324,6 @@ class SolutionsChatflowDeploy(GedisChatBot):
                 Reason: {{reason}}
                 """
         start_time = time()
-        POD_INITIALIZING_TIMEOUT = 120
         while time() - start_time <= POD_INITIALIZING_TIMEOUT:
             if self.chart_pods_started():
                 break

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -20,6 +20,7 @@ RESOURCE_VALUE_TEMPLATE = {"cpu": "CPU {}", "memory": "Memory {}"}
 HELM_REPOS = {"marketplace": {"name": "marketplace", "url": "https://threefoldtech.github.io/vdc-solutions-charts/"}}
 VDC_ENDPOINT = "/vdc"
 PREFERRED_FARM = "csfarmer"
+from time import time
 
 
 class SolutionsChatflowDeploy(GedisChatBot):
@@ -298,18 +299,45 @@ class SolutionsChatflowDeploy(GedisChatBot):
             extra_config=self.chart_config,
         )
 
+    def doesnt_contain_resources(self):
+        pods_info = self.k8s_client.execute_native_cmd(
+            cmd=f"kubectl get pods -l app.kubernetes.io/name={self.SOLUTION_TYPE} -l app.kubernetes.io/instance={self.release_name} -o=jsonpath='{{.items[*].status.conditions[0].message}}'"
+        )
+        pods_status_info = self.k8s_client.execute_native_cmd(
+            cmd=f"kubectl get pods -l app.kubernetes.io/name={self.SOLUTION_TYPE} -l app.kubernetes.io/instance={self.release_name} -o=jsonpath='{{.items[*].status.phase}}'"
+        )
+        if "Pending" in pods_status_info and "Insufficient" in pods_info:
+            return True
+        return False
+
     @chatflow_step(title="Initializing", disable_previous=True)
     def initializing(self, timeout=300):
         self.md_show_update(f"Initializing your {self.SOLUTION_TYPE}...")
-
-        if not j.sals.reservation_chatflow.wait_http_test(f"https://{self.domain}", timeout=timeout, verify=False):
-            stop_message = f"""\
+        error_message_template = f"""\
                 Failed to initialize {self.SOLUTION_TYPE}, please contact support with this information:
 
                 Domain: {self.domain}
                 VDC Name: {self.vdc_name}
                 Farm name: {self.vdc_info["farm_name"]}
+                Reason: {{reason}}
                 """
+        start_time = time()
+        POD_INITIALIZING_TIMEOUT = 60
+        while time() - start_time <= POD_INITIALIZING_TIMEOUT:
+            if not self.doesnt_contain_resources():
+                break
+
+        if self.doesnt_contain_resources():
+            stop_message = error_message_template.format(
+                reason="Couldn't find resources in the cluster for the solution"
+            )
+            self.k8s_client.delete_deployed_release(self.release_name)
+            self.stop(dedent(stop_message))
+
+        if not j.sals.reservation_chatflow.wait_http_test(
+            f"https://{self.domain}", timeout=timeout - POD_INITIALIZING_TIMEOUT, verify=False
+        ):
+            stop_message = error_message_template.format(reason="Couldn't reach the website after deployment")
             self.stop(dedent(stop_message))
 
     @chatflow_step(title="Success", disable_previous=True, final_step=True)


### PR DESCRIPTION
### Description

When the pod requests resources not available in the cluster, it gets stuck at "PENDING" state. In this PR it waits for the pods in the chart deployment for two minutes, if at any moment all pods got to RUNNING state it assumes there's enough resources. Otherwise,  after the two minutes it checks it at least on of the pods is pending and the last error message contained "Insufficient", if so it decides that there's no enough resources and removes chart.

Summary:
1. It deploys the chart and waits for it to fail to decide insufficient resources.