### PR TITLE
fix service manager typo

### DIFF
--- a/jumpscale/tools/servicemanager/servicemanager.py
+++ b/jumpscale/tools/servicemanager/servicemanager.py
@@ -123,7 +123,7 @@ class ServiceManager(Base):
             greenlet (Greenlet): greenlet object
         """
         message = f"Service {greenlet.service.name} raised an exception: {greenlet.exception}"
-        j.tools.alerthandler.alert_raise(appname="servicemanager", message=message, alert_type="exception")
+        j.tools.alerthandler.alert_raise(app_name="servicemanager", message=message, alert_type="exception")
 
     def __callback(self, greenlet):
         """Callback runs after greenlet finishes execution


### PR DESCRIPTION
appname is called app_name in the method

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
