### PR TITLE
fix state when restoring threebot state

### DIFF
--- a/jumpscale/packages/threebot_deployer/bottle/utils.py
+++ b/jumpscale/packages/threebot_deployer/bottle/utils.py
@@ -136,6 +136,10 @@ def list_threebot_solutions(owner):
             solution_info["state"] = ThreebotState.ERROR.value
             threebot.state = ThreebotState.ERROR
             threebot.save()
+        elif j.sals.reservation_chatflow.wait_http_test(domain, timeout=10, verify=not j.config.get("TEST_CERT")):
+            solution_info["state"] = ThreebotState.RUNNING.value
+            threebot.state = ThreebotState.RUNNING
+            threebot.save()
 
         result.append(solution_info)
 


### PR DESCRIPTION
### Description

- The state was set to error and never went back

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
