### PR TITLE
Fix new backup listing

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Actions.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Actions.vue
@@ -80,15 +80,15 @@ module.exports = {
           this.show = true;
           this.msg = response.data;
           this.close();
-          this.getlist();
+          this.getlist(10000);
         })
         .finally(() => {
           this.loading = false;
           this.confirmName = null;
         });
     },
-    getlist() {
-      this.$emit("reload-backups", { message: "Backup list reloaded!" });
+    getlist(timeout=2000) {
+      this.$emit("reload-backups", timeout, { message: "Backup list reloaded!" });
     },
   },
   mounted() {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Actions.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Actions.vue
@@ -65,7 +65,7 @@ module.exports = {
           this.show = true;
           this.msg = response.data;
           this.close();
-          this.getlist();
+          this.getlist(5000);
         })
         .finally(() => {
           this.loading = false;

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Backups.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Backups.vue
@@ -187,9 +187,9 @@ module.exports = {
     confirmCreation() {
       this.dialogs.confirmBackup = true;
     },
-    reload() {
+    reload(timeout) {
       this.loading = true;
-      setTimeout(()=> {this.list()} , 2000);
+      setTimeout(()=> {this.list()} , timeout);
     },
     updateStatus(status) {
       if (status === "PartiallyFailed") {


### PR DESCRIPTION
### Description

Fix new backup listing by adding a variable timeout with the reload event.
For create --> 10 sec
For delete --> 5 sec
Default      --> 2 sec

### Related Issues

#2921

### Screenshots
- Create backup
![add_backup](https://user-images.githubusercontent.com/11272864/114900735-725a7f00-9e14-11eb-8840-a926ae329bf4.gif)

- Delete backup
![delete_backup](https://user-images.githubusercontent.com/11272864/114900768-77b7c980-9e14-11eb-9f29-08a9a84f8e1d.gif)

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
