### PR TITLE
disable wallet tests and add return xlms to activation wallet method

### DIFF
--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -18,6 +18,8 @@ from .balance import AccountBalances, Balance, EscrowAccount
 from .transaction import Effect, PaymentSummary, TransactionSummary
 from .exceptions import UnAuthorized
 
+XLM_TRANSACTION_FEES = 0.00001
+ACTIVATION_ADDRESS = "GCKLGWHEYT2V63HC2VDJRDWEY3G54YSHHPOA6Q3HAPQUGA5OZDWZL7KW"
 
 _THREEFOLDFOUNDATION_TFTSTELLAR_SERVICES = {"TEST": "testnet.threefold.io", "STD": "tokenservices.threefold.io"}
 _HORIZON_NETWORKS = {"TEST": "https://horizon-testnet.stellar.org", "STD": "https://horizon.stellar.org"}
@@ -344,6 +346,16 @@ class Stellar(Client):
         except stellar_sdk.exceptions.BadRequestError as e:
             j.logger.debug(e)
             raise e
+
+    def return_xlms_to_activation(self):
+        xlm_balance = 0
+        for balance in self.get_balances():
+            if balance.asset_code == "XLM":
+                xlm_balance = balance.balance
+        trustlines = len(self.get_balances()) - 1
+        minimum_balance = 1 + 0.5 * trustlines
+        amount = xlm_balance - minimum_balance - XLM_TRANSACTION_FEES
+        self.transfer(ACTIVATION_ADDRESS, amount)
 
     def transfer(
         self,
@@ -864,7 +876,7 @@ class Stellar(Client):
 
         Args:
             selling_asset (str): Selling Asset
-            buying_asset str): Buying Asset 
+            buying_asset str): Buying Asset
             amount (Union[str, decimal.Decimal]): Amount to sell.
             price (Union[str, decimal.Decimal]): Price for selling.
             timeout (int, optional): Timeout for submitting the transaction. Defaults to 30.

--- a/tests/clients/stellar/test_stellarclient.py
+++ b/tests/clients/stellar/test_stellarclient.py
@@ -2,27 +2,8 @@ import pytest
 from jumpscale.loader import j
 
 
+@pytest.mark.skip("https://github.com/threefoldtech/js-sdk/issues/2062")
 def test_stellar_client_get_asset_known_assets():
-
-    stellarclient = j.clients.stellar.new(j.data.random_names.random_name(), network="TEST")
-    # native XLM
-    asset = stellarclient._get_asset(code="XLM")
-    assert asset.is_native()
-    # No issuer supplied and unknown code
-    with pytest.raises(ValueError):
-        stellarclient._get_asset(code="unknown")
-    # testnet
-    asset = stellarclient._get_asset(code="TFT")
-    assert asset.code == "TFT"
-    assert asset.issuer == "GA47YZA3PKFUZMPLQ3B5F2E3CJIB57TGGU7SPCQT2WAEYKN766PWIMB3"
-    asset = stellarclient._get_asset(code="TFTA")
-    assert asset.code == "TFTA"
-    assert asset.issuer == "GB55A4RR4G2MIORJTQA4L6FENZU7K4W7ATGY6YOT2CW47M5SZYGYKSCT"
-    asset = stellarclient._get_asset(code="FreeTFT")
-
-    assert asset.code == "FreeTFT"
-    assert asset.issuer == "GBLDUINEFYTF7XEE7YNWA3JQS4K2VD37YU7I2YAE7R5AHZDKQXSS2J6R"
-
     # public network
     stellarclient = j.clients.stellar.new(j.data.random_names.random_name())
     asset = stellarclient._get_asset(code="TFT")

--- a/tests/frontend/tests/test_wallets.py
+++ b/tests/frontend/tests/test_wallets.py
@@ -4,6 +4,7 @@ from tests.frontend.tests.base_tests import BaseTest
 
 
 @pytest.mark.integration
+@pytest.mark.skip("https://github.com/threefoldtech/js-sdk/issues/2062")
 class WalletTests(BaseTest):
     def test01_create_delete_wallet(self):
         """Test case for creating a wallet and deleting it.


### PR DESCRIPTION
### Description

Disable tests that include wallet creation until a proper cleanup is presented.

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2062