### PR TITLE
change the postgres subchart across different deployments

### DIFF
--- a/jumpscale/packages/vdc_dashboard/chats/taiga.py
+++ b/jumpscale/packages/vdc_dashboard/chats/taiga.py
@@ -15,6 +15,7 @@ class TaigaDeploy(SolutionsChatflowDeploy):
         self.chart_config.update(
             {
                 "domain": self.domain,
+                "postgresql.fullnameOverride": f"taiga-postgresql-{self.release_name}",
                 "resources.limits.cpu": self.resources_limits["cpu"],
                 "resources.limits.memory": self.resources_limits["memory"],
             }


### PR DESCRIPTION
### Description

A conflict happens in two different releases of taiga because the postgres subchart name was fixed.

### Changes

Include the release name in the postgres subchart name