### PR TITLE
Add hours attribute to deploy VDC

### DIFF
--- a/tests/sals/automated_chatflows/test_vdc_dashboard.py
+++ b/tests/sals/automated_chatflows/test_vdc_dashboard.py
@@ -19,7 +19,11 @@ class VDCDashboard(VDCBase):
         cls._import_wallet("demos_wallet")
         no_deployment = "single"
         cls.flavor = "platinum"
-        cls.kube_config = cls.deploy_vdc()
+
+        if cls.no_deployment == "single":
+            cls.kube_config = cls.deploy_vdc()
+        else:
+            cls.kube_config = cls.deploy_vdc(hours=2)
 
         if not cls.kube_config:
             raise RuntimeError("VDC is not deployed")

--- a/tests/sals/vdc/vdc_base.py
+++ b/tests/sals/vdc/vdc_base.py
@@ -50,7 +50,7 @@ class VDCBase(BaseTests):
             cls.me = j.core.identity.me
 
         # Configure test identity and start threebot server.
-        cls.explorer_url = "https://explorer.testnet.grid.tf/api/v1"
+        cls.explorer_url = "https://explorer.devnet.grid.tf/api/v1"
         cls.identity_name = j.data.random_names.random_name()
         identity = j.core.identity.new(
             cls.identity_name, tname=cls.tname, email=cls.email, words=cls.words, explorer_url=cls.explorer_url
@@ -84,4 +84,5 @@ class VDCBase(BaseTests):
         minio_sk = cls.random_string()
         cls.timestamp_now = j.data.time.get().utcnow().timestamp
         kube_config = cls.deployer.deploy_vdc(minio_ak, minio_sk)
+        cls.deployer.renew_plan(duration=hours / 24)
         return kube_config

--- a/tests/sals/vdc/vdc_base.py
+++ b/tests/sals/vdc/vdc_base.py
@@ -50,7 +50,7 @@ class VDCBase(BaseTests):
             cls.me = j.core.identity.me
 
         # Configure test identity and start threebot server.
-        cls.explorer_url = "https://explorer.devnet.grid.tf/api/v1"
+        cls.explorer_url = "https://explorer.testnet.grid.tf/api/v1"
         cls.identity_name = j.data.random_names.random_name()
         identity = j.core.identity.new(
             cls.identity_name, tname=cls.tname, email=cls.email, words=cls.words, explorer_url=cls.explorer_url
@@ -74,9 +74,8 @@ class VDCBase(BaseTests):
         cls.info(f"Transfer needed TFT to deploy vdc for {hours} hour/s to the provisioning wallet.")
         cls.vdc_price = j.tools.zos.consumption.calculate_vdc_price(cls.flavor)
         extension_fees = TRANSACTION_FEES if hours > 1 else 0
-        needed_tft = hours * (
-            float(cls.vdc_price) / 24 / 30 ) + 2 * TRANSACTION_FEES + extension_fees
-        )  # 2 transaction fees for creating the pool and extend it
+        needed_tft = hours * (float(cls.vdc_price) / 24 / 30) + 2 * TRANSACTION_FEES + extension_fees
+        # 2 transaction fees for creating the pool and extend it
         cls.vdc.transfer_to_provisioning_wallet(needed_tft, "test_wallet")
 
         cls.info(f"Deploy VDC for {hours} hours.")
@@ -85,5 +84,6 @@ class VDCBase(BaseTests):
         minio_sk = cls.random_string()
         cls.timestamp_now = j.data.time.get().utcnow().timestamp
         kube_config = cls.deployer.deploy_vdc(minio_ak, minio_sk)
-        cls.deployer.renew_plan(duration=hours / 24)
+        if hours > 1:
+            cls.deployer.renew_plan(duration=hours / 24)
         return kube_config

--- a/tests/sals/vdc/vdc_base.py
+++ b/tests/sals/vdc/vdc_base.py
@@ -73,8 +73,9 @@ class VDCBase(BaseTests):
 
         cls.info(f"Transfer needed TFT to deploy vdc for {hours} hour/s to the provisioning wallet.")
         cls.vdc_price = j.tools.zos.consumption.calculate_vdc_price(cls.flavor)
+        extension_fees = TRANSACTION_FEES if hours > 1 else 0
         needed_tft = hours * (
-            float(cls.vdc_price) / 24 / 30 + 2 * TRANSACTION_FEES
+            float(cls.vdc_price) / 24 / 30 ) + 2 * TRANSACTION_FEES + extension_fees
         )  # 2 transaction fees for creating the pool and extend it
         cls.vdc.transfer_to_provisioning_wallet(needed_tft, "test_wallet")
 

--- a/tests/sals/vdc/vdc_base.py
+++ b/tests/sals/vdc/vdc_base.py
@@ -66,19 +66,19 @@ class VDCBase(BaseTests):
         cls.server.start()
 
     @classmethod
-    def deploy_vdc(cls):
+    def deploy_vdc(cls, hours=1):
         cls.vdc_name = cls.random_name().lower()
         cls.password = cls.random_string()
         cls.vdc = j.sals.vdc.new(cls.vdc_name, cls.tname, cls.flavor)
 
         cls.info("Transfer needed TFT to deploy vdc for an hour to the provisioning wallet.")
         cls.vdc_price = j.tools.zos.consumption.calculate_vdc_price(cls.flavor)
-        needed_tft = (
+        needed_tft = hours * (
             float(cls.vdc_price) / 24 / 30 + 2 * TRANSACTION_FEES
         )  # 2 transaction fees for creating the pool and extend it
         cls.vdc.transfer_to_provisioning_wallet(needed_tft, "test_wallet")
 
-        cls.info("Deploy VDC.")
+        cls.info(f"Deploy VDC for {hours} hours.")
         cls.deployer = cls.vdc.get_deployer(password=cls.password)
         minio_ak = cls.random_name().lower()
         minio_sk = cls.random_string()

--- a/tests/sals/vdc/vdc_base.py
+++ b/tests/sals/vdc/vdc_base.py
@@ -71,7 +71,7 @@ class VDCBase(BaseTests):
         cls.password = cls.random_string()
         cls.vdc = j.sals.vdc.new(cls.vdc_name, cls.tname, cls.flavor)
 
-        cls.info("Transfer needed TFT to deploy vdc for an hour to the provisioning wallet.")
+        cls.info(f"Transfer needed TFT to deploy vdc for {hours} hour/s to the provisioning wallet.")
         cls.vdc_price = j.tools.zos.consumption.calculate_vdc_price(cls.flavor)
         needed_tft = hours * (
             float(cls.vdc_price) / 24 / 30 + 2 * TRANSACTION_FEES


### PR DESCRIPTION
### Description

In VDC Dashboard testing, VDC expire before the end of the tests because it deploys default for 1 hour, Add hours attribute to deploy VDC with custom number of hours

### Changes

- Add hours attribute for deploy_vdc function
- For double test deploy it for 2 hours

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
