### PR TITLE
report availble capacity on nodes for specific explorer

### DIFF
--- a/jumpscale/sals/zos/node_finder.py
+++ b/jumpscale/sals/zos/node_finder.py
@@ -11,47 +11,40 @@ from .network import is_private
 class NodeFinder:
     """ """
 
-    def __init__(self, identity):
+    def __init__(self, identity=None, explorer=None):
         self._identity = identity
-        explorer = identity.explorer
+        explorer = explorer or identity.explorer  # to make the usage of node finder without identity
         self._nodes = explorer.nodes
         self._farms = explorer.farms
         self._pools = explorer.pools
 
     def filter_is_up(self, node: Node):
-        """filter function that filters out nodes that have not received update for more then 10 minutes
-        """
+        """filter function that filters out nodes that have not received update for more then 10 minutes"""
         ago = now().timestamp - (60 * 10)
         return node.updated.timestamp() > ago
 
     def filter_is_free_to_use(self, node: Node):
-        """filter function that filters out nodes that are marked as free to use
-        """
+        """filter function that filters out nodes that are marked as free to use"""
         return node.free_to_use
 
     def filter_is_not_free_to_use(self, node):
-        """filter function that filters out nodes that are not marked as free to use
-        """
+        """filter function that filters out nodes that are not marked as free to use"""
         return not node.free_to_use
 
     def filter_public_ip4(self, node):
-        """filter function that filters out nodes that have a public IPv4 address
-        """
+        """filter function that filters out nodes that have a public IPv4 address"""
         return filter_public_ip(node, 4)
 
     def filter_public_ip6(self, node):
-        """filter function that filters out nodes that have a public IPv6 address
-        """
+        """filter function that filters out nodes that have a public IPv6 address"""
         return filter_public_ip(node, 6)
 
     def filter_accessnode_ip4(self, node):
-        """filter function that filters out nodes that have a public config with IPv4 address
-        """
+        """filter function that filters out nodes that have a public config with IPv4 address"""
         return is_access_node(node, 4)
 
     def filter_accessnode_ip6(self, node):
-        """filter function that filters out nodes that have a public config with IPv6 address
-        """
+        """filter function that filters out nodes that have a public config with IPv6 address"""
         return is_access_node(node, 6)
 
     def filter_farm_currency(self, farm: Farm, currency: str):

--- a/jumpscale/tools/zos/reporting/__init__.py
+++ b/jumpscale/tools/zos/reporting/__init__.py
@@ -30,19 +30,38 @@
 - get nodes availble capacity
 
     ```
-    JS-NG> j.tools.zos.reporting.get_available_farm_capacity()
+    JS-NG> j.tools.zos.reporting.get_available_farm_capacity(explorer_name="testnet", farm_name="freefarm")
 
-    Available capacity for nodes on Farm: lochristi_dev_lab in Explorer: devnet
+    Available capacity for nodes on Farm: freefarm in Explorer: testnet
 
-                    Node                              CRU        MRU        SRU        HRU
-    Gr8NxBLHe7yjSsnSTgTqGr7BHbyAUVPJqs8fnudEE4Sf       -3      140.0       6.25     8352.0
-    qzuTJJVd5boi6Uyoco1WWnSgzTb7q8uN79AjBT9x9N3        5      152.0        0.5     8233.0
-    BpTAry1Na2s1J8RAHNyDsbvaBSM3FjR4gMXEKga3UPbs        2      153.0       3.75     7903.0
-    2anfZwrzskXiUHPLTqH1veJAia8G6rW2eFLy5YFMa1MP        3      150.0   19.21875     7913.0
-    BBmMHCw392RLiByVEUT2ac6y6qJpbW9xj8TRdgk5rMGN        0      142.0       15.5     8243.0
-    3NAkUYqm5iPRmNAnmLfjwdreqDssvsebj4uPUt9BxFPm        9      159.0      46.75     8173.0
-    48YmkyvfoXnXqEojpJieMfFPnCv2enEuqEJcmhvkcdAk        3      132.0       45.0     8153.0
-    ```
+    +----------------------------------------------+-----+-------+--------+--------+
+    | Node                                         | CRU | MRU   | SRU    | HRU    |
+    +----------------------------------------------+-----+-------+--------+--------+
+    | 26ZATmd3K1fjeQKQsi8Dr7bm9iSRa3ePsV8ubMcbZEuY | 1   | 0.0   | 141.0  | 913.0  |
+    | 8zPYak76CXcoZxRoJBjdU69kVjo7XYU1SFE2NEK4UMqn | -1  | 0.0   | 243.0  | 0.0    |
+    | 85J3zEvcqDoPaN7qQHRQ2QgPVcYdCvp8JmRY5qAwzxfm | -1  | 2.0   | 278.0  | 883.0  |
+    | FED1ZsfbUz3jcJzzqJWyGaoGC61bdN8coKJNte96Fo7k | -2  | 0.0   | 265.75 | 0.0    |
+    | DJoL9ZV53K5YQurmxor2BLWTPf3WA9dT3RsFWeDeAx1z | 0   | 0.0   | 212.0  | 1103.0 |
+    | Hx4B6B8s8yQ5ABLStma1kZ33kCuprSxzU8tY4totKbWH | -1  | 0.0   | 246.0  | 0.0    |
+    | 8YLrviP78Msue8ptejusq7xxxAgD4ZHNDXXF9KXVGYWr | 4   | 7.0   | 299.0  | 0.0    |
+    | APxTCEYX2YjF9dgDGwRrGsi6gNmQ1a1rzgXaHrAAdbST | -7  | 133.0 | 6.0    | 7563.0 |
+    | 52phivuJMFXcuLwGP7rkbjVRaxjTDnP9japDwf8fBAtn | 24  | 187.0 | 476.0  | 8263.0 |
+    | 89HWyx6iurJKk7BXEa4tL7ziWFHwycRwidMtPWsepgZo | 19  | 182.0 | 450.0  | 8283.0 |
+    | 3VBKrSTVieFzJ9Bv9MSzvQBQcTwnxgPhC9tMNsUsv5BH | 13  | 165.0 | 76.0   | 8363.0 |
+    | DHjz97zzNY1BxpVZ1mmv3gwwmPRN9oB91pSjeRVDZe6A | 3   | 145.0 | 1.0    | 8283.0 |
+    | EMg1z3up8UcYNK5Rbfya7kKkKsuyqhNWrv15JKHERbuW | 9   | 142.0 | 100.0  | 8313.0 |
+    | 3xhQQssbgsUxJtsGoDmnF77SyogsC71Q8UFMkAAUi3ki | 14  | 167.0 | 226.0  | 8383.0 |
+    | 3pRRo2s6h1XPSiNY5W98nPUUmWYN5NzrvyUCkpFugfL7 | 8   | 155.0 | 26.0   | 7923.0 |
+    | HC1WPUg8GMsbcYakHbHZxeWB1dGhwyvdjGr59dfk7vwE | 10  | 161.0 | 122.0  | 8373.0 |
+    | FzWp4mhvC6xutRebE8JRv9bMjquioQbdBJoSXgNxtzSG | 20  | 179.0 | 375.0  | 8373.0 |
+    | 7e8iFD2inToLQzqTp855SpYf8LfVt9K3MUzrTWoqtvov | -3  | 143.0 | 31.0   | 8153.0 |
+    | BhAgw6PMUUETKQmZCCGqfNF2Pt4n6FKW4D8p7yY7hWpQ | 7   | 154.0 | 46.75  | 8373.0 |
+    | 2imakaznKfYx3vA4CDcTKxWbw9GcW3eXX8wQfr61X1Lz | 8   | 139.0 | 75.0   | 8353.0 |
+    | 93qJrfeBqYiuVC973n9kPX79uA4rZU6oHL9pdJGBegHL | 1   | 130.0 | 16.0   | 8363.0 |
+    | 3otHJ8H3Wv5oSCWQWqharzYmB5BdWecMhUB11D88YZwC | 20  | 179.0 | 325.0  | 8373.0 |
+    | 9Bkf6fmWkAh4kMgawjpP8N35Ybh1AhzaRHisBawR8ef3 | 24  | 187.0 | 376.0  | 8363.0 |
+    +----------------------------------------------+-----+-------+--------+--------+
+
 
 
 """
@@ -68,9 +87,10 @@ def get_public_ip_usage(explorer_name: str = "devnet"):
     Returns:
         str: nice view for the used ips or json
     """
-    print("\n+========================= RESERVED IPS =========================+")
+    print("\nGetting public ip usage ...")
     explorer = j.clients.explorer.get_by_url(DEFAULT_EXPLORER_URLS[explorer_name])
     c = 0
+    ip_usage = [["Username", "Owner tid", "WID"]]
     if not explorer_name in ["devnet", "testnet", "mainnet"]:
         raise j.exceptions.Value(f"Explorers: devnet, testnet, mainnet are only supported, you passed {explorer_name}")
     farm = explorer.farms.get(farm_name=PUBLIC_IP_FARMS[explorer_name])
@@ -81,11 +101,14 @@ def get_public_ip_usage(explorer_name: str = "devnet"):
         workload = explorer.workloads.get(ip.reservation_id)
         owner_tid = workload.info.customer_tid
         user = explorer.users.get(owner_tid)
-        print(f"user: {user.name:30}|\ttid: {owner_tid:<5}|\twid: {workload.id}")
-    print("+----------------------------------------------------------------+")
-    print(
-        f"busy: {c:<6}|\t    free: {len(farm.ipaddresses)-c:<10}|\ttotal:{len(farm.ipaddresses):<3}"
-        "\n+=========================     DONE     =========================+\n"
+        ip_usage.append([user.name, owner_tid, workload.id])
+    ip_usage.append(["---------------------------------------------------------------", "--------", "--------"])
+    ip_usage.append([f"Busy: {c}", f"Free: {len(farm.ipaddresses) - c}", f"Total: {len(farm.ipaddresses)}"])
+    j.data.terminaltable.print_table(
+        j.tools.console.printcolors(
+            f"\nReserved public IPs on Farm: {{GREEN}}{farm.name}{{RESET}} in Explorer: {{GREEN}}{explorer_name}{{RESET}}\n"
+        ),
+        ip_usage,
     )
 
 
@@ -106,18 +129,22 @@ def get_available_farm_capacity(explorer_name: str = "devnet", farm_name: str = 
     node_finder = NodeFinder(explorer=explorer)
     nodes = list(node_finder.nodes_search(farm_name=farm_name))
 
-    j.tools.console.printcolors(
-        f"\nAvailable capacity for nodes on Farm: {{GREEN}}{farm_name}{{RESET}} in Explorer: {{GREEN}}{explorer_name}{{RESET}}\n"
-    )
-    print(f'{"Node":>20} {"CRU":>32} {"MRU":>10} {"SRU":>10} {"HRU":>10}')
+    capacity = [["Node", "CRU", "MRU", "SRU", "HRU"]]
     for node in nodes:
         if not node_finder.filter_is_up(node):
             continue
-        print(
-            f"{node.node_id:>8}",
-            f"{node.total_resources.cru - node.reserved_resources.cru:>8}",
-            f"{node.total_resources.mru - node.reserved_resources.mru:>10}",
-            f"{node.total_resources.sru - node.reserved_resources.sru:>10}",
-            f"{node.total_resources.hru - node.reserved_resources.hru:>10}",
+        capacity.append(
+            [
+                node.node_id,
+                node.total_resources.cru - node.reserved_resources.cru,
+                node.total_resources.mru - node.reserved_resources.mru,
+                node.total_resources.sru - node.reserved_resources.sru,
+                node.total_resources.hru - node.reserved_resources.hru,
+            ]
         )
-    print("\n")
+    j.data.terminaltable.print_table(
+        j.tools.console.printcolors(
+            f"\nAvailable capacity for nodes on Farm: {{GREEN}}{farm_name}{{RESET}} in Explorer: {{GREEN}}{explorer_name}{{RESET}}\n"
+        ),
+        capacity,
+    )


### PR DESCRIPTION
### Changes

- Implement report available capacity on nodes for specific explorer
- Update viewing  the usage usage of public ips to terminal table

### Description

![Screenshot from 2021-04-15 15-30-33](https://user-images.githubusercontent.com/10658229/114877424-8fd11e00-9dff-11eb-9089-c47447f6b193.png)

![Screenshot from 2021-04-15 15-30-16](https://user-images.githubusercontent.com/10658229/114877410-8cd62d80-9dff-11eb-8119-1b9cc900dd75.png)

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
