### PR TITLE
Send sigkill if sigterm failed when stopping 3bot

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/restart.sh
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/restart.sh
@@ -5,10 +5,10 @@ after=$1
 sleep $after
 zinit stop start
 # wait until dead
-zinit status start | grep Down
 
 start_time=`date +%s`
-while [[ $? == 1 ]]; do
+
+while ! zinit status start | grep -q 'pid: 0' ; do
     echo "waiting for server to stop"
     current_time=`date +%s`
     if [[ $current_time > $(($start_time + 120)) ]]; then
@@ -16,6 +16,5 @@ while [[ $? == 1 ]]; do
       current_time=$start_time # to not call sigkill twice
     fi
     sleep 1
-    zinit status start | grep Down
 done
 zinit start start

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/restart.sh
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/restart.sh
@@ -1,11 +1,20 @@
+#!/bin/bash
+
 after=$1
 
 sleep $after
 zinit stop start
 # wait until dead
 zinit status start | grep Down
+
+start_time=`date +%s`
 while [[ $? == 1 ]]; do
     echo "waiting for server to stop"
+    current_time=`date +%s`
+    if [[ $current_time > $(($start_time + 120)) ]]; then
+      zinit kill start SIGKILL
+      current_time=$start_time # to not call sigkill twice
+    fi
     sleep 1
     zinit status start | grep Down
 done


### PR DESCRIPTION
### Description

Send SIGKILL after 2 minutes if the server didn't stop with SIGTERM

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2246
