### PR TITLE
start vdc with only one worker for all flavors

### DIFF
--- a/jumpscale/sals/vdc/deployer.py
+++ b/jumpscale/sals/vdc/deployer.py
@@ -375,7 +375,7 @@ class VDCDeployer:
             VDC_SIZE.VDC_FLAVORS[self.flavor]["k8s"]["size"],
             cluster_secret,
             [self.ssh_key.public_key.strip()],
-            no_nodes,
+            1,
             duration=INITIAL_RESERVATION_DURATION / 24,
             solution_uuid=self.vdc_uuid,
             external=False,
@@ -429,7 +429,7 @@ class VDCDeployer:
         if not gcc.add_query(**master_query):
             return False
 
-        worker_query = {"farm_name": farm_name, "no_nodes": plan["k8s"]["no_nodes"]}
+        worker_query = {"farm_name": farm_name, "no_nodes": 1}
         worker_query.update(VDC_SIZE.K8S_SIZES[plan["k8s"]["size"]])
         if not gcc.add_query(**worker_query):
             return False


### PR DESCRIPTION
### Description

change initial vdc deployment to use only one worker for all flavors 

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2123

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
