### PR TITLE
Add missing fields in the stellar client

### DIFF
--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -71,6 +71,8 @@ class Network(Enum):
 class Stellar(Client):
     network = fields.Enum(Network)
     address = fields.String()
+    sequence = fields.Integer()
+    sequencedate = fields.Integer()
 
     def secret_updated(self, value):
         self.address = stellar_sdk.Keypair.from_secret(value).public_key


### PR DESCRIPTION
### Description
Two fields were missing in the definition of the stellar client, resulting in an AttributeError when reaching code that depends on them.
This fixes [Error in the tx funding service](https://github.com/threefoldfoundation/tft-stellar/issues/264)

