### PR TITLE
use gevent.signal_handler instead of the deprecated gevent.signal

### DIFF
--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -807,7 +807,7 @@ class ThreebotServer(Base):
         # start default servers in the rack
         # handle signals
         for signal_type in (signal.SIGTERM, signal.SIGINT, signal.SIGKILL):
-            gevent.signal(signal_type, self.stop)
+            gevent.signal_handler(signal_type, self.stop)
 
         # mark app as started
         if self.is_running():


### PR DESCRIPTION
Solves #2744

### Description

gevent.signal is deprecated, gevent.signal_handler is the same ( https://github.com/gevent/gevent/blob/1.4.0/src/gevent/__init__.py )  but supported in newer gevent versions

### Changes
In the start of the threebot, replacement of `gevent.signal` with `gevent.signal_handler`

### Related Issues

gevent.signal is deprecated, use gevent.signal_handler : #2744
