### PR TITLE
Reverse calculate timeDifference in the base JSONRenderer component

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/base/Info.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/base/Info.vue
@@ -5,6 +5,7 @@
           title="App details"
           :jsonobj="data"
           :ignored="KeysIgnored"
+          :typedict="KeysWithTypeDict"
         ></json-renderer>
       </template>
       <template #actions>
@@ -22,6 +23,7 @@ module.exports = {
       },
       tab: 0,
       KeysIgnored: ["Status Details", "User Supplied Values"],
+      KeysWithTypeDict: ["progress"],
     };
   },
   props: { data: Object },

--- a/jumpscale/packages/vdc_dashboard/frontend/components/base/JSONRenderer.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/base/JSONRenderer.vue
@@ -67,9 +67,9 @@ module.exports = {
   },
   methods: {
     timeDifference(ts) {
-      var timestamp = moment.unix(ts);
       var now = new Date();
-      return timestamp.to(now);
+      var timestamp = moment.unix(now / 1000);
+      return timestamp.to(ts * 1000);
     },
   },
   updated() {


### PR DESCRIPTION
### Changes

- Reverse calculate `timeDifference` in the base JSONRenderer component
![image](https://user-images.githubusercontent.com/36021484/112958350-ad855e80-9142-11eb-95c0-5f2f44611b83.png)

### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/2840
### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
