### PR TITLE
Update etcd chatflow with more info

### DIFF
--- a/jumpscale/packages/vdc_dashboard/chats/etcd.py
+++ b/jumpscale/packages/vdc_dashboard/chats/etcd.py
@@ -4,7 +4,6 @@ from jumpscale.loader import j
 from jumpscale.sals.chatflows.chatflows import chatflow_step
 from jumpscale.packages.vdc_dashboard.sals.solutions_chatflow import SolutionsChatflowDeploy, POD_INITIALIZING_TIMEOUT
 from jumpscale.packages.vdc_dashboard.sals.vdc_dashboard_sals import get_deployments
-from time import time
 
 CHART_LIMITS = {
     "Silver": {"cpu": "100m", "memory": "128Mi", "no_nodes": "1", "volume_size": "2Gi"},

--- a/jumpscale/packages/vdc_dashboard/chats/etcd.py
+++ b/jumpscale/packages/vdc_dashboard/chats/etcd.py
@@ -71,10 +71,10 @@ class EtcdDeploy(SolutionsChatflowDeploy):
             self.stop(dedent(stop_message))
 
         self.is_certified = False
-        start_request_time = time()
+        start_request_time = j.data.time.now().timestamp
         request = None
         j.logger.debug("ETCD Check certificate")
-        while time() - start_request_time <= timeout:
+        while j.data.time.now().timestamp - start_request_time <= timeout:
             try:
                 request = j.tools.http.get(f"https://{self.domain}", timeout=timeout, verify=True)
                 self.is_certified = True

--- a/jumpscale/packages/vdc_dashboard/chats/etcd.py
+++ b/jumpscale/packages/vdc_dashboard/chats/etcd.py
@@ -47,7 +47,8 @@ class EtcdDeploy(SolutionsChatflowDeploy):
         )
 
     @chatflow_step(title="Initializing", disable_previous=True)
-    def initializing(self):
+    def initializing(self, timeout=300):
+        self.md_show_update(f"Initializing your {self.SOLUTION_TYPE}...")
         error_message_template = f"""\
                 Failed to initialize {self.SOLUTION_TYPE}, please contact support with this information:
 
@@ -69,9 +70,46 @@ class EtcdDeploy(SolutionsChatflowDeploy):
             self.k8s_client.delete_deployed_release(self.release_name)
             self.stop(dedent(stop_message))
 
+        self.is_certified = False
+        start_request_time = time()
+        request = None
+        j.logger.debug("ETCD Check certificate")
+        while time() - start_request_time <= timeout:
+            try:
+                request = j.tools.http.get(f"https://{self.domain}", timeout=timeout, verify=True)
+                self.is_certified = True
+                break
+            except j.tools.http.exceptions.SSLError:
+                self.md_show_update(
+                    dedent(
+                        f"Initializing your {self.SOLUTION_TYPE}...<br />\n### Check domain certificate should take around 2 to 3 minutes... <br />\n"
+                    ),
+                    md=True,
+                )
+                gevent.sleep(10)
+
+        if not self.is_certified:
+            request = j.tools.http.get(f"https://{self.domain}", timeout=timeout, verify=False)
+
+        # Etcd using TCP, always response return this msg "404 page not found"
+        if not "404 page not found" in str(request.content):
+            stop_message = error_message_template.format(reason="Couldn't reach the website after deployment")
+            self.stop(dedent(stop_message))
+
     @chatflow_step(title="Success", disable_previous=True, final_step=True)
     def success(self):
+        name = self.k8s_client.execute_native_cmd(
+            cmd=f"kubectl --namespace {self.chart_name}-{self.release_name} get pods -l app.kubernetes.io/name={self.chart_name} -l app.kubernetes.io/instance={self.release_name} -o=jsonpath='{{.items[0].metadata.generateName}}'"
+        )
         domain_message = f'- You can access it through this url: <a href="https://{self.domain}" target="_blank">https://{self.domain}</a> as follow:<br />\n'
+
+        additional_message = ""
+        if not self.is_certified:
+            additional_message = f"""- <a href="https://{self.domain}" target="_blank">https://{self.domain}</a> can't get certificate, you can still access your etcd as follow:\
+            <br />\n
+            <br />\n
+            `kubectl --namespace {self.chart_name}-{self.release_name} exec -it {name}0 -- etcdctl put hello Threefold`"""
+
         message = f"""\
         # You deployed a new instance {self.release_name} of {self.SOLUTION_TYPE}
         <br />\n
@@ -79,7 +117,9 @@ class EtcdDeploy(SolutionsChatflowDeploy):
         `etcdctl --endpoints=https://{self.domain}:2379 put hello Threefold`
         <br />\n
         `OK` will appear as confirmation message.
-
+        <br />\n
+        {additional_message}
+        <br />\n
         - You can visit <a href="https://etcd.io/docs/v3.4.0/" target="_blank">ETCD Docs</a> for more information
         """
         self.md_show(dedent(message), md=True)


### PR DESCRIPTION
### Description

Update etcd chatflow with more info related to certificate and add additional msg shown only if cert not verified, This message contains another method to use etcd using kubectl.

## ScreenShots

### Initialize step
![image](https://user-images.githubusercontent.com/11272864/108773554-33702180-7567-11eb-96cd-0f141ae4b8f6.png)

### In case cert verified
![withoutwarning](https://user-images.githubusercontent.com/11272864/108772531-c7d98480-7565-11eb-87a1-e60643164e23.png)
### In case cert not verified
![image](https://user-images.githubusercontent.com/11272864/108773483-176c8000-7567-11eb-9157-d118db939654.png)


### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
