### PR TITLE
convert no_nodes from string to int

### DIFF
--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -77,7 +77,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
         )
         flavor = chosen_flavor.split()[0]
         self.resources_limits = chart_limits[flavor]
-        no_nodes = self.resources_limits.get("no_nodes", 1)
+        no_nodes = int(self.resources_limits.get("no_nodes", 1))
         memory = int(self.resources_limits["memory"][:-2])
         cpu = int(self.resources_limits["cpu"][:-1])
 


### PR DESCRIPTION
### Description

Fixes:

```
root@zosv2-05:~# tail -f ~/.config/jumpscale/logs/fs/log.txt -n 10

  File "/sandbox/code/github/threefoldtech/js-sdk/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py", line 87, in _validate_resource_limits
    queries = [{"cpu": cpu, "memory": memory}] * no_nodes
                       │              │          └ '1'
                       │              └ 128
                       └ 100

TypeError: can't multiply sequence by non-int of type 'str'

```

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
