### PR TITLE
Stop redis last when killing 3bot

### DIFF
--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -841,6 +841,6 @@ class ThreebotServer(Base):
         self.nginx.stop()
         # mark app as stopped, do this before stopping redis
         j.logger.unregister()
-        self.redis.stop()
         self.rack.stop()
+        self.redis.stop()
         self._started = False


### PR DESCRIPTION
### Description

Some services saves their state in redis and it appears that gedis also somehow depends on it. so it makes sense to stop it after all the components that depends on it is stopped.

An example of when the redis fails some services:

![Screenshot from 2021-01-27 12-41-23](https://user-images.githubusercontent.com/13040543/105979998-04b47780-609d-11eb-8957-adcccd6349e8.png)
