### PR TITLE
update js-ng to 11.0b11...

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -591,7 +591,7 @@ tests = ["coverage (>=4.0)", "pytest-cache (>=1.0)", "pytest-cov", "flake8", "py
 
 [[package]]
 name = "js-ng"
-version = "11.0b10"
+version = "11.0b11"
 description = "system automation, configuration management and RPC framework"
 category = "main"
 optional = false
@@ -1488,7 +1488,7 @@ test = ["zope.security", "zope.testrunner"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "4c33924572b946c37a2f271045e4e669b7e7ca8150e5fee0b2e8364ccd905a42"
+content-hash = "a9177d6bc4cb606d19977aa8baae8708e28a964ed4fe4e540babba74e304e7b0"
 
 [metadata.files]
 acme = [
@@ -1783,8 +1783,8 @@ josepy = [
     {file = "josepy-1.4.0.tar.gz", hash = "sha256:c37ff4b93606e6a452b72cdb992da5e0544be12912fac01b31ddbdd61f6d5bd0"},
 ]
 js-ng = [
-    {file = "js-ng-11.0b10.tar.gz", hash = "sha256:d90c47a13607742accb33dd97c0c7c2e8ca07fc1f20a75b7ff267b12b4210bde"},
-    {file = "js_ng-11.0b10-py3-none-any.whl", hash = "sha256:4e88b2e4cb3e651aac6160b0ee5aa9bd609e988a68ca4b9c7f7d8a59c5be6979"},
+    {file = "js-ng-11.0b11.tar.gz", hash = "sha256:3a02fafdab0df4ac985677080daab46019ec25cbb562fd92d9674504d5991366"},
+    {file = "js_ng-11.0b11-py3-none-any.whl", hash = "sha256:4461a75a281345d46d961b1527a216ef3e00c720f4599be19a4e7504ef846ccb"},
 ]
 jsonpickle = [
     {file = "jsonpickle-1.4.1-py2.py3-none-any.whl", hash = "sha256:8919c166bac0574e3d74425c7559434062002d9dfc0ac2afa6dc746ba4a19439"},
@@ -2026,6 +2026,7 @@ pycryptodomex = [
     {file = "pycryptodomex-3.9.8-cp38-cp38-win_amd64.whl", hash = "sha256:914fbb18e29c54585e6aa39d300385f90d0fa3b3cc02ed829b08f95c1acf60c2"},
     {file = "pycryptodomex-3.9.8-cp39-cp39-manylinux1_i686.whl", hash = "sha256:35b9c9177a9fe7288b19dd41554c9c8ca1063deb426dd5a02e7e2a7416b6bd11"},
     {file = "pycryptodomex-3.9.8-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:e070a1f91202ed34c396be5ea842b886f6fa2b90d2db437dc9fb35a26c80c060"},
+    {file = "pycryptodomex-3.9.8.tar.gz", hash = "sha256:48cc2cfc251f04a6142badeb666d1ff49ca6fdfc303fd72579f62b768aaa52b9"},
 ]
 pygithub = [
     {file = "PyGithub-1.53-py3-none-any.whl", hash = "sha256:8ad656bf79958e775ec59f7f5a3dbcbadac12147ae3dc42708b951064096af15"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 cryptography = "3.0"
-js-ng = "11.0b10"
+js-ng = "11.0b11"
 greenlet = "0.4.16"
 python = "^3.6"
 captcha = "^0.3"


### PR DESCRIPTION
### Description

Update `js-ng` version to 11.0b11 to use allow_cors in gedis http server

### Changes

Update pyproject.toml and poetry.lock files

### Related Issues

#2110

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
