### PR TITLE
Fix get local latest tag for js-sdk repo

### DIFF
--- a/jumpscale/packages/vdc_dashboard/bottle/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/deployments.py
@@ -362,8 +362,9 @@ def check_update():
     except Exception as e:
         raise j.exceptions.Runtime(f"Failed to fetch remote releases. {str(e)}")
 
-    _, latest_local_tag, _ = j.sals.process.execute("git describe --tags --abbrev=0")
-
+    vdc_dashboard_path = j.packages.vdc_dashboard.__file__
+    sdk_repo_path = j.tools.git.find_git_path(vdc_dashboard_path)
+    _, latest_local_tag, _ = j.sals.process.execute("git describe --tags --abbrev=0", cwd=sdk_repo_path)
     if latest_remote_tag != latest_local_tag.rstrip("\n"):
         return HTTPResponse(
             j.data.serializers.json.dumps({"new_release": latest_remote_tag}),

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Home.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Home.vue
@@ -149,8 +149,8 @@ module.exports = {
         .then((response) => {
           let new_release = response.data.new_release;
           if (new_release) {
-            this.release = false; //new_release;
-            this.dialog.release = false; //true;
+            this.release = new_release;
+            this.dialog.release = true;
           }
         })
     },


### PR DESCRIPTION
### Description

- Fix get local latest tag for js-sdk repo
### Changes

- get the latest local tag from the right dir
### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/2712
