### PR TITLE
Use vdc password hash

### DIFF
--- a/jumpscale/packages/vdc/chats/new_vdc.py
+++ b/jumpscale/packages/vdc/chats/new_vdc.py
@@ -7,6 +7,8 @@ from textwrap import dedent
 from jumpscale.sals.vdc.scheduler import GlobalCapacityChecker
 from urllib.parse import urlparse
 import math
+import hashlib
+
 
 MINIMUM_ACTIVATION_XLMS = 0
 
@@ -165,10 +167,11 @@ class VDCDeploy(GedisChatBot):
             self.backup_config = {}
             return
 
+        self.password_hash = hashlib.md5(self.vdc_secret.encode()).hexdigest()
         alias = j.sals.minio_admin.get_alias(
             "vdc", backup_config["S3_URL"], backup_config["S3_AK"], backup_config["S3_SK"]
         )
-        alias.add_user(f"{self.username}-{self.vdc_name.value}", self.vdc_secret)
+        alias.add_user(f"{self.username}-{self.vdc_name.value}", self.password_hash)
         alias.allow_user_to_bucket(
             f"{self.username}-{self.vdc_name.value}",
             backup_config["S3_BUCKET"],
@@ -176,7 +179,7 @@ class VDCDeploy(GedisChatBot):
         )
         self.backup_config = {
             "ak": f"{self.username}-{self.vdc_name.value}",
-            "sk": self.vdc_secret,
+            "sk": self.password_hash,
             "region": "minio",
             "url": backup_config.get("S3_URL", ""),
             "bucket": backup_config.get("S3_BUCKET", ""),

--- a/jumpscale/packages/vdc/chats/new_vdc.py
+++ b/jumpscale/packages/vdc/chats/new_vdc.py
@@ -7,7 +7,6 @@ from textwrap import dedent
 from jumpscale.sals.vdc.scheduler import GlobalCapacityChecker
 from urllib.parse import urlparse
 import math
-import hashlib
 
 
 MINIMUM_ACTIVATION_XLMS = 0
@@ -167,7 +166,7 @@ class VDCDeploy(GedisChatBot):
             self.backup_config = {}
             return
 
-        self.password_hash = hashlib.md5(self.vdc_secret.encode()).hexdigest()
+        self.password_hash = j.data.hash.md5(self.vdc_secret)
         alias = j.sals.minio_admin.get_alias(
             "vdc", backup_config["S3_URL"], backup_config["S3_AK"], backup_config["S3_SK"]
         )

--- a/tests/sals/automated_chatflows/test_vdc_dashboard.py
+++ b/tests/sals/automated_chatflows/test_vdc_dashboard.py
@@ -66,7 +66,10 @@ class VDCDashboard(VDCBase):
         kubernetes = K8s()
         kubernetes.size = VDC_SIZE.K8SNodeFlavor.MEDIUM.value
         # It will be deployed for an hour.
-        price = j.tools.zos.consumption.cost(kubernetes, 60 * 60) + TRANSACTION_FEES  # transactions fees.
+        zos = j.sals.zos.get()
+        farm_name = self.get_farm_name()
+        farm_id = zos._explorer.farms.get(farm_name=farm_name).id
+        price = j.tools.zos.consumption.cost(kubernetes, 60 * 60, farm_id) + TRANSACTION_FEES  # transactions fees.
         cls.vdc.transfer_to_provisioning_wallet(round(price, 6), "test_wallet")
 
         # Timeout for any exposed solution to be reachable and certified.

--- a/tests/sals/vdc/test_vdc.py
+++ b/tests/sals/vdc/test_vdc.py
@@ -127,7 +127,10 @@ class TestVDC(VDCBase):
         kubernetes = K8s()
         kubernetes.size = VDC_SIZE.K8SNodeFlavor.MEDIUM.value
         # It will be deployed for an hour.
-        price = j.tools.zos.consumption.cost(kubernetes, 60 * 60) + TRANSACTION_FEES  # transactions fees.
+        zos = j.sals.zos.get()
+        farm_name = self.get_farm_name()
+        farm_id = zos._explorer.farms.get(farm_name=farm_name).id
+        price = j.tools.zos.consumption.cost(kubernetes, 60 * 60, farm_id) + TRANSACTION_FEES  # transactions fees.
         self.vdc.transfer_to_provisioning_wallet(round(price, 6), "test_wallet")
 
         self.info("Add kubernetes node")
@@ -234,7 +237,10 @@ class TestVDC(VDCBase):
         zdb = ZdbNamespace()
         zdb.size = 10
         # In case of all tests runs, it will be deployed for an hour and renewed by a day.
-        price = j.tools.zos.consumption.cost(zdb, 25 * 60 * 60) + TRANSACTION_FEES  # transactions fees.
+        zos = j.sals.zos.get()
+        farm_name = self.get_farm_name()
+        farm_id = zos._explorer.farms.get(farm_name=farm_name).id
+        price = j.tools.zos.consumption.cost(zdb, 25 * 60 * 60, farm_id) + TRANSACTION_FEES  # transactions fees.
         self.vdc.transfer_to_provisioning_wallet(round(price, 6), "test_wallet")
 
         self.info("Extend zdbs")


### PR DESCRIPTION
### Description

- Use vdc password hash instead of password directly for backup config to allow spaces and quotes
- Fix cost method call in tests.

### Related Issues

#2804

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
