### PR TITLE
Change listing of all vdc solutions to only list specific solution types

### DIFF
--- a/jumpscale/packages/vdc_dashboard/bottle/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/deployments.py
@@ -78,7 +78,7 @@ def expose_s3() -> str:
     return j.data.serializers.json.dumps({"data": s3_domain})
 
 
-@app.route("/api/deployments/<solution_type>")
+@app.route("/api/deployments/<solution_type>", method="GET")
 @package_authorized("vdc_dashboard")
 def list_deployments(solution_type: str) -> str:
     deployments = {}
@@ -88,12 +88,14 @@ def list_deployments(solution_type: str) -> str:
     return j.data.serializers.json.dumps({"data": deployments})
 
 
-@app.route("/api/deployments")
+@app.route("/api/deployments", method="POST")
 @package_authorized("vdc_dashboard")
 def list_all_deployments() -> str:
     deployments = []
+    data = j.data.serializers.json.loads(request.body.read())
+    solution_types = data.get("solution_types")
     try:
-        deployments = get_all_deployments()
+        deployments = get_all_deployments(solution_types)
     except Exception as e:
         j.logger.exception(message=str(e), exception=e)
 
@@ -184,8 +186,8 @@ def get_zstor_config():
         "parity_shards": 1,
         "redundant_groups": 0,
         "redundant_nodes": 0,
-        "encryption": {"algorithm": "AES", "key": encryption_key,},
-        "compression": {"algorithm": "snappy",},
+        "encryption": {"algorithm": "AES", "key": encryption_key},
+        "compression": {"algorithm": "snappy"},
         "meta": {
             "type": "etcd",
             "config": {
@@ -199,8 +201,8 @@ def get_zstor_config():
         data["groups"].append(
             {
                 "backends": [
-                    {"address": f"[{zdb.ip_address}]:{zdb.port}", "namespace": zdb.namespace, "password": password},
-                ],
+                    {"address": f"[{zdb.ip_address}]:{zdb.port}", "namespace": zdb.namespace, "password": password}
+                ]
             }
         )
     return j.data.serializers.json.dumps({"data": j.data.serializers.toml.dumps(data)})

--- a/jumpscale/packages/vdc_dashboard/frontend/api.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/api.js
@@ -23,10 +23,12 @@ const apiClient = {
         method: "get",
       })
     },
-    getAllSolutions: () => {
+    getAllSolutions: (solutionTypes) => {
       return axios({
         url: `${baseURL}/deployments`,
-        method: "get",
+        method: "post",
+        data: { solution_types: solutionTypes },
+        headers: { 'Content-Type': 'application/json' }
       })
     },
     deleteSolution: (releaseName, solutionId, vdcName) => {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/marketplace/Solution.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/marketplace/Solution.vue
@@ -114,7 +114,6 @@ module.exports = {
       },
       headers: [
         { text: "Release", value: "Release" },
-        { text: "VDC Name", value: "VDC Name" },
         { text: "URL", value: "domain" },
         { text: "Version", value: "Version" },
         { text: "Status", value: "Status" },
@@ -161,11 +160,15 @@ module.exports = {
     },
     getDeployedSolutions(solution_type) {
       if(solution_type === "all"){
+        let solutionTypes = []
+        for(sol in this.sections["All Solutions"].apps){
+          solutionTypes.push(sol)
+        }
         this.$api.solutions
-        .getAllSolutions()
+        .getAllSolutions(solutionTypes)
         .then((response) => {
           this.deployedSolutions = response.data.data;
-          chartTypeHeader = { text: "Deployment", value: "Chart"}
+          chartTypeHeader = { text: "Solution Type", value: "Chart"}
           this.headers = [this.headers[0],chartTypeHeader,...this.headers.slice(1)]
         })
         .finally(() => {

--- a/jumpscale/packages/vdc_dashboard/sals/vdc_dashboard_sals.py
+++ b/jumpscale/packages/vdc_dashboard/sals/vdc_dashboard_sals.py
@@ -1,5 +1,6 @@
 from jumpscale.loader import j
 from jumpscale.packages.auth.bottle.auth import get_user_info
+import gevent
 
 
 def _filter_data(deployment):
@@ -22,48 +23,23 @@ def _filter_data(deployment):
     return filtered_deployment
 
 
-def get_all_deployments() -> list:
+def get_all_deployments(solution_types: list = None) -> list:
     """List all deployments from kubectl and corresponding helm list info"""
+    if not solution_types:
+        return []
     all_deployments = []
     username = j.data.serializers.json.loads(get_user_info()).get("username")
-    vdc_names = [vdc.vdc_name for vdc in j.sals.vdc.list(username)]
-    for vdc_name in vdc_names:
-        config_path = j.sals.fs.expanduser("~/.kube/config")
-        k8s_client = j.sals.kubernetes.Manager(config_path=config_path)
-        # Get all deployments
-        kubectl_deployment_info = k8s_client.execute_native_cmd(cmd=f"kubectl get deployments -o json")
-        deployments = j.data.serializers.json.loads(kubectl_deployment_info)["items"]
 
-        kubectl_statefulset_info = k8s_client.execute_native_cmd(cmd=f"kubectl get statefulset -o json")
-        kubectl_statefulset_info = j.data.serializers.json.loads(kubectl_statefulset_info)["items"]
+    def get_deployment(solution_type):
+        solution_type_deployments = get_deployments(solution_type, username)
+        all_deployments.extend(solution_type_deployments)
 
-        deployments.extend(kubectl_statefulset_info)
-        deployment_names = []
-        for deployment_info in deployments:
-            if "app.kubernetes.io/name" not in deployment_info["metadata"]["labels"]:
-                continue
+    threads = []
+    for solution_type in solution_types:
+        thread = gevent.spawn(get_deployment, solution_type)
+        threads.append(thread)
 
-            solution_type = deployment_info["metadata"]["labels"]["app.kubernetes.io/name"]
-            deployment_info = _filter_data(deployment_info)
-            release_name = deployment_info["Release"]
-            helm_chart_supplied_values = k8s_client.get_helm_chart_user_values(release=release_name)
-            try:
-                deployment_host = k8s_client.execute_native_cmd(
-                    cmd=f"kubectl get ingress -l app.kubernetes.io/instance={release_name} -o=jsonpath='{{.items[0].spec.rules[0].host}}'"
-                )
-            except:
-                pass
-
-            deployment_info.update(
-                {
-                    "User Supplied Values": j.data.serializers.json.loads(helm_chart_supplied_values),
-                    "VDC Name": vdc_name,
-                    "Domain": deployment_host,
-                    "Chart": solution_type,
-                }
-            )
-            all_deployments.append(deployment_info)
-            deployment_names.append(release_name)
+    gevent.joinall(threads)
 
     return all_deployments
 
@@ -117,6 +93,7 @@ def get_deployments(solution_type: str = None, username: str = None) -> list:
                     "VDC Name": vdc_name,
                     "Domain": deployment_host,
                     "User Supplied Values": j.data.serializers.json.loads(helm_chart_supplied_values),
+                    "Chart": solution_type,
                 }
             )
             all_deployments.append(deployment_info)


### PR DESCRIPTION
### Description

VDC solution lists included all deployments and so a chart that included multiple deployments will show them in listing of solutions. This needs to change to only list one instance of the deployed solution.
example:
![Screenshot from 2021-02-10 17-47-44](https://user-images.githubusercontent.com/17128393/107535288-47ac3a00-6bc9-11eb-8601-84c455ea0039.png)

### Changes
- Get all possible solution types defined in frontend, and send them in the request to get the deployed solutions
- Loop over the solution types and get the deployments for it using the single solution type function, then merge all these results and return to frontend
- Use gevent to reduce time taken to get the deployment information for each solution type
- Change label of deployment colomn to "Solution Type"
example after changes:
![Screenshot from 2021-02-10 17-48-09](https://user-images.githubusercontent.com/17128393/107535637-98bc2e00-6bc9-11eb-879c-5d3704a45b54.png)


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2459

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
