### PR TITLE
fix status code for deleting backup

### DIFF
--- a/jumpscale/packages/vdc_dashboard/bottle/backup.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/backup.py
@@ -62,7 +62,7 @@ def delete_backup():
 
     try:
         client.execute_native_cmd(f"velero delete backup {name} --confirm")
-        return HTTPResponse("Backup deleted successfully.", status=204, headers={"Content-Type": "application/json"})
+        return HTTPResponse("Backup deleted successfully.", status=200, headers={"Content-Type": "application/json"})
     except Exception as e:
         j.logger.warning(f"Failed to delete backup due to {str(e)}")
         return HTTPResponse("Failed to delete backup.", status=500, headers={"Content-Type": "application/json"})


### PR DESCRIPTION
### Description

204 causes
```
<h1>Critical error while processing request: /api/backup/delete</h1>127.0.0.1 - - [2021-03-02 14:38:58] "POST /api/backup/delete HTTP/1.0" 500 222 0.591415

```

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
