### PR TITLE
Run js-sdk build tests only when a python file changed

### DIFF
--- a/.github/workflows/js-sdk.yml
+++ b/.github/workflows/js-sdk.yml
@@ -6,8 +6,12 @@ name: js-sdk
 on:
   push:
     branches: [ development ]
+    paths:
+    - '**.py'
   pull_request:
     branches: [ development ]
+    paths:
+    - '**.py'
 
 jobs:
   build:

--- a/.github/workflows/js-sdk.yml
+++ b/.github/workflows/js-sdk.yml
@@ -8,10 +8,16 @@ on:
     branches: [ development ]
     paths:
     - '**.py'
+    - '.github/workflows/**.yml'
+    - 'pyproject.toml'
+    - 'poetry.lock'
   pull_request:
     branches: [ development ]
     paths:
     - '**.py'
+    - '.github/workflows/**.yml'
+    - 'pyproject.toml'
+    - 'poetry.lock'
 
 jobs:
   build:


### PR DESCRIPTION
### Description

Adding the workflow feature requested in issue #2256

### Changes

- Now js-sdk build tests should run only when a python file `*.py` changed somewhere in the project

- update: after the discussion, `.github/workflows/**.yml` as well as `pyproject.toml` and `poetry.lock` files added to paths and the workflow will trigger if one of these files changed too.

## Notes:

- This affects the js-sdk workflow only. the js-sdk-check-wheel workflow will still work on every Push or PR.

### Related Issues

closes #2256