### PR TITLE
Add random value as the default for the zstor encryption key

### DIFF
--- a/jumpscale/packages/vdc_dashboard/bottle/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/deployments.py
@@ -175,6 +175,8 @@ def cancel_deployment():
 @app.route("/api/zstor/config", method="POST")
 @authenticated
 def get_zstor_config():
+    import secrets
+
     vdc = _get_vdc()
     vdc_zdb_monitor = vdc.get_zdb_monitor()
     password = vdc_zdb_monitor.get_password()
@@ -183,7 +185,7 @@ def get_zstor_config():
         "parity_shards": 1,
         "redundant_groups": 0,
         "redundant_nodes": 0,
-        "encryption": {"algorithm": "AES", "key": "",},
+        "encryption": {"algorithm": "AES", "key": secrets.token_hex(32),},
         "compression": {"algorithm": "snappy",},
         "groups": [],
     }

--- a/jumpscale/packages/vdc_dashboard/bottle/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/deployments.py
@@ -175,17 +175,16 @@ def cancel_deployment():
 @app.route("/api/zstor/config", method="POST")
 @authenticated
 def get_zstor_config():
-    import secrets
-
     vdc = _get_vdc()
     vdc_zdb_monitor = vdc.get_zdb_monitor()
     password = vdc_zdb_monitor.get_password()
+    encryption_key = password[:32].encode().zfill(32).hex()
     data = {
         "data_shards": 2,
         "parity_shards": 1,
         "redundant_groups": 0,
         "redundant_nodes": 0,
-        "encryption": {"algorithm": "AES", "key": secrets.token_hex(32),},
+        "encryption": {"algorithm": "AES", "key": encryption_key,},
         "compression": {"algorithm": "snappy",},
         "groups": [],
     }


### PR DESCRIPTION
### Changes

- Add random value as the default for the zstor encryption key
```
secrets.token_hex([nbytes=None])¶
Return a random text string, in hexadecimal. The string has nbytes random bytes, each byte converted to two hex digits. If nbytes is None or not supplied, a reasonable default is used.
```
### Related Issues

- [https://github.com/threefoldtech/js-sdk/issues/2425](https://github.com/threefoldtech/js-sdk/issues/2425)
### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
