### PR TITLE
Update vdc backup restore msg to warn it will take time

### DIFF
--- a/jumpscale/packages/vdc_dashboard/bottle/backup.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/backup.py
@@ -100,7 +100,11 @@ def restore_backup():
 
     try:
         client.execute_native_cmd(f"velero create restore restore-{name}-{time} --from-backup {name}")
-        return HTTPResponse("Backup restored successfully.", status=200, headers={"Content-Type": "application/json"})
+        return HTTPResponse(
+            "Backup restored successfully. It may take a few minutes to reflect.",
+            status=200,
+            headers={"Content-Type": "application/json"},
+        )
     except Exception as e:
         j.logger.warning(f"Failed to restore backup due to {str(e)}")
         return HTTPResponse("Failed to restore backup.", status=500, headers={"Content-Type": "application/json"})


### PR DESCRIPTION
### Description

When restoring vdc backup, user is unaware it may take some time

### Changes

Update vdc backup restore msg to warn it will take time
![Screenshot from 2021-03-23 14-11-18](https://user-images.githubusercontent.com/17128393/112146012-b9719d80-8be3-11eb-817a-3ad8d03cb9d5.png)


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2790

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
