### PR TITLE
Development vdc 3bot keys socat

### DIFF
--- a/docs/vdc/forwarding_ports_using_socat.md
+++ b/docs/vdc/forwarding_ports_using_socat.md
@@ -1,0 +1,14 @@
+# To forward certain ports using socat to a specific service
+in your chat flow do the following
+
+```
+@chatflow_step(title="forwardingports")
+    def forward_ports(self):
+        super()._forward_ports({
+            "<service-name>": {"src": <src-port>, "dest": <destination-port>, "protocol": "TCP"}})
+
+```
+where
+service-name: is your service name that you want to expose
+src-port: the port on host you want your service to be reachable through
+dest-port: the port of your service which is accessible from the cluster

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
@@ -177,4 +177,4 @@ wallet.save()
 if THREEBOT_PRIVATE_KEY:
     with open("/root/.ssh/id_rsa", "w") as f:
         f.writelines(THREEBOT_PRIVATE_KEY)
-    j.sals.fs.chmod("/root/.ssh/id_rsa", 600)
+    j.sals.fs.chmod("/root/.ssh/id_rsa", 0o600)

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
@@ -177,4 +177,4 @@ wallet.save()
 if THREEBOT_PRIVATE_KEY:
     with open("/root/.ssh/id_rsa", "w") as f:
         f.writelines(THREEBOT_PRIVATE_KEY)
-        j.sals.fs.chmod("/root/.ssh/id_rsa", 600)
+    j.sals.fs.chmod("/root/.ssh/id_rsa", 600)

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
@@ -28,6 +28,7 @@ Required env variables:
 - PREPAID_WALLET_SECRET -> secret for prepaid wallet
 - PROVISIONING_WALLET_SECRET -> secret for provisioning wallet
 - ACME_SERVER_URL -> to use for package certificate
+- THREEBOT_PRIVATE_KEY -> private key to be set on threebot
 
 
 Role:
@@ -49,6 +50,7 @@ KUBE_CONFIG = os.environ.get("KUBE_CONFIG")
 PROVISIONING_WALLET_SECRET = os.environ.get("PROVISIONING_WALLET_SECRET")
 PREPAID_WALLET_SECRET = os.environ.get("PREPAID_WALLET_SECRET")
 ACME_SERVER_URL = os.environ.get("ACME_SERVER_URL")
+THREEBOT_PRIVATE_KEY = os.environ.get("THREEBOT_PRIVATE_KEY")
 
 
 vdc_dict = j.data.serializers.json.loads(VDC_INSTANCE)
@@ -172,3 +174,7 @@ wallet = j.clients.stellar.get(
     name=f"provision_wallet_{vdc.solution_uuid}", secret=PROVISIONING_WALLET_SECRET, network=network
 )
 wallet.save()
+if THREEBOT_PRIVATE_KEY:
+    with open("/root/.ssh/id_rsa", "w") as f:
+        f.writelines(THREEBOT_PRIVATE_KEY)
+        j.sals.fs.chmod("/root/.ssh/id_rsa", 600)

--- a/jumpscale/packages/vdc_dashboard/bottle/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/deployments.py
@@ -166,7 +166,8 @@ def cancel_deployment():
         abort(400, "Error: Not all required params was passed.")
     config_path = j.sals.fs.expanduser("~/.kube/config")
     k8s_client = j.sals.kubernetes.Manager(config_path=config_path)
-    k8s_client.delete_deployed_release(data["release"])
+    vdc = _get_vdc()
+    k8s_client.delete_deployed_release(release=data["release"], vdc=vdc)
     j.sals.marketplace.solutions.cancel_solution_by_uuid(data["solution_id"])
     return j.data.serializers.json.dumps({"result": True})
 

--- a/jumpscale/packages/vdc_dashboard/bottle/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/deployments.py
@@ -167,7 +167,7 @@ def cancel_deployment():
     config_path = j.sals.fs.expanduser("~/.kube/config")
     k8s_client = j.sals.kubernetes.Manager(config_path=config_path)
     vdc = _get_vdc()
-    k8s_client.delete_deployed_release(release=data["release"], vdc=vdc)
+    k8s_client.delete_deployed_release(release=data["release"], vdc_instance=vdc)
     j.sals.marketplace.solutions.cancel_solution_by_uuid(data["solution_id"])
     return j.data.serializers.json.dumps({"result": True})
 

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -95,6 +95,21 @@ class SolutionsChatflowDeploy(GedisChatBot):
         self.admin_username = admin_username.value
         self.admin_password = admin_password.value
 
+    def get_k8s_sshclient(self, private_key_path="/root/.ssh/id_rsa", user="rancher"):
+        ssh_key = j.clients.sshkey.get(self.vdc_name)
+        ssh_key.private_key_path = private_key_path
+        ssh_key.load_from_file_system()
+        ssh_client = j.clients.sshclient.get(
+            self.vdc_name, user=user, host=self.vdc_info["master_ip"], sshkey=self.vdc_name
+        )
+        return ssh_client
+
+    def is_port_exposed(sshclient, src_port):
+        rc, out, err = ssh_client.sshclient.run(f"sudo netstat -tulpn | grep :{src_port}")
+        if rc == 0:
+            return True
+        return False
+
     def _forward_ports(self, port_forwards=None):
         """
         portforwards = {"<SERVICE_NAME>": {"src":<src_port>, "dest": <dest_port>} }
@@ -104,20 +119,21 @@ class SolutionsChatflowDeploy(GedisChatBot):
             }
 
         """
+        ssh_client = self.get_k8s_sshclient()
         port_forwards = port_forwards or {}
         for service, ports in port_forwards.items():
             if ports.get("src") and ports.get("dest"):
+                # Validate if the port not exposed
+                if is_port_exposed(ssh_client, ports.get("src")):
+                    j.logger.critical(
+                        f"VDC: Can not expose service with port {ports.get('src')} using socat, port already in use, error was rc:{rc}, out:{out}, error:{err}"
+                    )
+
                 cluster_ip = self.k8s_client.execute_native_cmd(
                     f"kubectl get service/{service} -o jsonpath='{{.spec.clusterIP}}'"
                 )
                 if cluster_ip and j.sals.fs.exists("/root/.ssh/id_rsa"):
                     socat = "/var/lib/rancher/k3s/data/current/bin/socat"
-                    ssh_key = j.clients.sshkey.get(self.vdc_name)
-                    ssh_key.private_key_path = "/root/.ssh/id_rsa"
-                    ssh_key.load_from_file_system()
-                    ssh_client = j.clients.sshclient.get(
-                        self.vdc_name, user="rancher", host=self.vdc_info["master_ip"], sshkey=self.vdc_name
-                    )
                     cmd = f"{socat} tcp-listen:{ports['src']},reuseaddr,fork tcp:{cluster_ip}:{ports['dest']}"
                     template = f"""#!/sbin/openrc-run
                     name="{service}"
@@ -126,7 +142,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
                     command_background=true
                     """
                     template = dedent(template)
-                    file_name = f"{self.release_name}-{service}"
+                    file_name = f"{self.release_name}-socat-{service}"
                     rc, out, err = ssh_client.sshclient.run(
                         f"sudo touch /etc/init.d/{file_name} && sudo chmod 777 /etc/init.d/{file_name} &&  echo '{template}' >> /etc/init.d/{file_name} && sudo rc-service {file_name} start",
                         warn=True,

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -126,8 +126,9 @@ class SolutionsChatflowDeploy(GedisChatBot):
                     command_background=true
                     """
                     template = dedent(template)
+                    file_name = f"{self.release_name}-{service}"
                     rc, out, err = ssh_client.sshclient.run(
-                        f"sudo touch /etc/init.d/{service} && sudo chmod 777 /etc/init.d/{service} &&  echo '{template}' >> /etc/init.d/{service} && sudo rc-service {service} start",
+                        f"sudo touch /etc/init.d/{file_name} && sudo chmod 777 /etc/init.d/{file_name} &&  echo '{template}' >> /etc/init.d/{file_name} && sudo rc-service {file_name} start",
                         warn=True,
                     )
                     if rc:

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -126,7 +126,10 @@ class SolutionsChatflowDeploy(GedisChatBot):
                 # Validate if the port not exposed
                 if self.is_port_exposed(ssh_client, ports.get("src")):
                     j.logger.critical(
-                        f"VDC: Can not expose service with port {ports.get('src')} using socat, port already in use, error was rc:{rc}, out:{out}, error:{err}"
+                        f"VDC: Can not expose service with port {ports.get('src')} using socat, port already in use"
+                    )
+                    raise StopChatFlow(
+                        f"VDC: Can not expose service with port {ports.get('src')} using socat, port already in use"
                     )
 
                 cluster_ip = self.k8s_client.execute_native_cmd(

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -106,7 +106,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
         """
         port_forwards = port_forwards or {}
         for service, ports in port_forwards.items():
-            if service.get("src") and service.get("dest"):
+            if ports.get("src") and ports.get("dest"):
                 cluster_ip = self.k8s_client.execute_native_cmd(
                     f"kubectl get service/{{service}} -o jsonpath='{{.spec.clusterIP}}'"
                 )
@@ -118,7 +118,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
                     ssh_client = j.clients.sshclient.get(
                         self.vdc_name, user="rancher", host=self.vdc_info["master_ip"], sshkey=self.vdc_name
                     )
-                    cmd = f"sudo {socat} tcp-listen:{ports['src']},reuseaddr,fork tcp:{cluster_ip}:{ports['dest']}"
+                    cmd = f"sudo {socat} tcp-listen:{ports.get('src')},reuseaddr,fork tcp:{cluster_ip}:{ports.get('dest')}"
                     rc, out, err = ssh_client.sshclient.run(cmd, warn=True)
                     if rc:
                         j.logger.critical(

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -108,7 +108,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
         for service, ports in port_forwards.items():
             if ports.get("src") and ports.get("dest"):
                 cluster_ip = self.k8s_client.execute_native_cmd(
-                    f"kubectl get service/{{service}} -o jsonpath='{{.spec.clusterIP}}'"
+                    f"kubectl get service/{service} -o jsonpath='{{.spec.clusterIP}}'"
                 )
                 if cluster_ip and j.sals.fs.exists("/root/.ssh/id_rsa"):
                     socat = "/var/lib/rancher/k3s/data/current/bin/socat"

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -104,7 +104,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
         )
         return ssh_client
 
-    def is_port_exposed(self, sshclient, src_port):
+    def is_port_exposed(self, ssh_client, src_port):
         rc, out, err = ssh_client.sshclient.run(f"sudo netstat -tulpn | grep :{src_port}")
         if rc == 0:
             return True

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -104,7 +104,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
         )
         return ssh_client
 
-    def is_port_exposed(sshclient, src_port):
+    def is_port_exposed(self, sshclient, src_port):
         rc, out, err = ssh_client.sshclient.run(f"sudo netstat -tulpn | grep :{src_port}")
         if rc == 0:
             return True
@@ -124,7 +124,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
         for service, ports in port_forwards.items():
             if ports.get("src") and ports.get("dest"):
                 # Validate if the port not exposed
-                if is_port_exposed(ssh_client, ports.get("src")):
+                if self.is_port_exposed(ssh_client, ports.get("src")):
                     j.logger.critical(
                         f"VDC: Can not expose service with port {ports.get('src')} using socat, port already in use, error was rc:{rc}, out:{out}, error:{err}"
                     )

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -105,7 +105,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
         return ssh_client
 
     def is_port_exposed(self, ssh_client, src_port):
-        rc, out, err = ssh_client.sshclient.run(f"sudo netstat -tulpn | grep :{src_port}")
+        rc, out, err = ssh_client.sshclient.run(f"sudo netstat -tulpn | grep :{src_port}", warn=True)
         if rc == 0:
             return True
         return False

--- a/jumpscale/sals/kubernetes/manager.py
+++ b/jumpscale/sals/kubernetes/manager.py
@@ -130,9 +130,32 @@ class Manager:
         Returns:
             str: output of the helm command
         """
+        # Getting k8s master IP
+        k8s_master_ip = ""
+        vdc_instance = j.sals.vdc.get(release)
+        for node in vdc_instance.kubernetes:
+            if node.role.value == "master":
+                k8s_master_ip = node.ip_address
+                break
+        else:
+            raise j.exceptions.Runtime(f"Failed to get the master ip for this release {release}")
+
         rc, out, err = self._execute(f"helm --kubeconfig {self.config_path} --namespace {namespace} delete {release}")
         if rc != 0:
             raise j.exceptions.Runtime(f"Failed to deploy chart {release} , error was {err}")
+
+        # Stop and remove Socat service
+        ssh_key = j.clients.sshkey.get(release)
+        ssh_key.private_key_path = "/root/.ssh/id_rsa"
+        ssh_key.load_from_file_system()
+        ssh_client = j.clients.sshclient.get(release, user="rancher", host=k8s_master_ip, sshkey=release)
+        rc, out, err = ssh_client.sshclient.run(
+            f"sudo rc-service {release}-* stop && rm /etc/init.d/{release}-*", warn=True,
+        )
+        if rc != 0:
+            raise j.exceptions.Runtime(
+                f"Failed to stop kubernetes rc-service starting with name {release} , error was {err}"
+            )
         return out
 
     @helm_required

--- a/jumpscale/sals/kubernetes/manager.py
+++ b/jumpscale/sals/kubernetes/manager.py
@@ -162,15 +162,16 @@ class Manager:
 
             # Validate service running
             ssh_client = self.get_k8s_sshclient(instance=release, host=k8s_master_ip)
-            rc, out, err = ssh_client.sshclient.run(f"sudo rc-service -l | grep -i '^{release}-socat-'", warn=True,)
+            rc, out, err = ssh_client.sshclient.run(f"sudo rc-service -l | grep -i '{release}-socat-'", warn=True,)
 
             if rc == 0:
                 results = out.split("\n")
                 for result in results:
-                    rc, out, err = ssh_client.sshclient.run(
-                        f"sudo rc-service -s {result.strip()} stop && sudo rm -f /etc/init.d/{result.strip()}",
-                        warn=True,
-                    )
+                    if result:
+                        rc, out, err = ssh_client.sshclient.run(
+                            f"sudo rc-service -s {result.strip()} stop && sudo rm -f /etc/init.d/{result.strip()}",
+                            warn=True,
+                        )
 
         return out
 

--- a/jumpscale/sals/kubernetes/manager.py
+++ b/jumpscale/sals/kubernetes/manager.py
@@ -138,8 +138,8 @@ class Manager:
             str: output of the helm command
         """
         # Getting k8s master IP
+        k8s_master_ip = ""
         if vdc_instance:
-            k8s_master_ip = ""
             for node in vdc_instance.kubernetes:
                 if node.role.value == "master":
                     k8s_master_ip = node.ip_address

--- a/jumpscale/sals/kubernetes/manager.py
+++ b/jumpscale/sals/kubernetes/manager.py
@@ -118,7 +118,7 @@ class Manager:
         return out
 
     @helm_required
-    def delete_deployed_release(self, release, namespace="default"):
+    def delete_deployed_release(self, release, vdc_instance, namespace="default"):
         """deletes deployed helm release
 
         Args:
@@ -132,7 +132,6 @@ class Manager:
         """
         # Getting k8s master IP
         k8s_master_ip = ""
-        vdc_instance = j.sals.vdc.get(release)
         for node in vdc_instance.kubernetes:
             if node.role.value == "master":
                 k8s_master_ip = node.ip_address

--- a/jumpscale/sals/vdc/deployer.py
+++ b/jumpscale/sals/vdc/deployer.py
@@ -475,7 +475,7 @@ class VDCDeployer:
             minio_sk: secret key for minio
             farm_name: where to initialize the vdc
         """
-        self.threebot_ssh_key = j.clients.sshclient.get(f"{self.vdc_name}_threebot")
+        self.threebot_ssh_key = j.clients.sshkey.get(f"{self.vdc_name}_threebot")
         self.threebot_ssh_key.generate_keys()
 
         farm_name = farm_name or PREFERED_FARM.get()
@@ -580,7 +580,7 @@ class VDCDeployer:
             self.bot_show_update("Updating Traefik")
             self.kubernetes.upgrade_traefik()
             self.vdc_instance.load_info()
-            j.clients.sshclient.delete(f"{self.vdc_name}_threebot")
+            j.clients.sshkey.delete(f"{self.vdc_name}_threebot")
             return kube_config
 
     def get_prefix(self):

--- a/jumpscale/sals/vdc/deployer.py
+++ b/jumpscale/sals/vdc/deployer.py
@@ -176,7 +176,7 @@ class VDCDeployer:
     def ssh_key(self):
         if not self._ssh_key:
             self._ssh_key = j.clients.sshkey.get(self.vdc_name)
-            KEYS_DIR_PATH = f"{j.core.dirs.CFGDIR}/vdc/keys/{self.tname}"
+            KEYS_DIR_PATH = f"{j.core.dirs.CFGDIR}/vdc/keys/{self.tname}/{self.vdc_name}"
             self._ssh_key.private_key_path = f"{KEYS_DIR_PATH}/id_rsa"
             if not j.sals.fs.exists(f"{KEYS_DIR_PATH}/id_rsa"):
                 j.sals.fs.mkdirs(KEYS_DIR_PATH)
@@ -365,13 +365,7 @@ class VDCDeployer:
         master_size = VDC_SIZE.VDC_FLAVORS[self.flavor]["k8s"]["controller_size"]
         pub_keys = pub_keys or []
         master_ip = self.kubernetes.deploy_master(
-            master_pool_id,
-            gs,
-            master_size,
-            cluster_secret,
-            pub_keys,
-            self.vdc_uuid,
-            nv,
+            master_pool_id, gs, master_size, cluster_secret, pub_keys, self.vdc_uuid, nv,
         )
         if not master_ip:
             self.error("failed to deploy kubernetes master")

--- a/jumpscale/sals/vdc/deployer.py
+++ b/jumpscale/sals/vdc/deployer.py
@@ -22,10 +22,6 @@ from jumpscale.core.exceptions import exceptions
 from contextlib import ContextDecorator
 from jumpscale.sals.zos.billing import InsufficientFunds
 import os
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-
 
 VDC_IDENTITY_FORMAT = "vdc_{}_{}_{}"  # tname, vdc_name, vdc_uuid
 IP_VERSION = "IPv4"

--- a/jumpscale/sals/vdc/deployer.py
+++ b/jumpscale/sals/vdc/deployer.py
@@ -365,7 +365,7 @@ class VDCDeployer:
             gs,
             master_size,
             cluster_secret,
-            [self.ssh_key.public_key.strip(), self.threebot.public_key.strip()],
+            [self.ssh_key.public_key.strip(), self.threebot_ssh_key.public_key.strip()],
             self.vdc_uuid,
             nv,
         )

--- a/jumpscale/sals/vdc/threebot.py
+++ b/jumpscale/sals/vdc/threebot.py
@@ -41,7 +41,7 @@ class VDCThreebotDeployer(VDCBaseComponent):
             "PROVISIONING_WALLET_SECRET": self.vdc_deployer.vdc_instance.provision_wallet.secret,
             "PREPAID_WALLET_SECRET": self.vdc_deployer.vdc_instance.prepaid_wallet.secret,
             "VDC_INSTANCE": j.data.serializers.json.dumps(vdc_dict),
-            "THREEBOT_PRIVATE_KEY": self.vdc_deployer.threebot.private_key,
+            "THREEBOT_PRIVATE_KEY": self.vdc_deployer.threebot_ssh_key.private_key,
         }
         env = {
             "VDC_NAME": self.vdc_name,

--- a/jumpscale/sals/vdc/threebot.py
+++ b/jumpscale/sals/vdc/threebot.py
@@ -23,7 +23,7 @@ THREEBOT_TRC_FLIST = "https://hub.grid.tf/ahmed_hanafy_1/ahmedhanafy725-js-sdk-l
 
 
 class VDCThreebotDeployer(VDCBaseComponent):
-    def deploy_threebot(self, minio_wid, pool_id, kube_config, embed_trc=True, priv_key=""):
+    def deploy_threebot(self, minio_wid, pool_id, kube_config, embed_trc=True):
         flist = THREEBOT_TRC_FLIST if embed_trc else THREEBOT_FLIST
         # workload = self.zos.workloads.get(minio_wid)
         # if workload.info.workload_type != WorkloadType.Container:
@@ -41,7 +41,7 @@ class VDCThreebotDeployer(VDCBaseComponent):
             "PROVISIONING_WALLET_SECRET": self.vdc_deployer.vdc_instance.provision_wallet.secret,
             "PREPAID_WALLET_SECRET": self.vdc_deployer.vdc_instance.prepaid_wallet.secret,
             "VDC_INSTANCE": j.data.serializers.json.dumps(vdc_dict),
-            "THREEBOT_PRIVATE_KEY": priv_key,
+            "THREEBOT_PRIVATE_KEY": self.vdc_deployer.ssh_key.private_key.strip(),
         }
         env = {
             "VDC_NAME": self.vdc_name,

--- a/jumpscale/sals/vdc/threebot.py
+++ b/jumpscale/sals/vdc/threebot.py
@@ -23,7 +23,7 @@ THREEBOT_TRC_FLIST = "https://hub.grid.tf/ahmed_hanafy_1/ahmedhanafy725-js-sdk-l
 
 
 class VDCThreebotDeployer(VDCBaseComponent):
-    def deploy_threebot(self, minio_wid, pool_id, kube_config, embed_trc=True):
+    def deploy_threebot(self, minio_wid, pool_id, kube_config, embed_trc=True, priv_key=""):
         flist = THREEBOT_TRC_FLIST if embed_trc else THREEBOT_FLIST
         # workload = self.zos.workloads.get(minio_wid)
         # if workload.info.workload_type != WorkloadType.Container:
@@ -41,7 +41,7 @@ class VDCThreebotDeployer(VDCBaseComponent):
             "PROVISIONING_WALLET_SECRET": self.vdc_deployer.vdc_instance.provision_wallet.secret,
             "PREPAID_WALLET_SECRET": self.vdc_deployer.vdc_instance.prepaid_wallet.secret,
             "VDC_INSTANCE": j.data.serializers.json.dumps(vdc_dict),
-            "THREEBOT_PRIVATE_KEY": self.vdc_deployer.threebot_ssh_key.private_key,
+            "THREEBOT_PRIVATE_KEY": priv_key,
         }
         env = {
             "VDC_NAME": self.vdc_name,

--- a/jumpscale/sals/vdc/threebot.py
+++ b/jumpscale/sals/vdc/threebot.py
@@ -41,6 +41,7 @@ class VDCThreebotDeployer(VDCBaseComponent):
             "PROVISIONING_WALLET_SECRET": self.vdc_deployer.vdc_instance.provision_wallet.secret,
             "PREPAID_WALLET_SECRET": self.vdc_deployer.vdc_instance.prepaid_wallet.secret,
             "VDC_INSTANCE": j.data.serializers.json.dumps(vdc_dict),
+            "THREEBOT_PRIVATE_KEY": self.vdc_deployer.threebot.private_key,
         }
         env = {
             "VDC_NAME": self.vdc_name,
@@ -67,7 +68,10 @@ class VDCThreebotDeployer(VDCBaseComponent):
                 return
             remote_ip, remote_port = remote.split(":")
             env.update(
-                {"REMOTE_IP": remote_ip, "REMOTE_PORT": remote_port,}
+                {
+                    "REMOTE_IP": remote_ip,
+                    "REMOTE_PORT": remote_port,
+                }
             )
             secret_env["TRC_SECRET"] = secret
         if not self.vdc_instance.kubernetes:

--- a/jumpscale/sals/vdc/vdc.py
+++ b/jumpscale/sals/vdc/vdc.py
@@ -275,7 +275,7 @@ class UserVDC(Base):
             if ip_address == "::/128":
                 continue
             ssh_key = j.clients.sshkey.get(self.vdc_name)
-            PRIV_KEY_PATH = f"{j.core.dirs.CFGDIR}/vdc/keys/{self.tname}/id_rsa"
+            PRIV_KEY_PATH = f"{j.core.dirs.CFGDIR}/vdc/keys/{self.tname}/{self.vdc_name}/id_rsa"
             if not j.sals.fs.exists(PRIV_KEY_PATH):
                 raise j.exceptions.NotFound(f"Can not find ssh key for vdc {self.vdc_name} in {PRIV_KEY_PATH}")
             ssh_key.private_key_path = PRIV_KEY_PATH
@@ -317,7 +317,7 @@ class UserVDC(Base):
             if ip_address == "::/128":
                 continue
             ssh_key = j.clients.sshkey.get(self.vdc_name)
-            PRIV_KEY_PATH = f"{j.core.dirs.CFGDIR}/vdc/keys/{self.tname}/id_rsa"
+            PRIV_KEY_PATH = f"{j.core.dirs.CFGDIR}/vdc/keys/{self.tname}/{self.vdc_name}/id_rsa"
             if not j.sals.fs.exists(PRIV_KEY_PATH):
                 raise j.exceptions.NotFound(f"Can not find ssh key for vdc {self.vdc_name} in {PRIV_KEY_PATH}")
             ssh_key.private_key_path = PRIV_KEY_PATH
@@ -361,11 +361,7 @@ class UserVDC(Base):
             refund_extra=False,
             expiry=expiry,
             description=j.data.serializers.json.dumps(
-                {
-                    "type": "VDC_INIT",
-                    "owner": self.owner_tname,
-                    "solution_uuid": self.solution_uuid,
-                }
+                {"type": "VDC_INIT", "owner": self.owner_tname, "solution_uuid": self.solution_uuid,}
             ),
         )
 
@@ -405,11 +401,7 @@ class UserVDC(Base):
             refund_extra=False,
             expiry=expiry,
             description=j.data.serializers.json.dumps(
-                {
-                    "type": "VDC_K8S_EXTEND",
-                    "owner": self.owner_tname,
-                    "solution_uuid": self.solution_uuid,
-                }
+                {"type": "VDC_K8S_EXTEND", "owner": self.owner_tname, "solution_uuid": self.solution_uuid,}
             ),
         )
         if amount > 0:

--- a/jumpscale/sals/vdc/vdc.py
+++ b/jumpscale/sals/vdc/vdc.py
@@ -275,8 +275,10 @@ class UserVDC(Base):
             if ip_address == "::/128":
                 continue
             ssh_key = j.clients.sshkey.get(self.vdc_name)
-            vdc_key_path = j.core.config.get("VDC_KEY_PATH", "~/.ssh/id_rsa")
-            ssh_key.private_key_path = j.sals.fs.expanduser(vdc_key_path)
+            PRIV_KEY_PATH = f"{j.core.dirs.CFGDIR}/vdc/keys/{self.tname}/id_rsa"
+            if not j.sals.fs.exists(PRIV_KEY_PATH):
+                raise j.exceptions.NotFound(f"Can not find ssh key for vdc {self.vdc_name} in {PRIV_KEY_PATH}")
+            ssh_key.private_key_path = PRIV_KEY_PATH
             ssh_key.load_from_file_system()
             try:
                 ssh_client = j.clients.sshclient.get(
@@ -315,8 +317,10 @@ class UserVDC(Base):
             if ip_address == "::/128":
                 continue
             ssh_key = j.clients.sshkey.get(self.vdc_name)
-            vdc_key_path = j.core.config.get("VDC_KEY_PATH", "~/.ssh/id_rsa")
-            ssh_key.private_key_path = j.sals.fs.expanduser(vdc_key_path)
+            PRIV_KEY_PATH = f"{j.core.dirs.CFGDIR}/vdc/keys/{self.tname}/id_rsa"
+            if not j.sals.fs.exists(PRIV_KEY_PATH):
+                raise j.exceptions.NotFound(f"Can not find ssh key for vdc {self.vdc_name} in {PRIV_KEY_PATH}")
+            ssh_key.private_key_path = PRIV_KEY_PATH
             ssh_key.load_from_file_system()
             try:
                 ssh_client = j.clients.sshclient.get(
@@ -357,7 +361,11 @@ class UserVDC(Base):
             refund_extra=False,
             expiry=expiry,
             description=j.data.serializers.json.dumps(
-                {"type": "VDC_INIT", "owner": self.owner_tname, "solution_uuid": self.solution_uuid,}
+                {
+                    "type": "VDC_INIT",
+                    "owner": self.owner_tname,
+                    "solution_uuid": self.solution_uuid,
+                }
             ),
         )
 
@@ -397,7 +405,11 @@ class UserVDC(Base):
             refund_extra=False,
             expiry=expiry,
             description=j.data.serializers.json.dumps(
-                {"type": "VDC_K8S_EXTEND", "owner": self.owner_tname, "solution_uuid": self.solution_uuid,}
+                {
+                    "type": "VDC_K8S_EXTEND",
+                    "owner": self.owner_tname,
+                    "solution_uuid": self.solution_uuid,
+                }
             ),
         )
         if amount > 0:


### PR DESCRIPTION
### Description

This pr adds support for exposing ports of services using `socat`
- Generates keys to `vdc threebot` and adds public keys to the cluster
- Adds method in solutions_chatflow.py to expose ports
- Validate if the port already exposed to prevent conflicts
- Create a service for Socat on k8s master node
- Stop and Delete the service if the solution was deleted to make sure everything is clean


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2199
