### PR TITLE
Fix the Matic object key in the js dictionary

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/data.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/data.js
@@ -238,7 +238,7 @@ const BC_SOLUTIONS = {
             helpLink: "https://now.threefold.io/now/docs/harmony/",
             description: "Fast and open blockchain for decentralized applications."
         },
-        Matic: {
+        matic: {
             name: "Matic",
             type: "matic",
             image: "./assets/matic.png",


### PR DESCRIPTION
### Description

Fix the Matic object key in the js dictionary
### Changes

change the object key to lower case characters, because the `object key` and the `type` have to be similar.

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
