### PR TITLE
delete old subdomain workloads

### DIFF
--- a/jumpscale/packages/threebot_deployer/bottle/utils.py
+++ b/jumpscale/packages/threebot_deployer/bottle/utils.py
@@ -338,7 +338,7 @@ def redeploy_threebot_solution(
                     j.logger.debug(f"searching for old subdomain workloads for domain: {domain}")
                     deployed_workloads = zos.workloads.list_workloads(identity.tid, NextAction.DEPLOY)
                     for workload in deployed_workloads:
-                        if not workload.info.workload_type == WorkloadType.Subdomain:
+                        if workload.info.workload_type != WorkloadType.Subdomain:
                             continue
                         if not workload.domain == domain:
                             continue

--- a/jumpscale/packages/threebot_deployer/bottle/utils.py
+++ b/jumpscale/packages/threebot_deployer/bottle/utils.py
@@ -340,7 +340,7 @@ def redeploy_threebot_solution(
                     for workload in deployed_workloads:
                         if workload.info.workload_type != WorkloadType.Subdomain:
                             continue
-                        if not workload.domain == domain:
+                        if workload.domain != domain:
                             continue
                         j.logger.debug(f"deleting old workload {workload.id}")
                         zos.workloads.decomission(workload.id)

--- a/jumpscale/packages/threebot_deployer/bottle/utils.py
+++ b/jumpscale/packages/threebot_deployer/bottle/utils.py
@@ -335,6 +335,15 @@ def redeploy_threebot_solution(
                         )
 
                     domain = new_solution_info["domain"]
+                    j.logger.debug(f"searching for old subdomain workloads for domain: {domain}")
+                    deployed_workloads = zos.workloads.list_workloads(identity.tid, NextAction.DEPLOY)
+                    for workload in deployed_workloads:
+                        if not workload.info.workload_type == WorkloadType.Subdomain:
+                            continue
+                        if not workload.domain == domain:
+                            continue
+                        j.logger.debug(f"deleting old workload {workload.id}")
+                        zos.workloads.decomission(workload.id)
                     j.logger.debug(f"deploying domain {domain} pointing to addresses {addresses}")
                     workload_ids.append(
                         deployer.create_subdomain(


### PR DESCRIPTION
### Description

check and clean old subdomain workloads before redeploying the subdomain

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2414

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
