### PR TITLE
Use activation wallet for vdc wallets activation instead of the activation service

### DIFF
--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -275,7 +275,14 @@ class Stellar(Client):
                 j.logger.error(f"failed to activate using the activation service {e}")
                 ## Try activating with `activation_wallet` j.clients.stellar.activation_wallet if exists
                 ## this activator should be imported on the system.
+        else:
+            raise RuntimeError(
+                "could not activate wallet. tried activation service and there's no activation_wallet configured on the system"
+            )
 
+    def activate_through_activation_wallet(self):
+        """Activate your wallet through activation wallet.
+        """
         if "activation_wallet" in j.clients.stellar.list_all() and self.instance_name != "activation_wallet":
             j.logger.info(f"trying to fund the wallet ourselves with the activation wallet")
             j.logger.info(f"activation wallet {self.instance_name}")
@@ -288,9 +295,7 @@ class Stellar(Client):
                 except Exception as e:
                     j.logger.error(f"failed to activate wallet {self.instance_name} using activation_wallet")
         else:
-            raise RuntimeError(
-                "could not activate wallet. tried activation service and there's no activation_wallet configured on the system"
-            )
+            raise RuntimeError("could not find the activation wallet")
 
     def activate_account(self, destination_address, starting_balance="3.6"):
         """Activates another account

--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -280,10 +280,10 @@ class Stellar(Client):
                 "could not activate wallet. tried activation service and there's no activation_wallet configured on the system"
             )
 
-    def activate_through_activation_wallet(self):
+    def activate_through_activation_wallet(self, wallet_name="activation_wallet"):
         """Activate your wallet through activation wallet.
         """
-        if "activation_wallet" in j.clients.stellar.list_all() and self.instance_name != "activation_wallet":
+        if wallet_name in j.clients.stellar.list_all() and self.instance_name != wallet_name:
             j.logger.info(f"trying to fund the wallet ourselves with the activation wallet")
             j.logger.info(f"activation wallet {self.instance_name}")
             for _ in range(5):

--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -295,7 +295,7 @@ class Stellar(Client):
                 except Exception as e:
                     j.logger.error(f"failed to activate wallet {self.instance_name} using activation_wallet")
         else:
-            raise RuntimeError("could not find the activation wallet")
+            raise RuntimeError(f"could not find the activation wallet: {wallet_name}")
 
     def activate_account(self, destination_address, starting_balance="3.6"):
         """Activates another account

--- a/jumpscale/packages/marketplace/package.py
+++ b/jumpscale/packages/marketplace/package.py
@@ -5,16 +5,15 @@ class marketplace:
     def install(self, **kwargs):
         """Called when package is added
         """
-        # WALLET_NAME = j.sals.marketplace.deployer.WALLET_NAME
-        # if WALLET_NAME not in j.clients.stellar.list_all():
-        #     secret = kwargs.get("secret", None)
-        #     wallet = j.clients.stellar.new(WALLET_NAME, secret=secret)
-        #     if not secret:
-        #         wallet.activate_through_threefold_service()
-        #         wallet.add_known_trustline("TFT")
-        #         j.logger.critical(f"Please fund the demos wallet using the address: {wallet.address}")
-        #     wallet.save()
-        pass
+        WALLET_NAME = j.sals.marketplace.deployer.WALLET_NAME
+        if WALLET_NAME not in j.clients.stellar.list_all():
+            secret = kwargs.get("secret", None)
+            if not secret:
+                j.logger.critical(f"Couldn't find wallet {WALLET_NAME} or its secret")
+            else:
+                wallet = j.clients.stellar.new(WALLET_NAME, secret=secret)
+                wallet.save()
+                j.logger.info(f"{WALLET_NAME} wallet has been imported successfully and ready to use.")
 
     def uninstall(self):
         """Called when package is deleted

--- a/jumpscale/packages/marketplace/package.py
+++ b/jumpscale/packages/marketplace/package.py
@@ -5,15 +5,16 @@ class marketplace:
     def install(self, **kwargs):
         """Called when package is added
         """
-        WALLET_NAME = j.sals.marketplace.deployer.WALLET_NAME
-        if WALLET_NAME not in j.clients.stellar.list_all():
-            secret = kwargs.get("secret", None)
-            wallet = j.clients.stellar.new(WALLET_NAME, secret=secret)
-            if not secret:
-                wallet.activate_through_threefold_service()
-                wallet.add_known_trustline("TFT")
-                j.logger.critical(f"Please fund the demos wallet using the address: {wallet.address}")
-            wallet.save()
+        # WALLET_NAME = j.sals.marketplace.deployer.WALLET_NAME
+        # if WALLET_NAME not in j.clients.stellar.list_all():
+        #     secret = kwargs.get("secret", None)
+        #     wallet = j.clients.stellar.new(WALLET_NAME, secret=secret)
+        #     if not secret:
+        #         wallet.activate_through_threefold_service()
+        #         wallet.add_known_trustline("TFT")
+        #         j.logger.critical(f"Please fund the demos wallet using the address: {wallet.address}")
+        #     wallet.save()
+        pass
 
     def uninstall(self):
         """Called when package is deleted

--- a/jumpscale/packages/threebot_deployer/package.py
+++ b/jumpscale/packages/threebot_deployer/package.py
@@ -11,17 +11,17 @@ class threebot_deployer:
             channel_port (int, optional): remote redis port
         """
         # Configure wallet
-        WALLET_NAME = j.sals.marketplace.deployer.WALLET_NAME
-        if WALLET_NAME not in j.clients.stellar.list_all():
-            wallet_secret = kwargs.get("wallet_secret", None)
-            wallet = j.clients.stellar.new(WALLET_NAME, secret=wallet_secret)
+        # WALLET_NAME = j.sals.marketplace.deployer.WALLET_NAME
+        # if WALLET_NAME not in j.clients.stellar.list_all():
+        #     wallet_secret = kwargs.get("wallet_secret", None)
+        #     wallet = j.clients.stellar.new(WALLET_NAME, secret=wallet_secret)
 
-            if not wallet_secret:
-                # mainnet, activate and add trustlines to an empty wallet
-                wallet.activate_through_threefold_service()
-                wallet.add_known_trustline("TFT")
-                wallet.save()
-            j.logger.info(f"Created wallet {WALLET_NAME} successfully and ready to use.")
+        #     if not wallet_secret:
+        #         # mainnet, activate and add trustlines to an empty wallet
+        #         wallet.activate_through_threefold_service()
+        #         wallet.add_known_trustline("TFT")
+        #         wallet.save()
+        #     j.logger.info(f"Created wallet {WALLET_NAME} successfully and ready to use.")
 
         # Configure Redis logs
         log_config = {}

--- a/jumpscale/packages/threebot_deployer/package.py
+++ b/jumpscale/packages/threebot_deployer/package.py
@@ -11,17 +11,16 @@ class threebot_deployer:
             channel_port (int, optional): remote redis port
         """
         # Configure wallet
-        # WALLET_NAME = j.sals.marketplace.deployer.WALLET_NAME
-        # if WALLET_NAME not in j.clients.stellar.list_all():
-        #     wallet_secret = kwargs.get("wallet_secret", None)
-        #     wallet = j.clients.stellar.new(WALLET_NAME, secret=wallet_secret)
-
-        #     if not wallet_secret:
-        #         # mainnet, activate and add trustlines to an empty wallet
-        #         wallet.activate_through_threefold_service()
-        #         wallet.add_known_trustline("TFT")
-        #         wallet.save()
-        #     j.logger.info(f"Created wallet {WALLET_NAME} successfully and ready to use.")
+        WALLET_NAME = j.sals.marketplace.deployer.WALLET_NAME
+        if WALLET_NAME not in j.clients.stellar.list_all():
+            wallet_secret = kwargs.get("wallet_secret", None)
+            if not wallet_secret:
+                j.logger.critical(f"Couldn't find wallet {WALLET_NAME} or its secret")
+            else:
+                # mainnet, activate and add trustlines to an empty wallet
+                wallet = j.clients.stellar.new(WALLET_NAME, secret=wallet_secret)
+                wallet.save()
+                j.logger.info(f"{WALLET_NAME} wallet has been imported successfully and ready to use.")
 
         # Configure Redis logs
         log_config = {}

--- a/jumpscale/sals/vdc/wallet.py
+++ b/jumpscale/sals/vdc/wallet.py
@@ -11,7 +11,7 @@ class VDCWallet(Base):
     def _init_wallet(self, secret=None):
         wallet = j.clients.stellar.new(self.instance_name, secret=secret)
         if not secret:
-            wallet.activate_through_threefold_service()
+            wallet.activate_through_activation_wallet()
         wallet.save()
         self.wallet_secret = wallet.secret
 

--- a/tests/frontend/tests/test_packages.py
+++ b/tests/frontend/tests/test_packages.py
@@ -1,6 +1,6 @@
 import pytest
 from jumpscale.loader import j
-from jumpscale.packages import polls
+from jumpscale.packages import marketplace
 from tests.frontend.pages.Packages.packages import Packages
 from tests.frontend.tests.base_tests import BaseTest
 
@@ -63,20 +63,20 @@ class PackagesTests(BaseTest):
         self.assertNotIn("notebooks", installed_packages.keys())
 
         self.info("Add a package using path")
-        path = j.sals.fs.dirname(polls.__file__)
+        path = j.sals.fs.dirname(marketplace.__file__)
         self.packages.add_package(path=path)
 
         self.info("Check that the package has been Added correctly")
         installed_packages, available_packages = self.packages.get_installed_and_available_packages()
-        self.assertNotIn("polls", available_packages.keys())
-        self.assertIn("polls", installed_packages.keys())
+        self.assertNotIn("marketplace", available_packages.keys())
+        self.assertIn("marketplace", installed_packages.keys())
 
         self.info("Delete the package")
-        self.packages.delete_package("polls")
+        self.packages.delete_package("marketplace")
 
         self.info("Check that the packages has been deleted successfully")
         installed_packages, available_packages = self.packages.get_installed_and_available_packages()
-        self.assertNotIn("polls", installed_packages.keys())
+        self.assertNotIn("marketplace", installed_packages.keys())
 
         self.info("Install another package")
         installed_package = self.packages.install_random_package()

--- a/tests/sals/vdc/vdc_base.py
+++ b/tests/sals/vdc/vdc_base.py
@@ -10,6 +10,7 @@ class VDCBase(BaseTests):
     def setUpClass(cls):
         cls._get_env_vars()
         cls._import_wallet()
+        cls._import_wallet("activation_wallet")
         cls._prepare_identity()
         cls._start_threebot_server()
 

--- a/tests/sals/zos/test_pools.py
+++ b/tests/sals/zos/test_pools.py
@@ -9,7 +9,7 @@ from tests.base_tests import BaseTests
 WALLET_NAME = os.environ.get("WALLET_NAME")
 WALLET_SECRET = os.environ.get("WALLET_SECRET")
 TRANSACTION_FEES = 0.1
-zos = j.sals.zos
+zos = j.sals.zos.get()
 
 
 def info(msg):
@@ -32,11 +32,11 @@ def new_wallet():
     info("Create empty wallet")
     wallet_name = j.data.idgenerator.nfromchoices(10, string.ascii_letters)
     wallet = j.clients.stellar.new(wallet_name, network="STD")
-    wallet.activate_through_threefold_service()
+    wallet.activate_through_activation_wallet()
     wallet.add_known_trustline("TFT")
     yield wallet
     info("Returning XLMs to the activation wallet")
-    wallet.return_xlms_to_activation()
+    wallet.merge_into_account(get_funded_wallet().address)
 
 
 def get_wallet_balance(wallet):


### PR DESCRIPTION
### Description

- Use activation wallet for vdc wallets activation instead of the activation service
- Remove creating wallet while adding packages.
- Adjust the tests for the activation wallets.

### Related Issues

#2637

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
