### PR TITLE
Add two buttons to download z-stor config and zdbs data

### DIFF
--- a/jumpscale/packages/vdc_dashboard/bottle/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/deployments.py
@@ -159,6 +159,14 @@ def cancel_deployment():
     return j.data.serializers.json.dumps({"result": True})
 
 
+@app.route("/api/formattoml", method="POST")
+@authenticated
+def formattoml():
+    request_data = j.data.serializers.json.loads(request.body.read())
+    data = request_data.get("data")
+    return j.data.serializers.json.dumps({"data": j.data.serializers.toml.dumps(data)})
+
+
 @app.route("/api/allowed", method="GET")
 @authenticated
 def allowed():

--- a/jumpscale/packages/vdc_dashboard/frontend/api.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/api.js
@@ -59,7 +59,15 @@ const apiClient = {
         data: { wid: wid },
         headers: { 'Content-Type': 'application/json' }
       })
-    }
+    },
+    formatTOML: (obj) => {
+      return axios({
+        url: `${baseURL}/formattoml`,
+        method: "post",
+        data: { data: obj },
+        headers: { 'Content-Type': 'application/json' }
+      })
+    },
   },
   license: {
     accept: () => {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/S3.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/S3.vue
@@ -2,7 +2,22 @@
   <div>
     <div class="actions mb-3">
       <h1 class="d-inline" color="primary" text>Storage Nodes</h1>
-
+      <v-btn
+        class="float-right p-4"
+        color="primary"
+        text
+        @click.stop="(dialogs.downloadInfo = true), (downloadType = 'zstor')"
+      >
+        <v-icon left>mdi-download</v-icon>Z-STOR Config
+      </v-btn>
+      <v-btn
+        class="float-right p-4"
+        color="primary"
+        text
+        @click.stop="(dialogs.downloadInfo = true), (downloadType = 'zdbs')"
+      >
+        <v-icon left>mdi-download</v-icon>Zdbs Info
+      </v-btn>
       <v-btn
         v-if="S3URL"
         class="float-right p-4"
@@ -12,10 +27,13 @@
         <v-icon color="primary" class="mr-2" left>mdi-web</v-icon>Storage
         Browser
       </v-btn>
-
-
     </div>
-    <v-data-table :headers="headers" :loading="loading" :items="zdbs" class="elevation-1">
+    <v-data-table
+      :headers="headers"
+      :loading="loading"
+      :items="zdbs"
+      class="elevation-1"
+    >
       <template slot="no-data">No VDC instance available</template>
       <template v-slot:item.wid="{ item }">
         <div>{{ item.wid }}</div>
@@ -29,13 +47,37 @@
         <div>{{ item.size }} GB</div>
       </template>
     </v-data-table>
+    <base-dialog
+      title="Download storage nodes Information file"
+      v-model="dialogs.downloadInfo"
+      v-if="dialogs.downloadInfo"
+    >
+      <template #default>
+        <p v-if="downloadType === 'zdbs'">
+          WARINING: Please keep the storage nodes Information safe and secure.
+        </p>
+        <p v-else-if="downloadType === 'zstor'">
+          WARINING: You should update the TOML file with your custom
+          configurations as documented
+          <a
+            href="https://github.com/threefoldtech/0-stor_v2#config-file"
+            target="blank"
+            >here</a
+          >.
+        </p>
+      </template>
+      <template #actions>
+        <v-btn text color="error" @click="downloadFile()">Download</v-btn>
+      </template>
+    </base-dialog>
   </div>
 </template>
 
 
 <script>
 module.exports = {
-  props: ["vdc", "loading"],
+  props: ["vdc"],
+  mixins: [dialog],
   data() {
     return {
       selected: null,
@@ -45,23 +87,76 @@ module.exports = {
         { text: "Disk Size", value: "size" },
       ],
       S3URL: null,
+      downloadType: null,
+      dialogs: {
+        downloadInfo: false,
+      },
     };
   },
   methods: {
-    exposeS3() {
-      this.loading = true;
-      this.$api.solutions
-        .exposeS3()
-        .then((response) => {
-          location.reload();
-        })
-        .catch((error) => {
-          console.log(`${error.message}`);
-          this.loading = false;
-        })
-        .finally(() => {
-          this.loading = false;
-        });
+    downloadFile() {
+      let data = null;
+      let fileType = null;
+      if (this.downloadType === "zdbs") {
+        fileType = "json";
+        data = JSON.stringify(this.vdc.s3.zdbs, null, "\t");
+        const blob = new Blob([data]);
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.setAttribute(
+          "download",
+          `${this.vdc.vdc_name}ZDBsInfo.${fileType}`
+        );
+        document.body.appendChild(link);
+        link.click();
+        link.parentNode.removeChild(link);
+        this.dialogs.downloadInfo = false;
+      } else if (this.downloadType === "zstor") {
+        fileType = "toml";
+        data = {
+          data_shards: 2,
+          parity_shards: 1,
+          redundant_groups: 0,
+          redundant_nodes: 0,
+          encryption: {
+            algorithm: "AES",
+            key: "",
+          },
+          compression: {
+            algorithm: "snappy",
+          },
+          groups: [],
+        };
+        for (i in this.vdc.s3.zdbs) {
+          let zdb = this.vdc.s3.zdbs[i];
+          data.groups.push({
+            address: `[${zdb.ip_address}]:${zdb.port}`,
+            namespace: zdb.namespace,
+          });
+        }
+        this.loading = true;
+        this.$api.solutions
+          .formatTOML(data)
+          .then((response) => {
+            data = response.data.data;
+            const blob = new Blob([data]);
+            const url = window.URL.createObjectURL(blob);
+            const link = document.createElement("a");
+            link.href = url;
+            link.setAttribute(
+              "download",
+              `${this.vdc.vdc_name}ZDBsInfo.${fileType}`
+            );
+            document.body.appendChild(link);
+            link.click();
+            link.parentNode.removeChild(link);
+            this.dialogs.downloadInfo = false;
+          })
+          .finally(() => {
+            this.loading = false;
+          });
+      }
     },
   },
   computed: {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/36021484/103551771-84db2900-4eb3-11eb-8329-6bcf08da83e1.png)
![image](https://user-images.githubusercontent.com/36021484/103552598-d3d58e00-4eb4-11eb-9553-f18802cb90d6.png)

### Related Issues

- [VDC: generate 0-stor config file to utilize the zdbs](https://github.com/threefoldtech/js-sdk/issues/2102)
### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
