### PR TITLE
fix threebot workloads deletion state

### DIFF
--- a/jumpscale/packages/threebot_deployer/bottle/utils.py
+++ b/jumpscale/packages/threebot_deployer/bottle/utils.py
@@ -216,7 +216,7 @@ def stop_threebot_solution(owner, solution_uuid, password, timeout=40):
                 # wait for workload to decommision
                 expiration = j.data.time.get().timestamp + timeout
                 while j.data.time.get().timestamp < expiration:
-                    if workload.info.next_action != NextAction.DELETED:
+                    if zos.workloads.get(workload.id).info.next_action == NextAction.DELETED:
                         break
                     gevent.sleep(1)
                 else:


### PR DESCRIPTION
### Description

- workload information were cached

### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/2797

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
