### PR TITLE
VDC remove kubeconfig from success message

### DIFF
--- a/jumpscale/packages/vdc/chats/new_vdc.py
+++ b/jumpscale/packages/vdc/chats/new_vdc.py
@@ -176,6 +176,7 @@ class VDCDeploy(GedisChatBot):
         # Your VDC {self.vdc.vdc_name} has been deployed successfully.
         <br />\n
         You can download the kubeconfig file from the dashboard to ~/.kube/config to start using your cluster with kubectl
+
         Kubernetes controller public IP: {self.public_ip}
         <br />\n
         """

--- a/jumpscale/packages/vdc/chats/new_vdc.py
+++ b/jumpscale/packages/vdc/chats/new_vdc.py
@@ -181,6 +181,7 @@ class VDCDeploy(GedisChatBot):
         <br />\n
         """
         )
+        self.md_show(dedent(msg), md=True)
 
 
 chat = VDCDeploy

--- a/jumpscale/packages/vdc/chats/new_vdc.py
+++ b/jumpscale/packages/vdc/chats/new_vdc.py
@@ -175,16 +175,9 @@ class VDCDeploy(GedisChatBot):
             f"""\
         # Your VDC {self.vdc.vdc_name} has been deployed successfully.
         <br />\n
-        Please download the config file to `~/.kube/config` to start using your cluster with [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-
         Kubernetes controller public IP: {self.public_ip}
         <br />\n
-        `WARINING: Please keep the kubeconfig file safe and secure. Anyone who has this file can access the kubernetes cluster`
         """
-        )
-
-        self.download_file(
-            msg, self.config, f"{self.vdc.vdc_name}.yaml", md=True,
         )
 
 

--- a/jumpscale/packages/vdc/chats/new_vdc.py
+++ b/jumpscale/packages/vdc/chats/new_vdc.py
@@ -175,6 +175,7 @@ class VDCDeploy(GedisChatBot):
             f"""\
         # Your VDC {self.vdc.vdc_name} has been deployed successfully.
         <br />\n
+        You can download the kubeconfig file from the dashboard to ~/.kube/config to start using your cluster with kubectl
         Kubernetes controller public IP: {self.public_ip}
         <br />\n
         """


### PR DESCRIPTION
### Description

VDC remove kubeconfig download from success message and tell the user that it can be download from the dashboard

![image](https://user-images.githubusercontent.com/18093386/105845434-61535c00-5fe3-11eb-9cd5-2b3684468387.png)

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2245
