### PR TITLE
Dashboard: Fix memory usage percentage

### DIFF
--- a/jumpscale/packages/admin/frontend/components/dashboard/MemoryUsage.vue
+++ b/jumpscale/packages/admin/frontend/components/dashboard/MemoryUsage.vue
@@ -43,7 +43,6 @@
         this.loading = true
         this.$api.health.getMemoryUsage().then((response) => {
           this.usage = JSON.parse(response.data).data
-          console.log(this.usage)
         }).finally (() => {
           this.loading = false
         })

--- a/jumpscale/packages/admin/frontend/components/dashboard/MemoryUsage.vue
+++ b/jumpscale/packages/admin/frontend/components/dashboard/MemoryUsage.vue
@@ -6,7 +6,7 @@
           <v-icon small left color="primary">mdi-circle</v-icon> Used Memory: {{usage.used}} GB
         </span><br>
         <span>
-          <v-icon small left color="secondary">mdi-circle</v-icon> Free Memory: {{usage.total - usage.used}} GB
+          <v-icon small left color="secondary">mdi-circle</v-icon> Available Memory: {{usage.total - usage.used}} GB
         </span><br>
         <span>
           <v-icon small left>mdi-circle-outline</v-icon> Total Memory: {{usage.total}} GB
@@ -15,9 +15,9 @@
       <v-col cols="6" class="ma-0 pa-0">
         <div class="text-center">
           <v-progress-circular :size="100" :rotate="-90" :width="10" :value="usage.percent" color="primary">
-            {{Math.round(usage.percent)}}%
+            {{Math.round((usage.used / usage.total) * 100)}}%
           </v-progress-circular>
-        </div>    
+        </div>
       </v-col>
     </v-row>
   </base-section>
@@ -43,6 +43,7 @@
         this.loading = true
         this.$api.health.getMemoryUsage().then((response) => {
           this.usage = JSON.parse(response.data).data
+          console.log(this.usage)
         }).finally (() => {
           this.loading = false
         })


### PR DESCRIPTION
### Description

Dashboard: Fix memory usage percentage
calculate percentage from used and total fields instead of the percent field of psutil which calculated from the available memory not the used ones. See https://psutil.readthedocs.io/en/latest/#psutil.virtual_memory

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/878