### PR TITLE
Change chatflow frontend validation to be on_change instead of on_burl

### DIFF
--- a/jumpscale/packages/chatflows/frontend/components/String.vue
+++ b/jumpscale/packages/chatflows/frontend/components/String.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Message :payload="payload"></Message>
-    <v-text-field v-model="val" :rules="rules" validate-on-blur outlined></v-text-field>
+    <v-text-field v-model="val" :rules="rules" validate-on-change outlined></v-text-field>
   </div>
 </template>
 

--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -51,7 +51,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
         "success",
     ]
 
-    CREATE_NAME_MESSAGE = "Just like humans, each 3Bot needs their own unique identity to exist on top of the Threefold Grid. Please enter a name for your new 3Bot. This name will be used as the web address that could give you access to your 3Bot anytime."
+    CREATE_NAME_MESSAGE = "Just like humans, each 3Bot needs its own unique identity. Please enter a name for your new 3Bot. This name can only consist of lower case letters and no special characters."
 
     def _threebot_start(self):
         self._validate_user()


### PR DESCRIPTION

### Changes

- Change chatflow frontend validation to be on_change instead of on_burl
- Change the 3Bot name message in the chatflow

![image](https://user-images.githubusercontent.com/36021484/108349184-5b6c2780-71eb-11eb-9a3f-d9b00fa0e349.png)


https://user-images.githubusercontent.com/36021484/108349229-6757e980-71eb-11eb-8864-78bc908d9d30.mp4


### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/2237
### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
