### PR TITLE
Add locations from package.toml for default server

### DIFF
--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -42,7 +42,7 @@ class NginxPackageConfig:
         default_server = {
             "name": "default",
             "ports": self.package.config.get("ports"),
-            "locations": [],
+            "locations": self.package.config.get("locations", []),
             "domain": self.package.default_domain,
             "letsencryptemail": self.package.default_email,
             "acme_server_type": self.package.default_acme_server_type,


### PR DESCRIPTION
### Description

Add option to add custom locations to the default server instead of custom servers

### Changes
- Add locations from package.toml that would be added for example in the following custom location
```
[[locations]]
name = "custom"
type = "custom"
custom_config = """
location /customlocation/ {
    rewrite /customlocation/(.*)$ /customlocation_redirection/$1;
}
"""
```

### Related Issues

- To be used for https://github.com/threefoldfoundation/tft-stellar/issues/262 to add multiple custom locations for different packages in the same location server(default)

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
