### PR TITLE
add option to clear blocked domains

### DIFF
--- a/jumpscale/sals/reservation_chatflow/deployer.py
+++ b/jumpscale/sals/reservation_chatflow/deployer.py
@@ -2043,6 +2043,15 @@ As an example, if you want to be able to run some workloads that consumes `5CU` 
             result[node_id] = {"expiration": expiration, "failure_count": failure_count}
         return result
 
+    def clear_blocked_managed_domains(self):
+        blocked_domains_keys = j.core.db.keys(f"{DOMAINS_DISALLOW_PREFIX}:*")
+
+        if blocked_domains_keys:
+            j.core.db.delete(*blocked_domains_keys)
+        j.core.db.delete(DOMAINS_COUNT_KEY)
+
+        return True
+
     def wait_workload_deletion(self, wid, timeout=5, identity_name=None):
         j.logger.info(f"waiting workload {wid} to be deleted")
         zos = j.sals.zos.get(identity_name)


### PR DESCRIPTION
### Description

```
JS-NG> j.sals.reservation_chatflow.deployer.block_managed_domain("3bottest.grid.tf")                 
JS-NG> j.sals.reservation_chatflow.deployer.list_blocked_managed_domains()                           
{'3bottest.grid.tf': {'expiration': 1610311404, 'failure_count': 2}}

JS-NG> j.sals.reservation_chatflow.deployer.list_blocked_managed_domains()                           
{'3bottest.grid.tf': {'expiration': 1610311404, 'failure_count': 2}}

JS-NG> j.sals.reservation_chatflow.deployer.clear_blocked_managed_domains()                          
True

JS-NG> j.sals.reservation_chatflow.deployer.list_blocked_managed_domains()                           
{}
```

### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/2154

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
