### PR TITLE
VDC: Fix publishingtools listing and update instructions

### DIFF
--- a/jumpscale/clients/github/repo.py
+++ b/jumpscale/clients/github/repo.py
@@ -76,6 +76,11 @@ class GithubRepo:
         return self._labels
 
     @property
+    def branches(self):
+        """list of `Branch` objects"""
+        return list(self.api.get_branches())
+
+    @property
     def stories(self):
         # walk overall issues find the stories (based on type)
         # only for home type repo, otherwise return []
@@ -440,6 +445,10 @@ class GithubRepo:
                     f.write(base64.b64decode(file_content.content).decode())
 
         return j.sals.fs.join_paths(dest, src)
+
+    def get_git_tree(self, sha_or_branch):
+        """return a list of `GitTreeElement` for every element in source tree"""
+        return self.api.get_git_tree(sha_or_branch).tree
 
     def __str__(self):
         return "gitrepo:%s" % self.fullname

--- a/jumpscale/packages/vdc_dashboard/chats/blog.py
+++ b/jumpscale/packages/vdc_dashboard/chats/blog.py
@@ -37,7 +37,6 @@ class BlogDeploy(Publisher):
         self.chart_config.update(
             {
                 "env.type": "blog",
-                "env.title": title.value,
                 "env.url": url.value,
                 "env.branch": branch.value,
                 "ingress.host": self.domain,

--- a/jumpscale/packages/vdc_dashboard/chats/blog.py
+++ b/jumpscale/packages/vdc_dashboard/chats/blog.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 from jumpscale.packages.vdc_dashboard.chats.publisher import Publisher
 from jumpscale.sals.chatflows.chatflows import chatflow_step
 

--- a/jumpscale/packages/vdc_dashboard/chats/blog.py
+++ b/jumpscale/packages/vdc_dashboard/chats/blog.py
@@ -3,16 +3,31 @@ from jumpscale.sals.chatflows.chatflows import chatflow_step
 
 
 class BlogDeploy(Publisher):
+    SOLUTION_TYPE = "blog"
     EXAMPLE_URL = "https://github.com/threefoldfoundation/blog_example"
 
     title = "Blog"
+
+    def get_mdconfig_msg(self):
+        # blog does not need a source directory
+        msg = dedent(
+            f"""\
+        Few parameters are needed to be able to publish your content online
+        - Create a github account
+        - Fork the following [template repository]({self.EXAMPLE_URL}) and add your content there.
+        - Copy your forked repository URL to this deployer
+        - Select the branch you want to deploy, e.g: main
+
+        For more information about repository structure and examples please check [the manual]({self.DOC_URL})
+        """
+        )
+        return msg
 
     @chatflow_step(title="Configurations")
     def set_config(self):
         self._choose_flavor()
 
         form = self.new_form()
-        title = form.string_ask("Title", required=True)
         url = form.string_ask("Repository URL", required=True, is_git_url=True)
         branch = form.string_ask("Branch", required=True)
         msg = self.get_mdconfig_msg()

--- a/jumpscale/packages/vdc_dashboard/chats/blog.py
+++ b/jumpscale/packages/vdc_dashboard/chats/blog.py
@@ -42,6 +42,7 @@ class BlogDeploy(Publisher):
                 "ingress.host": self.domain,
                 "resources.limits.cpu": self.resources_limits["cpu"],
                 "resources.limits.memory": self.resources_limits["memory"],
+                "nameOverride": self.SOLUTION_TYPE,
             }
         )
 

--- a/jumpscale/packages/vdc_dashboard/chats/publisher.py
+++ b/jumpscale/packages/vdc_dashboard/chats/publisher.py
@@ -7,7 +7,10 @@ from jumpscale.packages.vdc_dashboard.sals.solutions_chatflow import SolutionsCh
 class Publisher(SolutionsChatflowDeploy):
     SOLUTION_TYPE = "publishingtools"
     HELM_REPO_NAME = "marketplace"
+    CHART_NAME = "publishingtools"
+
     EXAMPLE_URL = "https://github.com/threefoldfoundation/info_gridmanual"
+    DOC_URL = "https://now.threefold.io/now/docs/publishing-tool/#repository-examples"
 
     title = "Publisher"
     steps = ["get_release_name", "create_subdomain", "set_config", "install_chart", "initializing", "success"]
@@ -16,12 +19,13 @@ class Publisher(SolutionsChatflowDeploy):
         msg = dedent(
             f"""\
         Few parameters are needed to be able to publish your content online
-        - Title  is the title shown up on your published content
-        - Repository URL  is a valid git repository URL where your content lives e.g ({self.EXAMPLE_URL})
-        - Branch is the deployment branch that exists on your git repository to be used as the version of your content to publish.
-        - Source directory is the directory where html or markdown files are served.
+        - Create a github account
+        - Fork the following [template repository]({self.EXAMPLE_URL}) and add your content there.
+        - Copy your forked repository URL to this deployer
+        - Select the branch you want to deploy, e.g: main
+        - Identify which source directory where the content lives in, e.g. src, html...
 
-        for more information on the publishing tools please check the [manual](https://manual.threefold.io/)
+        For more information about repository structure and examples please check [the manual]({self.DOC_URL}).
         """
         )
         return msg
@@ -34,7 +38,6 @@ class Publisher(SolutionsChatflowDeploy):
         site_type = form.single_choice(
             "Choose the publication type", options=["wiki", "www", "blog"], default="wiki", required=True
         )
-        title = form.string_ask("Title", required=True)
         url = form.string_ask("Repository URL", required=True, is_git_url=True)
         branch = form.string_ask("Branch", required=True)
         srcdir = form.string_ask("Source directory", required=False, default="")

--- a/jumpscale/packages/vdc_dashboard/chats/publisher.py
+++ b/jumpscale/packages/vdc_dashboard/chats/publisher.py
@@ -46,7 +46,6 @@ class Publisher(SolutionsChatflowDeploy):
         self.chart_config.update(
             {
                 "env.type": site_type.value,
-                "env.title": title.value,
                 "env.url": url.value,
                 "env.branch": branch.value,
                 "env.srcdir": srcdir.value,

--- a/jumpscale/packages/vdc_dashboard/chats/website.py
+++ b/jumpscale/packages/vdc_dashboard/chats/website.py
@@ -21,7 +21,6 @@ class WebsiteDeploy(Publisher):
         self.chart_config.update(
             {
                 "env.type": "www",
-                "env.title": title.value,
                 "env.url": url.value,
                 "env.branch": branch.value,
                 "env.srcdir": srcdir.value,

--- a/jumpscale/packages/vdc_dashboard/chats/website.py
+++ b/jumpscale/packages/vdc_dashboard/chats/website.py
@@ -3,6 +3,7 @@ from jumpscale.sals.chatflows.chatflows import chatflow_step
 
 
 class WebsiteDeploy(Publisher):
+    SOLUTION_TYPE = "website"
     EXAMPLE_URL = "https://github.com/threefoldfoundation/website_example"
 
     title = "Website"
@@ -12,7 +13,6 @@ class WebsiteDeploy(Publisher):
         self._choose_flavor()
 
         form = self.new_form()
-        title = form.string_ask("Title", required=True)
         url = form.string_ask("Repository URL", required=True, is_git_url=True)
         branch = form.string_ask("Branch", required=True)
         srcdir = form.string_ask("Source directory", required=False, default="html")

--- a/jumpscale/packages/vdc_dashboard/chats/website.py
+++ b/jumpscale/packages/vdc_dashboard/chats/website.py
@@ -27,6 +27,7 @@ class WebsiteDeploy(Publisher):
                 "ingress.host": self.domain,
                 "resources.limits.cpu": self.resources_limits["cpu"],
                 "resources.limits.memory": self.resources_limits["memory"],
+                "nameOverride": self.SOLUTION_TYPE,
             }
         )
 

--- a/jumpscale/packages/vdc_dashboard/chats/wiki.py
+++ b/jumpscale/packages/vdc_dashboard/chats/wiki.py
@@ -27,6 +27,7 @@ class WikiDeploy(Publisher):
                 "ingress.host": self.domain,
                 "resources.limits.cpu": self.resources_limits["cpu"],
                 "resources.limits.memory": self.resources_limits["memory"],
+                "nameOverride": self.SOLUTION_TYPE,
             }
         )
 

--- a/jumpscale/packages/vdc_dashboard/chats/wiki.py
+++ b/jumpscale/packages/vdc_dashboard/chats/wiki.py
@@ -3,6 +3,7 @@ from jumpscale.sals.chatflows.chatflows import chatflow_step
 
 
 class WikiDeploy(Publisher):
+    SOLUTION_TYPE = "wiki"
     EXAMPLE_URL = "https://github.com/threefoldfoundation/wiki_example"
 
     title = "Wiki"
@@ -12,7 +13,6 @@ class WikiDeploy(Publisher):
         self._choose_flavor()
 
         form = self.new_form()
-        title = form.string_ask("Title", required=True)
         url = form.string_ask("Repository URL", required=True, is_git_url=True)
         branch = form.string_ask("Branch", required=True)
         srcdir = form.string_ask("Source directory", required=False, default="src")

--- a/jumpscale/packages/vdc_dashboard/chats/wiki.py
+++ b/jumpscale/packages/vdc_dashboard/chats/wiki.py
@@ -21,7 +21,6 @@ class WikiDeploy(Publisher):
         self.chart_config.update(
             {
                 "env.type": "wiki",
-                "env.title": title.value,
                 "env.url": url.value,
                 "env.branch": branch.value,
                 "env.srcdir": srcdir.value,


### PR DESCRIPTION
### Description

Update instructions to be more clear and fix blog, website and wiki listing.

### Changes

- Adding a new class variable called `CHART_NAME` that can be used for chart name instead of solution type in `SolutionsChatflowDeploy`
- Update base publisher to use `CHART_NAME` and set the correct solution type.
- Pass `nameOverride` with the new solution type in blog, website and wiki chatflows.
- Change instructions in blog, website and wiki chatflows.

### Related Issues

#2375

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
