### PR TITLE
Split capactity pools chatflows to seperate extend and create chatflows

### DIFF
--- a/jumpscale/packages/admin/frontend/components/pools/Pools.vue
+++ b/jumpscale/packages/admin/frontend/components/pools/Pools.vue
@@ -3,7 +3,7 @@
     <base-component title="Capacity Pools" icon="mdi-cloud">
       <template #actions>
         <v-btn color="primary" text to="/solutions/pools">
-          <v-icon left>mdi-cloud</v-icon>Create/Extend Pool
+          <v-icon left>mdi-cloud</v-icon>Create Pool
         </v-btn>
         <v-btn color="primary" text @click="toggleHiddenPools">
           <v-icon left>mdi-eye-off</v-icon>{{toggle_button_text}}
@@ -21,6 +21,16 @@
           <template v-slot:item.active_su="{ item }">{{ ( item.active_su * (30*24*60*60) ).toFixed(1) }} </template>
           <template v-slot:item.empty_at="{ item }">
             <div :class="`${item.class}`">{{ item.empty_at }}</div>
+          </template>
+          <template v-slot:item.actions="{ item }" #actions>
+              <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs }">
+                    <v-btn icon @click="openChatflow(item.pool_id)">
+                      <v-icon v-bind="attrs" v-on="on" color=primary>mdi-cloud-upload</v-icon>
+                    </v-btn>
+                  </template>
+                  <span>Extend pool</span>
+                </v-tooltip>
           </template>
         </v-data-table>
       </template>
@@ -56,6 +66,7 @@ module.exports = {
         { text: "Active Storage Units / month", value: "active_su" },
         { text: "# Nodes", value: "node_ids" },
         { text: "# Active Workloads", value: "active_workload_ids" },
+        { text: "Actions", value: "actions" },
       ],
     };
   },
@@ -115,6 +126,13 @@ module.exports = {
         this.toggle_button_text = "Show hidden pools";
         this.headers.pop();
       }
+    },
+    openChatflow(pool_id) {
+      let queryparams = {pool_id:pool_id}
+      this.$router.push({
+        name: "SolutionChatflow",
+        params: {topic: "extend_pools", queryparams: queryparams },
+      });
     },
   },
   mounted() {

--- a/jumpscale/packages/admin/frontend/components/pools/Pools.vue
+++ b/jumpscale/packages/admin/frontend/components/pools/Pools.vue
@@ -26,7 +26,7 @@
               <v-tooltip top>
                   <template v-slot:activator="{ on, attrs }">
                     <v-btn icon @click="openChatflow(item.pool_id)">
-                      <v-icon v-bind="attrs" v-on="on" color=primary>mdi-cloud-upload</v-icon>
+                      <v-icon v-bind="attrs" v-on="on" color=primary>mdi-resize</v-icon>
                     </v-btn>
                   </template>
                   <span>Extend pool</span>

--- a/jumpscale/packages/admin/frontend/components/solutions/SolutionChatflow.vue
+++ b/jumpscale/packages/admin/frontend/components/solutions/SolutionChatflow.vue
@@ -6,7 +6,7 @@
   module.exports = {
     props: {
       topic: String,
-      queryparams: Object
+      queryparams: {type:Object,default:null}
     },
     data () {
       return {

--- a/jumpscale/packages/admin/frontend/components/solutions/SolutionChatflow.vue
+++ b/jumpscale/packages/admin/frontend/components/solutions/SolutionChatflow.vue
@@ -4,7 +4,10 @@
 
 <script>
   module.exports = {
-    props: {topic: String},
+    props: {
+      topic: String,
+      queryparams: Object
+    },
     data () {
       return {
         package: true,
@@ -13,7 +16,15 @@
     },
     computed: {
       url () {
-        return `/chatflows/tfgrid_solutions/chats/${this.topic}`
+        if (this.queryparams !== null) {
+          let chatflowUrl = `/chatflows/tfgrid_solutions/chats/${this.topic}#/?`
+          Object.keys(this.queryparams).forEach(key => {
+            chatflowUrl += `${key}=${this.queryparams[key]}&`
+          });
+          return chatflowUrl;
+        } else {
+          return `/chatflows/tfgrid_solutions/chats/${this.topic}`;
+        }
       }
     },
     mounted() {

--- a/jumpscale/packages/admin/frontend/components/solutions/SolutionChatflow.vue
+++ b/jumpscale/packages/admin/frontend/components/solutions/SolutionChatflow.vue
@@ -36,7 +36,7 @@
           if(event.origin != location.origin || event.data.slice(0, len) != message)
             return;
           let topic = event.data.slice(len)
-          if(topic == "pools"){
+          if(topic === "pools" || topic === "extend_pools"){
             this.$router.push({
               name: "Capacity Pools"
             })

--- a/jumpscale/packages/tfgrid_solutions/chats/extend_pools.py
+++ b/jumpscale/packages/tfgrid_solutions/chats/extend_pools.py
@@ -1,0 +1,35 @@
+import requests
+
+from jumpscale.loader import j
+from jumpscale.sals.chatflows.chatflows import GedisChatBot, chatflow_step, StopChatFlow
+from jumpscale.packages.tfgrid_solutions.models import PoolConfig
+from jumpscale.core.base import StoredFactory
+from jumpscale.sals.reservation_chatflow import deployer
+
+
+class PoolExtend(GedisChatBot):
+    steps = ["pool_start", "reserve_pool", "pool_success"]
+    title = "Capacity Pool Extend"
+
+    @chatflow_step(title="Welcome")
+    def pool_start(self):
+        self.md_show_update("Checking payment service...")
+        # check stellar service
+        if not j.clients.stellar.check_stellar_service():
+            raise StopChatFlow("Payment service is currently down, try again later")
+
+        self.pool_id = self.kwargs["pool_id"]
+
+    @chatflow_step(title="Capacity Pool")
+    def reserve_pool(self):
+        self.pool_data = deployer.extend_pool(self, self.pool_id)
+
+    @chatflow_step(title="Capacity Pool Info", final_step=True)
+    def pool_success(self):
+
+        self.md_show(
+            f"Transaction Succeeded! You just extended your capacity pool. It may take few minutes to reflect."
+        )
+
+
+chat = PoolExtend

--- a/jumpscale/packages/tfgrid_solutions/chats/pools.py
+++ b/jumpscale/packages/tfgrid_solutions/chats/pools.py
@@ -17,47 +17,32 @@ class PoolReservation(GedisChatBot):
         # check stellar service
         if not j.clients.stellar.check_stellar_service():
             raise StopChatFlow("Payment service is currently down, try again later")
-        self.pools = [p for p in j.sals.zos.get().pools.list() if p.node_ids]
-        if not self.pools:
-            self.action = "create"
-        else:
-            self.action = self.single_choice(
-                "Would you like to create a new capacity pool, or extend an existing one?",
-                ["create", "extend"],
-                required=True,
-                default="create",
-            )
 
     @chatflow_step(title="Capacity Pool")
     def reserve_pool(self):
-        if self.action == "create":
-            valid = False
-            pool_factory = StoredFactory(PoolConfig)
-            while not valid:
-                self.pool_name = self.string_ask(
-                    "Please choose a name for your new capacity pool. This name will only be used by you to identify the pool for later usage and management.",
-                    required=True,
-                    is_identifier=True,
-                )
-                _, _, result = pool_factory.find_many(name=self.pool_name)
-                if list(result):
-                    self.md_show("the name is already used. please choose a different one")
-                    continue
-                valid = True
-            self.pool_data = deployer.create_pool(self)
-        else:
-            pool_id = deployer.select_pool(self)
-            self.pool_data = deployer.extend_pool(self, pool_id)
+        valid = False
+        pool_factory = StoredFactory(PoolConfig)
+        while not valid:
+            self.pool_name = self.string_ask(
+                "Please choose a name for your new capacity pool. This name will only be used by you to identify the pool for later usage and management.",
+                required=True,
+                is_identifier=True,
+            )
+            _, _, result = pool_factory.find_many(name=self.pool_name)
+            if list(result):
+                self.md_show("the name is already used. please choose a different one")
+                continue
+            valid = True
+        self.pool_data = deployer.create_pool(self)
 
     @chatflow_step(title="Capacity Pool Info", final_step=True)
     def pool_success(self):
-        if self.action == "create":
-            pool_id = self.pool_data.reservation_id
-            pool_factory = StoredFactory(PoolConfig)
-            p = pool_factory.new(f"pool_{pool_id}")
-            p.name = self.pool_name
-            p.pool_id = pool_id
-            p.save()
+        pool_id = self.pool_data.reservation_id
+        pool_factory = StoredFactory(PoolConfig)
+        p = pool_factory.new(f"pool_{pool_id}")
+        p.name = self.pool_name
+        p.pool_id = pool_id
+        p.save()
         self.md_show(
             f"Transaction Succeeded! You just created a new capacity pool. It may take few minutes to reflect."
         )


### PR DESCRIPTION
### Description

- Split capacity pools chatflows to separate extend and create chatflows
- Add separate button for extend of each capacity pool in admin dashboard pools

### Changes
- Add passing of query param options in solutions chatflows in admin dashboard
- Add seperate button for extend in actions colomn
![Screenshot from 2021-01-25 13-57-56](https://user-images.githubusercontent.com/17128393/105703667-436bf580-5f16-11eb-8da3-509693737de5.png)

- Split chatflows
![Screenshot from 2021-01-25 14-01-14](https://user-images.githubusercontent.com/17128393/105703682-46ff7c80-5f16-11eb-862d-a746988b4b9e.png)
![Screenshot from 2021-01-25 14-01-40](https://user-images.githubusercontent.com/17128393/105703686-47981300-5f16-11eb-82a5-21da0cb55fc7.png)


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2220

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
