### PR TITLE
Limit long solution names for Digibyte and Presearch

### DIFF
--- a/jumpscale/packages/vdc_dashboard/chats/digibyte.py
+++ b/jumpscale/packages/vdc_dashboard/chats/digibyte.py
@@ -23,9 +23,16 @@ class DigibyteDeploy(SolutionsChatflowDeploy):
 
     def get_release_name(self):
         self._check_uniqueness()
-        super().get_release_name()
-        if len(self.release_name) > 10:
-            raise StopChatFlow("Solution Name should not be more than 10 characters")
+        self._get_vdc_info()
+        message = "Please enter a name for your solution (will be used in listing and deletions in the future and in having a unique url)"
+        releases = [
+            release["name"]
+            for release in self.k8s_client.list_deployed_releases()
+            if release["namespace"].startswith(self.chart_name)
+        ]
+        self.release_name = self.string_ask(
+            message, required=True, is_identifier=True, not_exist=["solution name", releases], md=True, max_length=10
+        )
 
     def _enter_credentials(self):
         form = self.new_form()

--- a/jumpscale/packages/vdc_dashboard/chats/digibyte.py
+++ b/jumpscale/packages/vdc_dashboard/chats/digibyte.py
@@ -21,6 +21,7 @@ class DigibyteDeploy(SolutionsChatflowDeploy):
         if get_deployments(self.SOLUTION_TYPE, username):
             raise StopChatFlow("You can only have one Digibyte solution per VDC")
 
+    @chatflow_step(title="Solution Name")
     def get_release_name(self):
         self._check_uniqueness()
         self._get_vdc_info()

--- a/jumpscale/packages/vdc_dashboard/chats/digibyte.py
+++ b/jumpscale/packages/vdc_dashboard/chats/digibyte.py
@@ -24,9 +24,10 @@ class DigibyteDeploy(SolutionsChatflowDeploy):
     def get_release_name(self):
         self._check_uniqueness()
         super().get_release_name()
+        if len(self.release_name) > 10:
+            raise StopChatFlow("Solution Name should not be more than 10 characters")
 
     def _enter_credentials(self):
-
         form = self.new_form()
         self.rpcuser = form.string_ask("RPC Username", required=True)
         self.rpcpassword = form.secret_ask("RPC Password", required=True)

--- a/jumpscale/packages/vdc_dashboard/chats/presearch.py
+++ b/jumpscale/packages/vdc_dashboard/chats/presearch.py
@@ -22,9 +22,16 @@ class PresearchDeploy(SolutionsChatflowDeploy):
 
     def get_release_name(self):
         self._check_uniqueness()
-        super().get_release_name()
-        if len(self.release_name) > 10:
-            raise StopChatFlow("Solution Name should not be more than 10 characters")
+        self._get_vdc_info()
+        message = "Please enter a name for your solution (will be used in listing and deletions in the future and in having a unique url)"
+        releases = [
+            release["name"]
+            for release in self.k8s_client.list_deployed_releases()
+            if release["namespace"].startswith(self.chart_name)
+        ]
+        self.release_name = self.string_ask(
+            message, required=True, is_identifier=True, not_exist=["solution name", releases], md=True, max_length=10
+        )
 
     def _enter_registration_code(self):
         self.registration_code = self.string_ask("Enter Registration Code", required=True)

--- a/jumpscale/packages/vdc_dashboard/chats/presearch.py
+++ b/jumpscale/packages/vdc_dashboard/chats/presearch.py
@@ -23,6 +23,8 @@ class PresearchDeploy(SolutionsChatflowDeploy):
     def get_release_name(self):
         self._check_uniqueness()
         super().get_release_name()
+        if len(self.release_name) > 10:
+            raise StopChatFlow("Solution Name should not be more than 10 characters")
 
     def _enter_registration_code(self):
         self.registration_code = self.string_ask("Enter Registration Code", required=True)

--- a/jumpscale/packages/vdc_dashboard/chats/presearch.py
+++ b/jumpscale/packages/vdc_dashboard/chats/presearch.py
@@ -20,6 +20,7 @@ class PresearchDeploy(SolutionsChatflowDeploy):
         if get_deployments(self.SOLUTION_TYPE, username):
             raise StopChatFlow("You can only have one Presearch solution per VDC")
 
+    @chatflow_step(title="Solution Name")
     def get_release_name(self):
         self._check_uniqueness()
         self._get_vdc_info()


### PR DESCRIPTION
### Description

Need to limit unnecessarily long solution names by the user because it is used as release_name is in helm charts to distinguish different services in the cluster and at times the helm charts fail to deploy if the names are more than 15 characters 

