### PR TITLE
Add wallet topup qrcode in vdc dashboard and vdc deployer

### DIFF
--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -315,11 +315,5 @@ class Admin(BaseActor):
     def get_notifications_count(self) -> str:
         return j.data.serializers.json.dumps({"data": j.tools.notificationsqueue.count()})
 
-    @actor_method
-    def get_wallet_qrcode_image(self, address: str, amount: int, scale: int = 5) -> str:
-        data = f"TFT:{address}?amount={amount}&message=topup&sender=me"
-        qrcode_image = j.tools.qrcode.base64_get(data, scale=scale)
-        return j.data.serializers.json.dumps({"data": qrcode_image})
-
 
 Actor = Admin

--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -315,5 +315,11 @@ class Admin(BaseActor):
     def get_notifications_count(self) -> str:
         return j.data.serializers.json.dumps({"data": j.tools.notificationsqueue.count()})
 
+    @actor_method
+    def get_wallet_qrcode_image(self, address: str, amount: int, scale: int = 5) -> str:
+        data = f"TFT:{address}?amount={amount}&message=topup&sender=me"
+        qrcode_image = j.tools.qrcode.base64_get(data, scale=scale)
+        return j.data.serializers.json.dumps({"data": qrcode_image})
+
 
 Actor = Admin

--- a/jumpscale/packages/vdc/frontend/api.js
+++ b/jumpscale/packages/vdc/frontend/api.js
@@ -54,5 +54,16 @@ const apiClient = {
         method: "get"
       })
     },
-  }
+  },
+  wallets: {
+    walletQRCodeImage: (address, amount, scale) => {
+      return axios({
+        url: `/admin/actors/admin/get_wallet_qrcode_image`,
+        method: "post",
+        data: { address: address,amount: amount, scale: scale},
+        headers: { 'Content-Type': 'application/json' }
+      })
+    },
+  },
+
 }

--- a/jumpscale/packages/vdc/frontend/api.js
+++ b/jumpscale/packages/vdc/frontend/api.js
@@ -58,7 +58,7 @@ const apiClient = {
   wallets: {
     walletQRCodeImage: (address, amount, scale) => {
       return axios({
-        url: `/admin/actors/admin/get_wallet_qrcode_image`,
+        url: `/vdc/api/wallet/qrcode/get`,
         method: "post",
         data: { address: address,amount: amount, scale: scale},
         headers: { 'Content-Type': 'application/json' }

--- a/jumpscale/packages/vdc/frontend/components/solutions/Wallet.vue
+++ b/jumpscale/packages/vdc/frontend/components/solutions/Wallet.vue
@@ -81,7 +81,7 @@ module.exports = {
       this.$api.wallets
         .walletQRCodeImage(this.wallet.address,100,3)
         .then(result => {
-          this.qrcode = JSON.parse(result.data).data;
+          this.qrcode = result.data.data;
           this.currentWalletAddress =  this.wallet.address
         })
         .catch((err) => {

--- a/jumpscale/packages/vdc/frontend/components/solutions/Wallet.vue
+++ b/jumpscale/packages/vdc/frontend/components/solutions/Wallet.vue
@@ -40,7 +40,21 @@
                 </v-chip>
               </td>
             </tr>
+            <tr>
+              <td>QRCode</td>
+              <td class="pt-1">
+                <v-tooltip top>
+                  <template v-slot:activator="{ on, attrs }">
+                    <div class="text-left ma-4" v-bind="attrs" v-on="on">
+                      <img style="border:1px dashed #85929E" :src="`data:image/png;base64, ${qrcode}`"/>
+                    </div>
+                  </template>
+                  <span>Scan the QRCode to topup wallet using Threefold Connect application</span>
+                </v-tooltip>
+              </td>
+            </tr>
           </tbody>
+
         </template>
       </v-simple-table>
     </template>
@@ -57,7 +71,29 @@ module.exports = {
   data() {
     return {
       showSecret: false,
+      qrcode: "",
+      currentWalletAddress: null
     };
   },
+
+  methods: {
+    getQRCode() {
+      this.$api.wallets
+        .walletQRCodeImage(this.wallet.address,100,3)
+        .then(result => {
+          this.qrcode = JSON.parse(result.data).data;
+          this.currentWalletAddress =  this.wallet.address
+        })
+        .catch((err) => {
+          console.log(err);
+        })
+      },
+    },
+  updated(){
+      if(this.wallet && this.currentWalletAddress !== this.wallet.address){
+        this.getQRCode();
+      }
+  }
 };
+
 </script>

--- a/jumpscale/packages/vdc/frontend/index.html
+++ b/jumpscale/packages/vdc/frontend/index.html
@@ -27,6 +27,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.55.0/mode/python/python.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.55.0/addon/scroll/simplescrollbars.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.55.0/mode/python/python.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.js"></script>
   <script src="https://unpkg.com/vue-json-tree@0.4.1/dist/json-tree.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="data.js"></script>

--- a/jumpscale/packages/vdc_dashboard/bottle/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/deployments.py
@@ -316,4 +316,19 @@ def update():
     )
 
 
+@app.route("/api/wallet/qrcode/get", method="POST")
+@login_required
+def get_wallet_qrcode_image():
+    request_data = j.data.serializers.json.loads(request.body.read())
+    address = request_data.get("address")
+    amount = request_data.get("amount")
+    scale = request_data.get("scale", 5)
+    if not all([address, amount, scale]):
+        return HTTPResponse("Not all parameters satisfied", status=400, headers={"Content-Type": "application/json"})
+
+    data = f"TFT:{address}?amount={amount}&message=topup&sender=me"
+    qrcode_image = j.tools.qrcode.base64_get(data, scale=scale)
+    return j.data.serializers.json.dumps({"data": qrcode_image})
+
+
 app = SessionMiddleware(app, SESSION_OPTS)

--- a/jumpscale/packages/vdc_dashboard/frontend/api.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/api.js
@@ -103,7 +103,7 @@ const apiClient = {
   wallets: {
     walletQRCodeImage: (address, amount, scale) => {
       return axios({
-        url: `/admin/actors/admin/get_wallet_qrcode_image`,
+        url: `${baseURL}/wallet/qrcode/get`,
         method: "post",
         data: { address: address,amount: amount, scale: scale},
         headers: { 'Content-Type': 'application/json' }

--- a/jumpscale/packages/vdc_dashboard/frontend/api.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/api.js
@@ -99,5 +99,15 @@ const apiClient = {
         method: "get"
       })
     }
-  }
+  },
+  wallets: {
+    walletQRCodeImage: (address, amount, scale) => {
+      return axios({
+        url: `/admin/actors/admin/get_wallet_qrcode_image`,
+        method: "post",
+        data: { address: address,amount: amount, scale: scale},
+        headers: { 'Content-Type': 'application/json' }
+      })
+    },
+  },
 }

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Wallet.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Wallet.vue
@@ -64,6 +64,19 @@
               {{ new Date(expirationdate * 1000).toLocaleString("en-GB") }}
             </td>
           </tr>
+          <tr>
+            <td>QRCode</td>
+            <td class="pt-1">
+            <div class="text-left ma-1" >
+              <v-tooltip top>
+                <template v-slot:activator="{ on, attrs }">
+                    <img v-bind="attrs" v-on="on" style="border:1px dashed #85929E" :src="`data:image/png;base64, ${qrcode}`"/>
+                </template>
+                <span>Scan the QRCode to topup wallet using Threefold Connect application</span>
+              </v-tooltip>
+            </div>
+            </td>
+          </tr>
         </tbody>
       </template>
     </v-simple-table>
@@ -77,8 +90,26 @@ module.exports = {
   data() {
     return {
       showSecret: false,
+      qrcode: "",
     };
   },
+  methods: {
+    getQRCode() {
+      this.$api.wallets
+        .walletQRCodeImage(this.wallet.address,100,3)
+        .then(result => {
+          this.qrcode = JSON.parse(result.data).data;
+        })
+        .catch((err) => {
+          console.log(err);
+        })
+      },
+    },
+    mounted(){
+      if(this.wallet){
+        this.getQRCode();
+    }
+  }
 };
 </script>
 <style scoped>

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Wallet.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Wallet.vue
@@ -98,7 +98,7 @@ module.exports = {
       this.$api.wallets
         .walletQRCodeImage(this.wallet.address,100,3)
         .then(result => {
-          this.qrcode = JSON.parse(result.data).data;
+          this.qrcode = result.data.data;
         })
         .catch((err) => {
           console.log(err);

--- a/jumpscale/packages/vdc_dashboard/frontend/index.html
+++ b/jumpscale/packages/vdc_dashboard/frontend/index.html
@@ -27,8 +27,10 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.55.0/mode/python/python.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.55.0/addon/scroll/simplescrollbars.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.55.0/mode/python/python.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.js"></script>
   <script src="https://unpkg.com/vue-json-tree@0.4.1/dist/json-tree.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+
 
   <script src="data.js"></script>
   <script src="api.js"></script>


### PR DESCRIPTION
### Description
To top up a vdc wallet, the address needs to manually be transferred to the Threefold Connect app to fund this wallet. A top up QRCode should be available to simply scan using the app and fund the wallet.

### Changes

Add top up wallet QRCodes with 100 TFT default value in vdc deployer and vdc dashboard wallets

![Screenshot from 2021-02-22 15-39-50](https://user-images.githubusercontent.com/17128393/108716214-7fe63d80-7524-11eb-8477-a667b3485c2a.png)
![Screenshot from 2021-02-22 15-38-34](https://user-images.githubusercontent.com/17128393/108716335-a5734700-7524-11eb-9ecb-ed9b3e545b92.png)


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2502

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
