### PR TITLE
Update kubernetes workload with etcd datastore endpoint and disable default ingress

### DIFF
--- a/jumpscale/clients/explorer/models.py
+++ b/jumpscale/clients/explorer/models.py
@@ -49,6 +49,7 @@ class FarmerIP(Base):
     gateway = fields.IPAddress()
     reservation_id = fields.Integer()
 
+
 class CloudUnitMonthPrice(Base):
     cu = fields.Float(default=10)
     su = fields.Float(default=8)
@@ -72,10 +73,12 @@ class Farm(Base):
     def __str__(self):
         return " - ".join([x for x in [self.name, str(self.location)] if x])
 
+
 class FarmThreebotPrice(Base):
     threebot_id = fields.Integer()
     farm_id = fields.Integer()
     custom_cloudunits_price = fields.Object(CloudUnitMonthPrice)
+
 
 class WorkloadsAmount(Base):
     network = fields.Integer()
@@ -356,7 +359,6 @@ class ReservationInfo(Base):
     workload_type = fields.Enum(WorkloadType)
 
 
-
 class GatewayProxy(Base):
     id = fields.Integer()
     domain = fields.String(default="")
@@ -433,6 +435,9 @@ class K8s(Base):
     public_ip = fields.Integer()
     stats_aggregator = fields.List(fields.Object(Statsaggregator))
     info = fields.Object(ReservationInfo)
+    datastore_endpoint = fields.String(default="")
+    disable_default_ingress = fields.Boolean(default=True)
+
     SIZES = OrderedDict(
         {
             1: {"cru": 1, "mru": 2, "sru": 50},

--- a/jumpscale/sals/zos/kubernetes.py
+++ b/jumpscale/sals/zos/kubernetes.py
@@ -24,6 +24,8 @@ class KubernetesGenerator:
         ssh_keys: List[str],
         pool_id: int,
         public_ip_wid: int = 0,
+        disable_default_ingress=True,
+        datastore_endpoint="",
     ) -> K8s:
         """create a kubernetes marster workload object
 
@@ -60,6 +62,8 @@ class KubernetesGenerator:
             ssh_keys = [ssh_keys]
         master.ssh_keys = ssh_keys
         master.public_ip = public_ip_wid
+        master.disable_default_ingress = disable_default_ingress
+        master.datastore_endpoint = datastore_endpoint
 
         return master
 


### PR DESCRIPTION
PR will be needed for spawning kubernetes cluster with external etcds without doing any manual work on the k3s. related to #2553  let's not merge before the explorer is updated 