### PR TITLE
Add marker extend for excluding the expensive tests

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           sudo --preserve-env=TNAME --preserve-env=EMAIL --preserve-env=WORDS --preserve-env=WALLET_SECRET --preserve-env=SOURCE_WALLET_SECRET \
           --preserve-env=DESTINATION_WALLET_SECRET --preserve-env=FAKE_EMAIL --preserve-env=FAKE_GITHUB_TOKEN \
-          poetry run pytest tests -sv --cov=jumpscale --cov-report=xml --ignore=tests/clients/digitalocean --ignore=tests/clients/sendgrid
+          poetry run pytest tests -sv -m "not extend" --cov=jumpscale --cov-report=xml --ignore=tests/clients/digitalocean --ignore=tests/clients/sendgrid
       - name: Upload coverage to Codecov
         if: success()
         uses: codecov/codecov-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,4 @@ build-backend = "poetry.masonry.api"
 
 [tool.pytest.ini_options]
 markers = ["integration: marks tests as integration (deselect with '-m \"not integration\"')",
-           "unittests"]
+           "unittests", "extend"]


### PR DESCRIPTION
### Description

Add marker `extend` for excluding the expensive tests to run daily 

### Related Issues

#2601 

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
