### PR TITLE
migrate threebot deployer and threebot server to use STD wallet

### DIFF
--- a/jumpscale/entry_points/threebot.py
+++ b/jumpscale/entry_points/threebot.py
@@ -248,21 +248,11 @@ def cli():
 
 def have_wallets():
     wallets = j.clients.stellar.list_all()
-    test, main = False, False
     for wallet_name in wallets:
         wallet = j.clients.stellar.get(wallet_name)
-        if wallet.network.value == "TEST":
-            test = True
-        elif wallet.network.value == "STD":
-            main = True
-    return test, main
-
-
-def create_test_wallet(wallet_name):
-    try:
-        j.clients.stellar.create_testnet_funded_wallet(wallet_name)
-    except Exception as e:
-        j.logger.error(str(e))
+        if wallet.network.value == "STD":
+            return True
+    return False
 
 
 def create_main_wallet(wallet_name):
@@ -274,14 +264,12 @@ def create_main_wallet(wallet_name):
 
 
 def create_wallets_if_not_exists():
-    test, main = have_wallets()
+    main_wallet = have_wallets()
     if not j.core.identity.is_configured:
         j.logger.warning("skipping wallets creation, identity isn't configured yet")
         return
     else:
-        if not test and "testnet" in j.core.identity.me.explorer_url:
-            create_test_wallet("test")
-        if not main and "explorer.grid.tf" in j.core.identity.me.explorer_url:
+        if not main_wallet:
             create_main_wallet("main")
 
 

--- a/jumpscale/packages/threebot_deployer/package.py
+++ b/jumpscale/packages/threebot_deployer/package.py
@@ -3,24 +3,24 @@ from jumpscale.loader import j
 
 class threebot_deployer:
     def install(self, **kwargs):
+        """
+        Args:
+            wallet_secret (str, optional): if you have the wallet secret already activated you can pass it. Defaults to "STD".
+            channel_type (str, optional): if you want to forward logs to redis for example
+            channel_host (str, optional): hostname with public redis
+            channel_port (int, optional): remote redis port
+        """
         # Configure wallet
         WALLET_NAME = j.sals.marketplace.deployer.WALLET_NAME
         if WALLET_NAME not in j.clients.stellar.list_all():
             wallet_secret = kwargs.get("wallet_secret", None)
-            wallet_network = kwargs.get("wallet_network", "TEST")
-
-            wallet = j.clients.stellar.new(WALLET_NAME, secret=wallet_secret, network=wallet_network)
+            wallet = j.clients.stellar.new(WALLET_NAME, secret=wallet_secret)
 
             if not wallet_secret:
-                if wallet_network == "TEST":
-                    # in case of testnetwork, we'll create a funded wallet
-                    j.clients.stellar.delete(WALLET_NAME)
-                    j.clients.stellar.create_testnet_funded_wallet(WALLET_NAME)
-                else:
-                    # mainnet, activate and add trustlines to an empty wallet
-                    wallet.activate_through_threefold_service()
-                    wallet.add_known_trustline("TFT")
-                    wallet.save()
+                # mainnet, activate and add trustlines to an empty wallet
+                wallet.activate_through_threefold_service()
+                wallet.add_known_trustline("TFT")
+                wallet.save()
             j.logger.info(f"Created wallet {WALLET_NAME} successfully and ready to use.")
 
         # Configure Redis logs


### PR DESCRIPTION
### Description

- Limit 3bot deployer to only use STD wallets
- Limit 3bot deployer demos wallet to be STD

### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/2059

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
