### PR TITLE
chore: Fixing a typo in js-sdk-check-wheel.yml

### DIFF
--- a/.github/workflows/js-sdk-check-wheel.yml
+++ b/.github/workflows/js-sdk-check-wheel.yml
@@ -12,7 +12,7 @@ on:
     branches: [ development ]
 
 jobs:
-  chec-the-wheels:
+  check-the-wheels:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:


### PR DESCRIPTION
Fixing a workflow job name typo chec --> check