### PR TITLE
Add cert parameter to allow disabling certbot certificate generation

### DIFF
--- a/jumpscale/entry_points/threebot.py
+++ b/jumpscale/entry_points/threebot.py
@@ -69,7 +69,8 @@ http {
 @click.option(
     "--local/--no-local", default=False, help="run threebot server on none privileged ports instead of 80/443"
 )
-def start(identity=None, background=False, local=False, development=False, domain=None, email=None):
+@click.option("--cert/--no-cert", default=True, help="Generate certificates for ssl virtual hosts")
+def start(identity=None, background=False, local=False, cert=True, development=False, domain=None, email=None):
     """start 3Bot server after making sure identity is ok
     It will start with the default identity in j.me, if you'd like to specify an identity
     please pass the optional arguments
@@ -139,9 +140,7 @@ def start(identity=None, background=False, local=False, development=False, domai
 
     if background:
         cmd = j.tools.startupcmd.get("threebot_default")
-        cmd.start_cmd = (
-            f"jsng 'j.servers.threebot.start_default(wait=True, local={local}, domain={domain}, email={email})'"
-        )
+        cmd.start_cmd = f"jsng 'j.servers.threebot.start_default(wait=True, local={local}, domain={domain}, email={email}, cert={cert})'"
         cmd.process_strings_regex = [".*threebot_default.sh"]
         cmd.ports = [8000, 8999]
         cmd.start()
@@ -158,7 +157,7 @@ def start(identity=None, background=False, local=False, development=False, domai
                 f"{{WHITE}}Visit admin dashboard at: {{GREEN}}http://localhost:{PORTS.HTTP}/\n{{RESET}}"
             )
     else:
-        j.servers.threebot.start_default(wait=True, local=local, domain=domain, email=email)
+        j.servers.threebot.start_default(wait=True, local=local, domain=domain, email=email, cert=cert)
 
 
 @click.command()

--- a/jumpscale/sals/nginx/nginx.py
+++ b/jumpscale/sals/nginx/nginx.py
@@ -333,8 +333,9 @@ class Website(Base):
 
         j.sals.fs.write_file(self.cfg_file, self.get_config())
 
-        if generate_certificates and self.ssl:
+        if self.ssl:
             self.generate_self_signed_certificates()
+        if generate_certificates and self.ssl:
             self.generate_certificates()
 
     def clean(self):
@@ -343,6 +344,7 @@ class Website(Base):
 
 class NginxConfig(Base):
     websites = fields.Factory(Website)
+    cert = fields.Boolean(default=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jumpscale/servers/threebot/__init__.py
+++ b/jumpscale/servers/threebot/__init__.py
@@ -23,7 +23,7 @@ class ThreebotServerFactory(StoredFactory):
         """
         return super().get("default", *args, **kwargs)
 
-    def start_default(self, wait=False, local=False, domain=None, email=None):
+    def start_default(self, wait=False, local=False, domain=None, email=None, cert=True):
         PORTS.init_default_ports(local)
         server = self.get("default")
         if not server.domain:
@@ -31,7 +31,7 @@ class ThreebotServerFactory(StoredFactory):
             server.email = email
         server.save()
         create_wallets_if_not_exists()
-        server.start(wait=wait)
+        server.start(wait=wait, cert=cert)
 
 
 def export_module_as():

--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -194,7 +194,7 @@ class NginxPackageConfig:
                         loc.package_name = self.package.name
 
                 website.save()
-                website.configure()
+                website.configure(generate_certificates=self.nginx.cert)
                 self.nginx.save()
 
 
@@ -810,7 +810,7 @@ class ThreebotServer(Base):
         if not ret:
             raise j.exceptions.NotFound(f"git is not installed.\n{install_msg}")
 
-    def start(self, wait: bool = False):
+    def start(self, wait: bool = False, cert: bool = True):
         # start default servers in the rack
         # handle signals
         for signal_type in (signal.SIGTERM, signal.SIGINT, signal.SIGKILL):
@@ -824,6 +824,7 @@ class ThreebotServer(Base):
 
         self.redis.start()
         self.nginx.start()
+        j.sals.nginx.get(self.nginx.server_name).cert = cert
         self.rack.start()
         j.logger.register(f"threebot_{self.instance_name}")
         if j.config.get("SEND_REMOTE_ALERTS", False):


### PR DESCRIPTION
### Description

3Bot takes a lot of time when run locally because of failing to generate a certificate from certbot. cert paramter added to the threebot command and start method to allow disabling it.