### PR TITLE
Supporting extra storage for cryptpad chart through k8s volumes

### DIFF
--- a/jumpscale/packages/vdc_dashboard/chats/cryptpad.py
+++ b/jumpscale/packages/vdc_dashboard/chats/cryptpad.py
@@ -19,7 +19,7 @@ class CryptpadDeploy(SolutionsChatflowDeploy):
         self.chart_config.update(
             {
                 "ingress.host": self.domain,
-                "volumeSize": f"{self.volume_size}Gi",
+                "volume.size": f"{self.volume_size}Gi",
                 "resources.limits.cpu": self.resources_limits["cpu"],
                 "resources.limits.memory": self.resources_limits["memory"],
             }

--- a/jumpscale/packages/vdc_dashboard/chats/cryptpad.py
+++ b/jumpscale/packages/vdc_dashboard/chats/cryptpad.py
@@ -19,7 +19,7 @@ class CryptpadDeploy(SolutionsChatflowDeploy):
         self.chart_config.update(
             {
                 "ingress.host": self.domain,
-                "volume.size": f"{self.volume_size}Gi",
+                "volume.size": self.volume_size,
                 "resources.limits.cpu": self.resources_limits["cpu"],
                 "resources.limits.memory": self.resources_limits["memory"],
             }

--- a/jumpscale/packages/vdc_dashboard/chats/cryptpad.py
+++ b/jumpscale/packages/vdc_dashboard/chats/cryptpad.py
@@ -12,9 +12,14 @@ class CryptpadDeploy(SolutionsChatflowDeploy):
     def set_config(self):
         # TODO: get config from user
         self._choose_flavor()
+        choices = ["10", "15", "20"]
+        self.volume_size = self.single_choice(
+            "Please select your storage size (in GBs)", choices, required=True, default="10",
+        )
         self.chart_config.update(
             {
                 "ingress.host": self.domain,
+                "volumeSize": f"{self.volume_size}Gi",
                 "resources.limits.cpu": self.resources_limits["cpu"],
                 "resources.limits.memory": self.resources_limits["memory"],
             }

--- a/jumpscale/packages/vdc_dashboard/chats/cryptpad.py
+++ b/jumpscale/packages/vdc_dashboard/chats/cryptpad.py
@@ -20,6 +20,7 @@ class CryptpadDeploy(SolutionsChatflowDeploy):
             {
                 "ingress.host": self.domain,
                 "volume.size": self.volume_size,
+                "volume.hostPath": f"/persistent-data/{self.release_name}",
                 "resources.limits.cpu": self.resources_limits["cpu"],
                 "resources.limits.memory": self.resources_limits["memory"],
             }


### PR DESCRIPTION
### Description

Supporting extra storage for cryptpad chart through k8s volumes
Currently the volume is of type hostPath, but will be changed to local in another PR (because hostPath cannot be backuped)

### Related Issues

https://github.com/threefoldtech/vdc-solutions-charts/issues/18
