### PR TITLE
only log certificates warnings

### DIFF
--- a/jumpscale/sals/marketplace/apps_chatflow.py
+++ b/jumpscale/sals/marketplace/apps_chatflow.py
@@ -346,7 +346,7 @@ class MarketPlaceAppsChatflow(MarketPlaceChatflow):
                         continue
                 except requests.exceptions.HTTPError:
                     is_http_failure = True
-                    continue
+
                 domains[domain] = gw_dict
                 self.gateway_pool = gw_dict["pool"]
                 self.gateway = gw_dict["gateway"]
@@ -398,8 +398,8 @@ class MarketPlaceAppsChatflow(MarketPlaceChatflow):
                 return self.domain
 
         if is_http_failure:
-            raise StopChatFlow(
-                'An error encountered while trying to fetch certifcates information from <a href="crt.sh" target="_blank">crt.sh</a>. Please try again later.'
+            j.logger.warning(
+                'An error encountered while trying to fetch certifcates information from "https://crt.sh". Please try again later.'
             )
         elif not is_managed_domains:
             raise StopChatFlow("Couldn't find managed domains in the available gateways. Please contact support.")


### PR DESCRIPTION
### Description

- Since we are using zerossl with unlimited certificates, we don't need to raise when crt.sh is unreachable

### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/2422

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
