### PR TITLE
raise DeploymentFailed when all retries fail to redeploy 3bot

### DIFF
--- a/jumpscale/packages/threebot_deployer/bottle/utils.py
+++ b/jumpscale/packages/threebot_deployer/bottle/utils.py
@@ -476,3 +476,5 @@ def redeploy_threebot_solution(
                 j.logger.error(f"3Bot {solution_uuid} redeployment failed. retrying {retries}")
                 if bot and e.wid:
                     bot.md_show_update(f"Deployment Failed for wid {e.wid}. retrying {retries} ....")
+            else:
+                raise e


### PR DESCRIPTION
### Description

raise DeploymentFailed when all retries fail instead of return empty

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2319

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
