### PR TITLE
Change create/extend pool button to only create

### DIFF
--- a/jumpscale/packages/admin/frontend/components/dashboard/Dashboard.vue
+++ b/jumpscale/packages/admin/frontend/components/dashboard/Dashboard.vue
@@ -4,7 +4,7 @@
 
       <template #actions>
         <v-btn color="primary" text to="/solutions/pools">
-          <v-icon left>mdi-cloud</v-icon> Create/Extend Pool
+          <v-icon left>mdi-cloud</v-icon> Create Pool
         </v-btn>
 
         <v-btn color="primary" text @click.stop="dialogs.addAdmin = true">


### PR DESCRIPTION
### Description

Create/Extend Pool button in admin dashboard goes to creating a new pool chatflow so needs to be renamed after the create and extend chatflows were seperated

### Changes

- Change "Create/Extend Pool" to "Create Pool" in admin dashboard
![Screenshot from 2021-02-10 18-09-07](https://user-images.githubusercontent.com/17128393/107537623-c1452780-6bcb-11eb-8ba8-0c50bed2ba83.png)


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2220

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstrings
