### PR TITLE
presearch node - lower chart limits

### DIFF
--- a/jumpscale/packages/vdc_dashboard/chats/presearch.py
+++ b/jumpscale/packages/vdc_dashboard/chats/presearch.py
@@ -10,8 +10,8 @@ class PresearchDeploy(SolutionsChatflowDeploy):
     steps = ["get_release_name", "create_subdomain", "set_config", "install_chart", "initializing", "success"]
 
     CHART_LIMITS = {
-        "Silver": {"cpu": "2000m", "memory": "2024Mi"},
-        "Gold": {"cpu": "3000m", "memory": "3072Mi"},
+        "Silver": {"cpu": "1000m", "memory": "1024Mi"},
+        "Gold": {"cpu": "2000m", "memory": "2048Mi"},
         "Platinum": {"cpu": "4000m", "memory": "4096Mi"},
     }
 


### PR DESCRIPTION
### Description

The Presearch node is deployable with less resources. In the chatflow, we need to lower the chart limits for the users to select less resources.

### Changes

- Lower chart limits in the chatflow

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2684

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
