### PR TITLE
Handle the case when the cpu is passed as cores not milicores

### DIFF
--- a/jumpscale/sals/vdc/kubernetes_auto_extend.py
+++ b/jumpscale/sals/vdc/kubernetes_auto_extend.py
@@ -195,7 +195,11 @@ class KubernetesMonitor:
             node = pod_info["spec"]["nodeName"]
             for cont in pod_info["spec"]["containers"]:
                 cont_requests = cont["resources"].get("requests", {})
-                cpu += float(cont_requests.get("cpu", "0m").split("m")[0])
+                cpu_str = cont_requests.get("cpu", "0m")
+                if not cpu_str.endswith("m"):
+                    cpu += float(cpu_str) * 1000
+                else:
+                    cpu += float(cpu_str.split("m")[0])
                 p = re.search(r"^([0-9]*)(.*)$", cont_requests.get("memory", "0Gi"))
                 memory = float(p.group(1))
                 memory_unit = p.group(2)


### PR DESCRIPTION
### Description

Sometimes the cpu usage is passed in this format:

![Screenshot from 2021-02-11 11-28-33](https://user-images.githubusercontent.com/13040543/107620283-1da45780-6c5d-11eb-9443-b8dd4530c6a8.png)


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2474
