### PR TITLE
Handle unfound unlockhashes in the stellar client gracefully

### DIFF
--- a/jumpscale/clients/stellar/__init__.py
+++ b/jumpscale/clients/stellar/__init__.py
@@ -22,8 +22,7 @@ class StellarFactory(StoredFactory):
         return instance
 
     def check_stellar_service(self):
-        """This method will check if stellar and token service is up or not
-        """
+        """This method will check if stellar and token service is up or not"""
         _THREEFOLDFOUNDATION_TFTSTELLAR_SERVICES = {
             "TEST": "https://testnet.threefold.io/threefoldfoundation/transactionfunding_service/fund_transaction",
             "STD": "https://tokenservices.threefold.io/threefoldfoundation/transactionfunding_service/fund_transaction",

--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -120,6 +120,8 @@ class Stellar(Client):
     def _get_unlockhash_transaction(self, unlockhash):
         data = {"unlockhash": unlockhash}
         resp = j.tools.http.post(self._get_url("GET_UNLOCK"), json={"args": data})
+        if resp.status_code ==j.tools.http.status_codes.codes.NOT_FOUND:
+            return None
         resp.raise_for_status()
         return resp.json()
 

--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -120,7 +120,7 @@ class Stellar(Client):
     def _get_unlockhash_transaction(self, unlockhash):
         data = {"unlockhash": unlockhash}
         resp = j.tools.http.post(self._get_url("GET_UNLOCK"), json={"args": data})
-        if resp.status_code ==j.tools.http.status_codes.codes.NOT_FOUND:
+        if resp.status_code == j.tools.http.status_codes.codes.NOT_FOUND:
             return None
         resp.raise_for_status()
         return resp.json()
@@ -149,8 +149,7 @@ class Stellar(Client):
         self._create_unlockhash_transaction(unlock_hash=unlock_hash, transaction_xdr=txe.to_xdr())
 
     def get_balance(self, address=None):
-        """Gets the balances for a stellar address
-        """
+        """Gets the balances for a stellar address"""
         if address is None:
             address = self.address
         all_balances = self._get_free_balances(address)
@@ -254,8 +253,7 @@ class Stellar(Client):
         server.submit_transaction(transaction)
 
     def activate_through_friendbot(self):
-        """Activates and funds a testnet account using friendbot
-        """
+        """Activates and funds a testnet account using friendbot"""
         if self.network.value != "TEST":
             raise Exception("Account activation through friendbot is only available on testnet")
 
@@ -286,8 +284,7 @@ class Stellar(Client):
             )
 
     def activate_through_activation_wallet(self, wallet_name="activation_wallet"):
-        """Activate your wallet through activation wallet.
-        """
+        """Activate your wallet through activation wallet."""
         if wallet_name in j.clients.stellar.list_all() and self.instance_name != wallet_name:
             j.logger.info(f"trying to fund the wallet ourselves with the activation wallet")
             j.logger.info(f"activation wallet {self.instance_name}")
@@ -825,7 +822,7 @@ class Stellar(Client):
             return tx.to_xdr()
 
     def sign(self, tx_xdr: str, submit: bool = True):
-        """ sign signs a transaction xdr and optionally submits it to the network
+        """sign signs a transaction xdr and optionally submits it to the network
 
         Args:
             tx_xdr (str): transaction to sign in xdr format


### PR DESCRIPTION
### Description
before, un unfound unlockhash on an escrow account resulted in a crash in the get_balance method , see #2812

Now it shows:
```
j.clients.stellar.robtest.get_balance()
Balances
  10000.0000000 XLM
Locked balances:
 - Escrow account GAPABHUXFY5C2KT33Y4RSIX2OBAPM3BHFJZR6R5WQ6Y5T4UUW6CMPR3N with unknown unlockhashes ['TBXLGRBJQY7SF7JJAGCXT7K7RZG4TJUPHFWVG4UINGPMZTSW7LAB6E2R']
- 0.0000000 TFT:GA47YZA3PKFUZMPLQ3B5F2E3CJIB57TGGU7SPCQT2WAEYKN766PWIMB3
- 7.5998700 XLM
 - Escrow account GASQGXK4YJ2QGGUPNMEMI34PVDRYNO6RN4KTNDISYYK2ZRB5QPMIERX3 with unknown unlockhashes ['TBCG52AFPFLBMIQSLSPNCEI6IPK5TS3LHQSK7X53BYXLTA3LZPU7L3H7']
- 0.0000000 TFT:GA47YZA3PKFUZMPLQ3B5F2E3CJIB57TGGU7SPCQT2WAEYKN766PWIMB3
- 7.5998700 XLM
 - Escrow account GAVUGUYJKKSW2QA6T6MHJKFWZN7YJQZ54DBUDBYTEQUML4J64I3TE5CI with unknown unlockhashes ['TCANSP5Q2ZIQPQ64BAWYWIYSE47LACESZKKC26FU2K6HYV66HEILTOAK']
- 0.0000000 TFT:GA47YZA3PKFUZMPLQ3B5F2E3CJIB57TGGU7SPCQT2WAEYKN766PWIMB3
- 7.5998700 XLM
 - Escrow account GDJ37FRCM2XSJJGNVCQ2HE6AU4XDDSD2CYMO73PZIFFDJZKL633QFYMY with unknown unlockhashes ['TAEUBH2LSD2PE6M2SIZDW6N4U6AZ5ZLQ5A7IN6AWXZCRFDGTTQUKFXKC']
- 0.0000000 TFT:GA47YZA3PKFUZMPLQ3B5F2E3CJIB57TGGU7SPCQT2WAEYKN766PWIMB3
- 7.5998700 XLM
```

Solves #2812 

