### PR TITLE
Add alphanumberic validation in secret ask and override the smpt meth…

### DIFF
--- a/jumpscale/packages/chatflows/frontend/mixins/field.js
+++ b/jumpscale/packages/chatflows/frontend/mixins/field.js
@@ -73,6 +73,12 @@ validators = {
         }
     },
     secret_ask: {
+        isAlphanumeric:(field) =>{
+            if(!field.val.match(/[A-Z]/i)){
+                return 'Value must be alphanumeric, including at least one character'
+            }
+
+        }
 
     },
     text_ask: {

--- a/jumpscale/packages/vdc_dashboard/chats/discourse.py
+++ b/jumpscale/packages/vdc_dashboard/chats/discourse.py
@@ -62,6 +62,18 @@ class DiscourseDeploy(SolutionsChatflowDeploy):
             else:
                 valid_password = True
 
+    def _ask_smtp_settings(self):
+        form = self.new_form()
+        smtp_host = form.string_ask("SMTP Host", default="smtp.gmail.com", required=True)
+        smtp_port = form.string_ask("SMTP Port", default=587, required=True)
+        smtp_username = form.string_ask("Email (SMTP username)", required=True)
+        smtp_password = form.secret_ask("Email Password", required=True, isAlphanumeric=True)
+        form.ask()
+        self.smtp_host = smtp_host.value
+        self.smtp_port = f'"{smtp_port.value}"'
+        self.smtp_username = smtp_username.value
+        self.smtp_password = smtp_password.value
+
     @chatflow_step(title="Configurations")
     def set_config(self):
         self._configure_admin_username_password()

--- a/jumpscale/packages/vdc_dashboard/chats/discourse.py
+++ b/jumpscale/packages/vdc_dashboard/chats/discourse.py
@@ -81,7 +81,7 @@ class DiscourseDeploy(SolutionsChatflowDeploy):
 
     @chatflow_step(title="Initializing", disable_previous=True)
     def initializing(self):
-        super().initializing(timeout=1200)
+        super().initializing(timeout=800, pod_initalizing_timeout=600)
 
 
 chat = DiscourseDeploy

--- a/jumpscale/packages/vdc_dashboard/chats/discourse.py
+++ b/jumpscale/packages/vdc_dashboard/chats/discourse.py
@@ -69,10 +69,10 @@ class DiscourseDeploy(SolutionsChatflowDeploy):
         smtp_username = form.string_ask("Email (SMTP username)", required=True)
         smtp_password = form.secret_ask("Email Password", required=True, isAlphanumeric=True)
         form.ask()
-        self.smtp_host = smtp_host.value
-        self.smtp_port = f'"{smtp_port.value}"'
-        self.smtp_username = smtp_username.value
-        self.smtp_password = smtp_password.value
+        self.config.chart_config.smtp_host = smtp_host.value
+        self.config.chart_config.smtp_port = f'"{smtp_port.value}"'
+        self.config.chart_config.smtp_username = smtp_username.value
+        self.config.chart_config.smtp_password = smtp_password.value
 
     @chatflow_step(title="Configurations")
     def set_config(self):

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -517,7 +517,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
 
         if not self.chart_pods_started():
             stop_message = error_message_template.format(reason="Pods initialization timed out")
-            self.k8s_client.execute_native_cmd(f"kubectl delete ns {self.chart_name}-{self.release_name}")
+            self.k8s_client.execute_native_cmd(f"kubectl delete ns {self.chart_name}-{self.config.release_name}")
             self.stop(dedent(stop_message))
 
         if self.config.chart_config.domain and not j.sals.reservation_chatflow.wait_http_test(


### PR DESCRIPTION
### Description

- Add alphanumeric validation for `secret_key`
- Override the SMTP method in discourse to use the alphanumeric argument
- Fix issue related to env vars index
- Update discourse timeout and add pod initialization timeout
### Changes

List of changes this PR includes

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2910

