### PR TITLE
Add export state command and endpoint for the 3bot

### DIFF
--- a/jumpscale/entry_points/threebot.py
+++ b/jumpscale/entry_points/threebot.py
@@ -245,12 +245,6 @@ def export(output):
     j.tools.export.export_threebot_state(output)
 
 
-@click.command()
-@click.option("-f", "--file", help="The path to the export file")
-def dexport(file):
-    j.tools.export.import_threebot_state(file)
-
-
 @click.group()
 def cli():
     pass
@@ -289,7 +283,6 @@ cli.add_command(status)
 cli.add_command(restart)
 cli.add_command(clean)
 cli.add_command(export)
-cli.add_command(dexport, name="import")
 
 
 if __name__ == "__main__":

--- a/jumpscale/entry_points/threebot.py
+++ b/jumpscale/entry_points/threebot.py
@@ -239,95 +239,16 @@ def clean(all=False):
             print(f"exception for debugging {e}")
 
 
-def preprocess_exported_file(temp):
-    project_path = j.sals.fs.parents(j.sals.fs.realpath(__file__))[2]
-    escaped_project_path = project_path.replace("/", "\\\\/")
-    project_files = [
-        "secureconfig/jumpscale/servers/threebot/threebot/ThreebotServer/default/_package_manager/jumpscale/servers/threebot/threebot/PackageManager/default/data"
-    ]
-    for pf in project_files:
-        j.sals.process.execute(
-            ["sed", "-i", f"s/{escaped_project_path}/{{PROJECTPATH}}/g", j.sals.fs.join_paths(temp, pf)]
-        )
-    root_files = ["secureconfig/jumpscale/tools/startupcmd/startupcmd/StartupCmd/nginx_main/data", "config.toml"]
-    home = j.core.dirs.HOMEDIR
-    escaped_home = home.replace("/", "\\\\/")
-    for rf in root_files:
-        j.sals.process.execute(["sed", "-i", f"s/{escaped_home}/{{HOME}}/g", j.sals.fs.join_paths(temp, rf)])
-
-
-def postprocess_imported_file(path):
-    project_path = j.sals.fs.parents(j.sals.fs.realpath(__file__))[2]
-    escaped_project_path = project_path.replace("/", "\\\\/")
-    project_files = [
-        "secureconfig/jumpscale/servers/threebot/threebot/ThreebotServer/default/_package_manager/jumpscale/servers/threebot/threebot/PackageManager/default/data"
-    ]
-    for pf in project_files:
-        j.sals.process.execute(
-            ["sed", "-i", f"s/{{PROJECTPATH}}/{escaped_project_path}/g", j.sals.fs.join_paths(path, pf)]
-        )
-    root_files = ["secureconfig/jumpscale/tools/startupcmd/startupcmd/StartupCmd/nginx_main/data", "config.toml"]
-    home = j.core.dirs.HOMEDIR
-    escaped_home = home.replace("/", "\\\\/")
-    for rf in root_files:
-        j.sals.process.execute(["sed", "-i", f"s/{{HOME}}/{escaped_home}/g", j.sals.fs.join_paths(path, rf)])
-
-
 @click.command()
 @click.option("-o", "--output", default="export.tar.gz", help="exported output file")
 def export(output):
-    home = j.core.dirs.HOMEDIR
-    if home is None:
-        j.tools.console.printcolors("Error: {RED}Home dir is not found{RESET}")
-        return
-    config_path = j.sals.fs.join_paths(home, ".config", "jumpscale")
-    preprocessing_path = tempfile.mkdtemp()
-    tmp_file = tempfile.mkstemp()[1]
-    target_file = tmp_file
-    try:
-        j.sals.fs.copy_tree(config_path, j.sals.fs.join_paths(preprocessing_path, "jumpscale"))
-        preprocess_exported_file(j.sals.fs.join_paths(preprocessing_path, "jumpscale"))
-        kube_config = j.sals.fs.join_paths(home, ".kube", "config")
-        tf = j.data.tarfile.tarfile.open(target_file, "w")
-        tf.add(j.sals.fs.join_paths(preprocessing_path, "jumpscale"), arcname="jumpscale")
-        tf.add(kube_config, "config")
-        tf.close()
-        if output is not None:
-            j.sals.fs.rename(target_file, output)
-            target_file = output
-        j.tools.console.printcolors("Success: {GREEN}Export file created successfully at " + target_file + " {RESET}")
-    finally:
-        j.sals.fs.rmtree(tmp_file)
-        j.sals.fs.rmtree(preprocessing_path)
+    j.tools.export.export_threebot_state(output)
 
 
 @click.command()
 @click.option("-f", "--file", help="The path to the export file")
 def dexport(file):
-    tf = j.data.tarfile.tarfile.open(file, "r")
-    home = j.core.dirs.HOMEDIR
-    if home is None:
-        j.tools.console.printcolors("Error: {RED}Home dir is not found{RESET}")
-        return
-    kube_config = j.sals.fs.join_paths(home, ".kube", "config")
-    config_path = j.sals.fs.join_paths(home, ".config", "jumpscale")
-    tmpdir = tempfile.mkdtemp()
-    try:
-        tf.extractall(tmpdir)
-        postprocess_imported_file(j.sals.fs.join_paths(tmpdir, "jumpscale"))
-        j.tools.console.printcolors(
-            "Warning: {YELLOW}Please take a backup of ~/.config/jumpscale and ~/.kube/config before continuing{RESET}"
-        )
-        x = input("Sure you want to override the local jumpscale config at ~/.config/jumpdsale [yn]? ")
-        if x == "y":
-            j.sals.fs.rmtree(config_path)
-            j.sals.fs.copy_tree(j.sals.fs.join_paths(tmpdir, "jumpscale"), config_path)
-        x = input("Sure you want to override the local kube config at ~/.kube/config [yn]? ")
-        if x == "y":
-            j.sals.fs.copy_file(j.sals.fs.join_paths(tmpdir, "config"), kube_config)
-        tf.close()
-    finally:
-        j.sals.fs.rmtree(tmpdir)
+    j.tools.export.import_threebot_state(file)
 
 
 @click.group()

--- a/jumpscale/packages/admin/bottle/admin.py
+++ b/jumpscale/packages/admin/bottle/admin.py
@@ -1,5 +1,5 @@
 from beaker.middleware import SessionMiddleware
-from bottle import Bottle, request, HTTPResponse
+from bottle import Bottle, request, HTTPResponse, static_file
 
 from jumpscale.loader import j
 from jumpscale.packages.auth.bottle.auth import SESSION_OPTS, login_required, get_user_info
@@ -67,6 +67,19 @@ def announce():
 @app.route("/api/heartbeat", method="GET")
 def heartbeat():
     return HTTPResponse(status=200)
+
+
+@app.route("/api/export")
+@login_required
+def export():
+    filename = j.tools.export.export_threebot_state()
+    exporttime = j.data.time.now().format("YYYY-MM-DDTHH-mm-ssZZ")
+    return static_file(
+        j.sals.fs.basename(filename),
+        root=j.sals.fs.dirname(filename),
+        download=f"export-{exporttime}.tar.gz",
+        mimetype="application/gzip",
+    )
 
 
 app = SessionMiddleware(app, SESSION_OPTS)

--- a/jumpscale/packages/admin/frontend/api.js
+++ b/jumpscale/packages/admin/frontend/api.js
@@ -191,6 +191,14 @@ const apiClient = {
                 url: `${baseURL}/admin/clear_blocked_nodes`,
             })
         },
+        getThreebotState: () => {
+          return axios({
+            url: `/admin/api/export`,
+            headers: { 'Content-Type': 'application/json' },
+            responseType: 'arraybuffer',
+            method: "get"
+          })
+        },
         clearBlockedManagedDomains: () => {
             return axios({
                 url: `${baseURL}/admin/clear_blocked_managed_domains`,

--- a/jumpscale/packages/admin/frontend/components/settings/Settings.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/Settings.vue
@@ -249,6 +249,14 @@
                 class="my-2 ml-2"
                 small
                 color="success"
+                @click="downloadThreebotStateFile()"
+                >Export 3Bot state</v-btn
+              >
+              <v-btn
+                hide-details
+                class="my-2 ml-2"
+                small
+                color="success"
                 @click="clearBlockedManagedDomains()"
                 >Clear blocked domains</v-btn
               >
@@ -547,6 +555,23 @@ module.exports = {
         })
         .catch((error) => {
           this.alert("Failed to clear blocked nodes", "error");
+        });
+    },
+    downloadThreebotStateFile() {
+      this.$api.admins
+        .getThreebotState()
+        .then((response) => {
+          const blob = new Blob([response.data], {type: response.headers["content-type"]});
+          const url = URL.createObjectURL(blob);
+          let filename = response.headers['content-disposition'].split('filename="')[1].slice(0, -1)
+          const link = document.createElement("a");
+          link.href = url;
+          link.setAttribute("download", filename);
+          link.click();
+          URL.revokeObjectURL(link.href);
+        })
+        .catch((err) => {
+          console.log("Failed to download threebot state due to " + err);
         });
     },
     clearBlockedManagedDomains() {

--- a/jumpscale/packages/vdc_dashboard/bottle/export.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/export.py
@@ -1,0 +1,23 @@
+from beaker.middleware import SessionMiddleware
+from bottle import Bottle, static_file
+from jumpscale.loader import j
+
+from jumpscale.packages.auth.bottle.auth import SESSION_OPTS, package_authorized
+
+
+app = Bottle()
+
+
+@app.route("/api/threebot/export")
+@package_authorized("vdc_dashboard")
+def export():
+    filename = j.tools.export.export_threebot_state()
+    return static_file(
+        j.sals.fs.basename(filename),
+        root=j.sals.fs.dirname(filename),
+        download="export.tar.gz",
+        mimetype="application/gzip",
+    )
+
+
+app = SessionMiddleware(app, SESSION_OPTS)

--- a/jumpscale/packages/vdc_dashboard/bottle/export.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/export.py
@@ -12,10 +12,11 @@ app = Bottle()
 @package_authorized("vdc_dashboard")
 def export():
     filename = j.tools.export.export_threebot_state()
+    exporttime = j.data.time.now().format("YYYY-MM-DDTHH-mm-ssZZ")
     return static_file(
         j.sals.fs.basename(filename),
         root=j.sals.fs.dirname(filename),
-        download="export.tar.gz",
+        download=f"export-{exporttime}.tar.gz",
         mimetype="application/gzip",
     )
 

--- a/jumpscale/packages/vdc_dashboard/frontend/api.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/api.js
@@ -71,7 +71,7 @@ const apiClient = {
     getThreebotState: () => {
       return axios({
         url: `${baseURL}/threebot/export`,
-        headers: { 'Content-Type': 'application/gzip' },
+        headers: { 'Content-Type': 'application/json' },
         responseType: 'arraybuffer',
         method: "get"
       })

--- a/jumpscale/packages/vdc_dashboard/frontend/api.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/api.js
@@ -68,6 +68,14 @@ const apiClient = {
         method: "get"
       })
     },
+    getThreebotState: () => {
+      return axios({
+        url: `${baseURL}/threebot/export`,
+        headers: { 'Content-Type': 'application/gzip' },
+        responseType: 'arraybuffer',
+        method: "get"
+      })
+    },
     deleteWorkerWorkload: (wid) => {
       return axios({
         url: `${baseURL}/kube/nodes/delete`,

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
@@ -173,9 +173,10 @@ module.exports = {
         .then((response) => {
           const blob = new Blob([response.data], {type: response.headers["content-type"]});
           const url = URL.createObjectURL(blob);
+          let filename = response.headers['content-disposition'].split('filename="')[1].slice(0, -1)
           const link = document.createElement("a");
           link.href = url;
-          link.setAttribute("download", "export.tar.gz");
+          link.setAttribute("download", filename);
           link.click();
           URL.revokeObjectURL(link.href);
         })

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
@@ -14,6 +14,14 @@
         class="float-right p-4"
         color="primary"
         text
+        @click.stop="downloadThreebotStateFile()"
+      >
+        <v-icon left>mdi-download</v-icon>ThreebotState
+      </v-btn>
+      <v-btn
+        class="float-right p-4"
+        color="primary"
+        text
         @click.stop="openChatflow('extend_kubernetes')"
       >
         <v-icon left>mdi-plus</v-icon>Add node
@@ -158,6 +166,22 @@ module.exports = {
       this.$emit("reload-vdcinfo", {
         message: "VDC info has been reloaded successfully!",
       });
+    },
+    downloadThreebotStateFile() {
+      this.$api.solutions
+        .getThreebotState()
+        .then((response) => {
+          const blob = new Blob([response.data], {type: response.headers["content-type"]});
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement("a");
+          link.href = url;
+          link.setAttribute("download", "export.tar.gz");
+          link.click();
+          URL.revokeObjectURL(link.href);
+        })
+        .catch((err) => {
+          console.log("Failed to download threebot state due to " + err);
+        });
     },
   },
   computed: {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
@@ -14,14 +14,6 @@
         class="float-right p-4"
         color="primary"
         text
-        @click.stop="downloadThreebotStateFile()"
-      >
-        <v-icon left>mdi-download</v-icon>ThreebotState
-      </v-btn>
-      <v-btn
-        class="float-right p-4"
-        color="primary"
-        text
         @click.stop="openChatflow('extend_kubernetes')"
       >
         <v-icon left>mdi-plus</v-icon>Add node

--- a/jumpscale/packages/vdc_dashboard/package.toml
+++ b/jumpscale/packages/vdc_dashboard/package.toml
@@ -35,6 +35,14 @@ path_dest = "/api/controller/"
 host = "0.0.0.0"
 port = 5591
 
+[[bottle_servers]]
+name = "threebot_export"
+file_path = "bottle/export.py"
+path_url = "/api/threebot/"
+path_dest = "/api/threebot/"
+host = "0.0.0.0"
+port = 5592
+
 [[servers]]
 name = "vdc_dashboard_root_proxy"
 domain = "vdc-dashboard.threefold.me"

--- a/jumpscale/packages/vdc_dashboard/package.toml
+++ b/jumpscale/packages/vdc_dashboard/package.toml
@@ -35,14 +35,6 @@ path_dest = "/api/controller/"
 host = "0.0.0.0"
 port = 5591
 
-[[bottle_servers]]
-name = "threebot_export"
-file_path = "bottle/export.py"
-path_url = "/api/threebot/"
-path_dest = "/api/threebot/"
-host = "0.0.0.0"
-port = 5592
-
 [[servers]]
 name = "vdc_dashboard_root_proxy"
 domain = "vdc-dashboard.threefold.me"

--- a/jumpscale/tools/export/__init__.py
+++ b/jumpscale/tools/export/__init__.py
@@ -1,0 +1,93 @@
+from jumpscale.loader import j
+import tempfile
+
+
+def _preprocess_exported_file(temp):
+    project_path = j.sals.fs.parents(j.sals.fs.realpath(__file__))[2]
+    escaped_project_path = project_path.replace("/", "\\\\/")
+    project_files = [
+        "secureconfig/jumpscale/servers/threebot/threebot/ThreebotServer/default/_package_manager/jumpscale/servers/threebot/threebot/PackageManager/default/data"
+    ]
+    for pf in project_files:
+        j.sals.process.execute(
+            ["sed", "-i", f"s/{escaped_project_path}/{{PROJECTPATH}}/g", j.sals.fs.join_paths(temp, pf)]
+        )
+    root_files = ["secureconfig/jumpscale/tools/startupcmd/startupcmd/StartupCmd/nginx_main/data", "config.toml"]
+    home = j.core.dirs.HOMEDIR
+    escaped_home = home.replace("/", "\\\\/")
+    for rf in root_files:
+        j.sals.process.execute(["sed", "-i", f"s/{escaped_home}/{{HOME}}/g", j.sals.fs.join_paths(temp, rf)])
+
+
+def _postprocess_imported_file(path):
+    project_path = j.sals.fs.parents(j.sals.fs.realpath(__file__))[2]
+    escaped_project_path = project_path.replace("/", "\\\\/")
+    project_files = [
+        "secureconfig/jumpscale/servers/threebot/threebot/ThreebotServer/default/_package_manager/jumpscale/servers/threebot/threebot/PackageManager/default/data"
+    ]
+    for pf in project_files:
+        j.sals.process.execute(
+            ["sed", "-i", f"s/{{PROJECTPATH}}/{escaped_project_path}/g", j.sals.fs.join_paths(path, pf)]
+        )
+    root_files = ["secureconfig/jumpscale/tools/startupcmd/startupcmd/StartupCmd/nginx_main/data", "config.toml"]
+    home = j.core.dirs.HOMEDIR
+    escaped_home = home.replace("/", "\\\\/")
+    for rf in root_files:
+        j.sals.process.execute(["sed", "-i", f"s/{{HOME}}/{escaped_home}/g", j.sals.fs.join_paths(path, rf)])
+
+
+def export_threebot_state(output=None):
+    home = j.core.dirs.HOMEDIR
+    if home is None:
+        j.tools.console.printcolors("Error: {RED}Home dir is not found{RESET}")
+        return
+    config_path = j.sals.fs.join_paths(home, ".config", "jumpscale")
+    preprocessing_path = tempfile.mkdtemp()
+    tmp_file = tempfile.mkstemp()[1]
+    alerts_path = j.sals.fs.join_paths(preprocessing_path, "jumpscale", "logs", "alerts")
+    target_file = tmp_file
+    try:
+        j.sals.fs.copy_tree(config_path, j.sals.fs.join_paths(preprocessing_path, "jumpscale"))
+        _preprocess_exported_file(j.sals.fs.join_paths(preprocessing_path, "jumpscale"))
+        kube_config = j.sals.fs.join_paths(home, ".kube", "config")
+        j.sals.process.execute(["sh", "-c", f"redis-cli HGETALL alerts > {alerts_path}"])
+        tf = j.data.tarfile.tarfile.open(target_file, "w")
+        tf.add(j.sals.fs.join_paths(preprocessing_path, "jumpscale"), arcname="jumpscale")
+        tf.add(kube_config, "config")
+        tf.close()
+        if output is not None:
+            j.sals.fs.rename(target_file, output)
+            target_file = output
+        j.tools.console.printcolors("Success: {GREEN}Export file created successfully at " + target_file + " {RESET}")
+    finally:
+        if tmp_file != target_file:
+            j.sals.fs.rmtree(tmp_file)
+        j.sals.fs.rmtree(preprocessing_path)
+    return target_file
+
+
+def import_threebot_state(file):
+    tf = j.data.tarfile.tarfile.open(file, "r")
+    home = j.core.dirs.HOMEDIR
+    if home is None:
+        j.tools.console.printcolors("Error: {RED}Home dir is not found{RESET}")
+        return
+    kube_config = j.sals.fs.join_paths(home, ".kube", "config")
+    config_path = j.sals.fs.join_paths(home, ".config", "jumpscale")
+    tmpdir = tempfile.mkdtemp()
+    try:
+        tf.extractall(tmpdir)
+        _postprocess_imported_file(j.sals.fs.join_paths(tmpdir, "jumpscale"))
+        j.tools.console.printcolors(
+            "Warning: {YELLOW}Please take a backup of ~/.config/jumpscale and ~/.kube/config before continuing{RESET}"
+        )
+        x = input("Sure you want to override the local jumpscale config at ~/.config/jumpscale [yn]? ")
+        if x == "y":
+            j.sals.fs.rmtree(config_path)
+            j.sals.fs.copy_tree(j.sals.fs.join_paths(tmpdir, "jumpscale"), config_path)
+        x = input("Sure you want to override the local kube config at ~/.kube/config [yn]? ")
+        if x == "y":
+            j.sals.fs.copy_file(j.sals.fs.join_paths(tmpdir, "config"), kube_config)
+        tf.close()
+    finally:
+        j.sals.fs.rmtree(tmpdir)

--- a/jumpscale/tools/export/__init__.py
+++ b/jumpscale/tools/export/__init__.py
@@ -2,92 +2,28 @@ from jumpscale.loader import j
 import tempfile
 
 
-def _preprocess_exported_file(temp):
-    project_path = j.sals.fs.parents(j.sals.fs.realpath(__file__))[2]
-    escaped_project_path = project_path.replace("/", "\\\\/")
-    project_files = [
-        "secureconfig/jumpscale/servers/threebot/threebot/ThreebotServer/default/_package_manager/jumpscale/servers/threebot/threebot/PackageManager/default/data"
-    ]
-    for pf in project_files:
-        j.sals.process.execute(
-            ["sed", "-i", f"s/{escaped_project_path}/{{PROJECTPATH}}/g", j.sals.fs.join_paths(temp, pf)]
-        )
-    root_files = ["secureconfig/jumpscale/tools/startupcmd/startupcmd/StartupCmd/nginx_main/data", "config.toml"]
-    home = j.core.dirs.HOMEDIR
-    escaped_home = home.replace("/", "\\\\/")
-    for rf in root_files:
-        j.sals.process.execute(["sed", "-i", f"s/{escaped_home}/{{HOME}}/g", j.sals.fs.join_paths(temp, rf)])
-
-
-def _postprocess_imported_file(path):
-    project_path = j.sals.fs.parents(j.sals.fs.realpath(__file__))[2]
-    escaped_project_path = project_path.replace("/", "\\\\/")
-    project_files = [
-        "secureconfig/jumpscale/servers/threebot/threebot/ThreebotServer/default/_package_manager/jumpscale/servers/threebot/threebot/PackageManager/default/data"
-    ]
-    for pf in project_files:
-        j.sals.process.execute(
-            ["sed", "-i", f"s/{{PROJECTPATH}}/{escaped_project_path}/g", j.sals.fs.join_paths(path, pf)]
-        )
-    root_files = ["secureconfig/jumpscale/tools/startupcmd/startupcmd/StartupCmd/nginx_main/data", "config.toml"]
-    home = j.core.dirs.HOMEDIR
-    escaped_home = home.replace("/", "\\\\/")
-    for rf in root_files:
-        j.sals.process.execute(["sed", "-i", f"s/{{HOME}}/{escaped_home}/g", j.sals.fs.join_paths(path, rf)])
-
-
 def export_threebot_state(output=None):
     home = j.core.dirs.HOMEDIR
     if home is None:
         j.tools.console.printcolors("Error: {RED}Home dir is not found{RESET}")
         return
     config_path = j.sals.fs.join_paths(home, ".config", "jumpscale")
-    preprocessing_path = tempfile.mkdtemp()
-    tmp_file = tempfile.mkstemp()[1]
-    alerts_path = j.sals.fs.join_paths(preprocessing_path, "jumpscale", "logs", "alerts")
-    target_file = tmp_file
+    output_tmp_file = tempfile.mkstemp()[1]
+    alerts_tmp_file = tempfile.mkstemp()[1]
+    alerts_path = j.sals.fs.join_paths("jumpscale", "logs", "alerts")
+    target_file = output_tmp_file
     try:
-        j.sals.fs.copy_tree(config_path, j.sals.fs.join_paths(preprocessing_path, "jumpscale"))
-        _preprocess_exported_file(j.sals.fs.join_paths(preprocessing_path, "jumpscale"))
-        kube_config = j.sals.fs.join_paths(home, ".kube", "config")
-        j.sals.process.execute(["sh", "-c", f"redis-cli HGETALL alerts > {alerts_path}"])
+        j.sals.process.execute(["sh", "-c", f"redis-cli HGETALL alerts > {alerts_tmp_file}"])
         tf = j.data.tarfile.tarfile.open(target_file, "w")
-        tf.add(j.sals.fs.join_paths(preprocessing_path, "jumpscale"), arcname="jumpscale")
-        tf.add(kube_config, "config")
+        tf.add(config_path, arcname="jumpscale")
+        tf.add(alerts_tmp_file, arcname=alerts_path)
         tf.close()
         if output is not None:
             j.sals.fs.rename(target_file, output)
             target_file = output
         j.tools.console.printcolors("Success: {GREEN}Export file created successfully at " + target_file + " {RESET}")
     finally:
-        if tmp_file != target_file:
-            j.sals.fs.rmtree(tmp_file)
-        j.sals.fs.rmtree(preprocessing_path)
+        if output_tmp_file != target_file:
+            j.sals.fs.rmtree(output_tmp_file)
+        j.sals.fs.rmtree(alerts_tmp_file)
     return target_file
-
-
-def import_threebot_state(file):
-    tf = j.data.tarfile.tarfile.open(file, "r")
-    home = j.core.dirs.HOMEDIR
-    if home is None:
-        j.tools.console.printcolors("Error: {RED}Home dir is not found{RESET}")
-        return
-    kube_config = j.sals.fs.join_paths(home, ".kube", "config")
-    config_path = j.sals.fs.join_paths(home, ".config", "jumpscale")
-    tmpdir = tempfile.mkdtemp()
-    try:
-        tf.extractall(tmpdir)
-        _postprocess_imported_file(j.sals.fs.join_paths(tmpdir, "jumpscale"))
-        j.tools.console.printcolors(
-            "Warning: {YELLOW}Please take a backup of ~/.config/jumpscale and ~/.kube/config before continuing{RESET}"
-        )
-        x = input("Sure you want to override the local jumpscale config at ~/.config/jumpscale [yn]? ")
-        if x == "y":
-            j.sals.fs.rmtree(config_path)
-            j.sals.fs.copy_tree(j.sals.fs.join_paths(tmpdir, "jumpscale"), config_path)
-        x = input("Sure you want to override the local kube config at ~/.kube/config [yn]? ")
-        if x == "y":
-            j.sals.fs.copy_file(j.sals.fs.join_paths(tmpdir, "config"), kube_config)
-        tf.close()
-    finally:
-        j.sals.fs.rmtree(tmpdir)


### PR DESCRIPTION
### Description

- Export the 3Bot state as a gzip file containing:
1. `~/.config/jumpscale/` directory
2. `~/.kube/config` file

- Confirm when importing to override the mentioned files.

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2793
