### PR TITLE
Fix the helpLink for file browser solution

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/data.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/data.js
@@ -127,7 +127,7 @@ const DECENTRALIZED_WE = {
             type: "filebrowser",
             image: "./assets/file_browser.jpg",
             disable: false,
-            helpLink: "https://now.threefold.io/now/docs/filebrowser/",
+            helpLink: "https://now.threefold.io/now/docs/file-browser/",
             description: "File browser is an open source solution that provides a file managing interface"
         },
         virtualspaces: {


### PR DESCRIPTION

### Changes
- Fix the helpLink for file browser solution to be [https://now.threefold.io/now/docs/file-browser/](https://now.threefold.io/now/docs/file-browser/)
 
### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/2380
### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
