### PR TITLE
Add UI name to packages and change flist marketplace to 3bot_apps

### DIFF
--- a/jumpscale/packages/admin/frontend/components/packages/Package.vue
+++ b/jumpscale/packages/admin/frontend/components/packages/Package.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
   <v-card class="ma-4 mt-2" width="300" :loading="loading" :disabled="loading">
-    <v-card-title class="primary--text">{{pkg.name}}</v-card-title>
+    <v-card-title class="primary--text">{{pkg.ui_name}}</v-card-title>
     <v-card-subtitle v-if="pkg.system_package">System Package</v-card-subtitle>
     <v-card-text style="height:75px">
       {{pkg.path.length > PACKAGE_PATH_MAXLENGTH ?

--- a/jumpscale/packages/marketplace/package.toml
+++ b/jumpscale/packages/marketplace/package.toml
@@ -1,4 +1,5 @@
 name = "marketplace"
+ui_name = "3bot_apps"
 is_auth = false
 is_admin = false
 frontend = "/marketplace"

--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -277,6 +277,10 @@ class Package:
         return self._config
 
     @property
+    def ui_name(self):
+        return self.config.get("ui_name", self.name)
+
+    @property
     def actors_dir(self):
         actors_dir = j.sals.fs.join_paths(self.path, self.config.get("actors_dir", "actors"))
         if j.sals.fs.exists(actors_dir):
@@ -414,6 +418,7 @@ class PackageManager(Base):
                             "installed": True,
                             "frontend": package.config.get("frontend", False),
                             "chatflows": chatflows,
+                            "ui_name": package.ui_name,
                         }
                     )
                 else:
@@ -426,6 +431,10 @@ class PackageManager(Base):
             for pkg in os.listdir(path):
                 pkg_path = j.sals.fs.join_paths(path, pkg)
                 pkgtoml_path = j.sals.fs.join_paths(pkg_path, "package.toml")
+                ui_name = pkg
+                with open(pkgtoml_path) as f:
+                    conf = j.data.serializers.toml.loads(f.read())
+                    ui_name = conf.get("ui_name", pkg)
                 if pkg not in self.packages and j.sals.fs.exists(pkgtoml_path):
                     all_packages.append(
                         {
@@ -434,6 +443,7 @@ class PackageManager(Base):
                             "giturl": "",
                             "system_package": pkg in DEFAULT_PACKAGES.keys(),
                             "installed": False,
+                            "ui_name": ui_name,
                         }
                     )
 
@@ -516,6 +526,7 @@ class PackageManager(Base):
             "giturl": package.giturl,
             "kwargs": package.kwargs,
             "admins": package.admins,
+            "ui_name": package.ui_name,
         }
 
         self.save()


### PR DESCRIPTION
- Allows packages to have human readable name using ui_name in config and fallback to package name if it's not defined.
- Changes the flist marketplace package UI name to 3bot_apps

![image](https://user-images.githubusercontent.com/64129/109292921-c0e79600-7833-11eb-9deb-632547c38dda.png)

Should fix https://github.com/threefoldtech/home/issues/1019 and #2645