### PR TITLE
Skip zdb workload in case it is not ready yet

### DIFF
--- a/jumpscale/sals/vdc/vdc.py
+++ b/jumpscale/sals/vdc/vdc.py
@@ -324,6 +324,9 @@ class UserVDC(Base):
                 self.etcd.append(node)
         elif workload.info.workload_type == WorkloadType.Zdb:
             result_json = j.data.serializers.json.loads(workload.info.result.data_json)
+            if not result_json:
+                j.logger.warning(f"Couldn't get result details for zdb workload: {workload.id}")
+                return
             if "IPs" in result_json:
                 ip = result_json["IPs"][0]
             else:


### PR DESCRIPTION
### Description

The problem was that we load vdc info in deployer to exclude master's node for deploying the workers, at the same time one of zdbs workload is not ready yet to get its info, so got `NoneType is not iterable`

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
