### PR TITLE
Development chatflow envvars

### DIFF
--- a/jumpscale/packages/vdc_dashboard/chats/discourse.py
+++ b/jumpscale/packages/vdc_dashboard/chats/discourse.py
@@ -66,18 +66,6 @@ class DiscourseDeploy(SolutionsChatflowDeploy):
             else:
                 valid_password = True
 
-    def _ask_smtp_settings(self):
-        form = self.new_form()
-        smtp_host = form.string_ask("SMTP Host", default="smtp.gmail.com", required=True)
-        smtp_port = form.string_ask("SMTP Port", default=587, required=True)
-        smtp_username = form.string_ask("Email (SMTP username)", required=True)
-        smtp_password = form.secret_ask("Email Password", required=True, isAlphanumeric=True)
-        form.ask()
-        self.config.chart_config.smtp_host = smtp_host.value
-        self.config.chart_config.smtp_port = smtp_port.value
-        self.config.chart_config.smtp_username = smtp_username.value
-        self.config.chart_config.smtp_password = smtp_password.value
-
     @chatflow_step(title="Configurations")
     def set_config(self):
         self._configure_admin_username_password()

--- a/jumpscale/packages/vdc_dashboard/chats/discourse.py
+++ b/jumpscale/packages/vdc_dashboard/chats/discourse.py
@@ -71,9 +71,5 @@ class DiscourseDeploy(SolutionsChatflowDeploy):
         self._configure_admin_username_password()
         self._ask_smtp_settings()
 
-    @chatflow_step(title="Initializing", disable_previous=True)
-    def initializing(self):
-        super().initializing(timeout=800, pod_initalizing_timeout=600)
-
 
 chat = DiscourseDeploy

--- a/jumpscale/packages/vdc_dashboard/chats/discourse.py
+++ b/jumpscale/packages/vdc_dashboard/chats/discourse.py
@@ -26,6 +26,10 @@ class DiscourseDeploy(SolutionsChatflowDeploy):
             "discourse.username": self.config.chart_config.admin_username,
             "discourse.password": self.config.chart_config.admin_password,
             "ingress.hostname": self.config.chart_config.domain,
+        }
+
+    def get_env_vars(self):
+        return {
             "discourse.extraEnvVars[0].name": "SMTP_HOST",
             "discourse.extraEnvVars[0].value": self.config.chart_config.smtp_host,
             "discourse.extraEnvVars[1].name": "SMTP_PORT",
@@ -70,7 +74,7 @@ class DiscourseDeploy(SolutionsChatflowDeploy):
         smtp_password = form.secret_ask("Email Password", required=True, isAlphanumeric=True)
         form.ask()
         self.config.chart_config.smtp_host = smtp_host.value
-        self.config.chart_config.smtp_port = f'"{smtp_port.value}"'
+        self.config.chart_config.smtp_port = smtp_port.value
         self.config.chart_config.smtp_username = smtp_username.value
         self.config.chart_config.smtp_password = smtp_password.value
 

--- a/jumpscale/packages/vdc_dashboard/chats/discourse.py
+++ b/jumpscale/packages/vdc_dashboard/chats/discourse.py
@@ -28,7 +28,7 @@ class DiscourseDeploy(SolutionsChatflowDeploy):
             "ingress.hostname": self.config.chart_config.domain,
         }
 
-    def get_env_vars(self):
+    def get_config_string_safe(self):
         return {
             "discourse.extraEnvVars[0].name": "SMTP_HOST",
             "discourse.extraEnvVars[0].value": self.config.chart_config.smtp_host,

--- a/jumpscale/packages/vdc_dashboard/chats/mastodon.py
+++ b/jumpscale/packages/vdc_dashboard/chats/mastodon.py
@@ -27,16 +27,20 @@ class MastodonDeploy(SolutionsChatflowDeploy):
     def get_config(self):
         return {
             "web.ingress.host": self.config.chart_config.domain,
+            "resources.limits.cpu": self.config.chart_config.resources_limits["cpu"][:-1],
+            "resources.limits.memory": self.config.chart_config.resources_limits["memory"][:-2],
+        }
+
+    def get_config_string_safe(self):
+        return {
             "env.smtp.server": self.config.chart_config.smtp_host,
-            "env.smtp.port": self.config.chart_config.smtp_port.strip('"'),
+            "env.smtp.port": self.config.chart_config.smtp_port,
             "env.smtp.address": f"support@{self.config.chart_config.domain}",
             "env.smtp.login": self.config.chart_config.smtp_username,
             "env.smtp.domain": self.config.chart_config.domain,
             "smtpPassword": self.config.chart_config.smtp_password,
             "env.extraEnvVars[0].name": "THREEBOT_KEY",
             "env.extraEnvVars[0].value": self.generate_signing_key(),
-            "resources.limits.cpu": self.config.chart_config.resources_limits["cpu"][:-1],
-            "resources.limits.memory": self.config.chart_config.resources_limits["memory"][:-2],
         }
 
     @chatflow_step(title="Configurations")

--- a/jumpscale/packages/vdc_dashboard/chats/taiga.py
+++ b/jumpscale/packages/vdc_dashboard/chats/taiga.py
@@ -28,9 +28,5 @@ class TaigaDeploy(SolutionsChatflowDeploy):
             "resources.memory": self.config.chart_config.resources_limits["memory"][:-2],  # remove units added in chart
         }
 
-    @chatflow_step(title="Initializing", disable_previous=True)
-    def initializing(self):
-        super().initializing(timeout=800, pod_initalizing_timeout=600)
-
 
 chat = TaigaDeploy

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -457,11 +457,7 @@ class SolutionsChatflowDeploy(GedisChatBot):
                 extra_config_string_safe=extra_config_string_safe,
             )
         except Exception as e:
-            stop_message = f"Helm time out for detailed error, {e}"
-            j.logger.error(stop_message)
-            j.tools.alerthandler.alert_raise(
-                app_name="chatflows", category="internal_errors", message=stop_message, alert_type="exception"
-            )
+            stop_message = f"Helm install command failed, {e}"
             self.k8s_client.execute_native_cmd(
                 f"helm delete -n {self.chart_name}-{self.config.release_name} {self.config.release_name}"
             )

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -56,7 +56,15 @@ class SolutionsChatflowDeploy(GedisChatBot):
     def get_config(self):
         return {}  # to be overridden in the chart chatflow
 
-    def get_env_vars(self):
+    def get_config_string_safe(self):
+        """ Get config that we want to ensure to be set as
+         string during passing the values to helm chart example passwords, ports,.... etc.
+         to prevent helm from doing wrong type casting
+
+        Returns:
+            dict: configurations to be passed to helm
+
+        """
         return {}  # to be overridden in the chart chatflow
 
     def _init_solution(self):
@@ -439,13 +447,13 @@ class SolutionsChatflowDeploy(GedisChatBot):
         }
         custom_config = self.get_config()
         chart_config.update(custom_config)
-        env_vars = self.get_env_vars()
+        extra_config_string_safe = self.get_config_string_safe()
         self.k8s_client.install_chart(
             release=self.config.release_name,
             chart_name=f"{self.HELM_REPO_NAME}/{self.chart_name}",
             namespace=f"{self.chart_name}-{self.config.release_name}",
             extra_config=chart_config,
-            env_vars=env_vars,
+            extra_config_string_safe=extra_config_string_safe,
         )
 
     def chart_pods_started(self):

--- a/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
+++ b/jumpscale/packages/vdc_dashboard/sals/solutions_chatflow.py
@@ -439,13 +439,13 @@ class SolutionsChatflowDeploy(GedisChatBot):
         }
         custom_config = self.get_config()
         chart_config.update(custom_config)
-        env_var = self.get_env_vars()
+        env_vars = self.get_env_vars()
         self.k8s_client.install_chart(
             release=self.config.release_name,
             chart_name=f"{self.HELM_REPO_NAME}/{self.chart_name}",
             namespace=f"{self.chart_name}-{self.config.release_name}",
             extra_config=chart_config,
-            env_vars=env_var,
+            env_vars=env_vars,
         )
 
     def chart_pods_started(self):

--- a/jumpscale/sals/kubernetes/manager.py
+++ b/jumpscale/sals/kubernetes/manager.py
@@ -126,8 +126,8 @@ class Manager:
         for key, arg in extra_config.items():
             params += f" --set {key}={quote(arg)}"
 
-        if env_vars:
-            for key, arg in env_vars.items():
+        if extra_config_string_safe:
+            for key, arg in extra_config_string_safe.items():
                 params += f" --set-string {key}={quote(arg)}"
 
         cmd = f"helm --kubeconfig {self.config_path} --namespace {namespace} install --create-namespace {release} {chart_name} {params}"

--- a/jumpscale/sals/kubernetes/manager.py
+++ b/jumpscale/sals/kubernetes/manager.py
@@ -105,8 +105,9 @@ class Manager:
         extra_config=None,
         chart_values_file=None,
         extra_config_string_safe=None,
+        timeout="7m0s",
     ):
-        """deployes a helm chart
+        """deploy a helm chart
 
         Args:
             release (str): name of the release to be deployed

--- a/jumpscale/sals/kubernetes/manager.py
+++ b/jumpscale/sals/kubernetes/manager.py
@@ -131,7 +131,7 @@ class Manager:
             for key, arg in extra_config_string_safe.items():
                 params += f" --set-string {key}={quote(arg)}"
 
-        cmd = f"helm --kubeconfig {self.config_path} --namespace {namespace} install --create-namespace {release} {chart_name} {params}"
+        cmd = f"helm --kubeconfig {self.config_path} --timeout {timeout} --namespace {namespace} install --create-namespace {release} {chart_name} {params}"
         if chart_values_file:
             cmd += f" -f {chart_values_file}"
         rc, out, err = self._execute(cmd)

--- a/jumpscale/sals/kubernetes/manager.py
+++ b/jumpscale/sals/kubernetes/manager.py
@@ -98,7 +98,13 @@ class Manager:
 
     @helm_required
     def install_chart(
-        self, release, chart_name, namespace="default", extra_config=None, chart_values_file=None, env_vars=None
+        self,
+        release,
+        chart_name,
+        namespace="default",
+        extra_config=None,
+        chart_values_file=None,
+        extra_config_string_safe=None,
     ):
         """deployes a helm chart
 
@@ -106,6 +112,8 @@ class Manager:
             release (str): name of the release to be deployed
             chart_name (str): the name of the chart you need to deploy
             extra_config: dict containing extra paramters passed to install command with --set
+            extra_config_string_safe: dict container extra paramters passed to install command with --set-string
+                      to ensure that the values of type string and prevent wrong type casting
 
         Raises:
             j.exceptions.Runtime: in case the helm command failed to execute

--- a/jumpscale/sals/kubernetes/manager.py
+++ b/jumpscale/sals/kubernetes/manager.py
@@ -131,7 +131,7 @@ class Manager:
             for key, arg in extra_config_string_safe.items():
                 params += f" --set-string {key}={quote(arg)}"
 
-        cmd = f"helm --kubeconfig {self.config_path} --timeout {timeout} --namespace {namespace} install --create-namespace {release} {chart_name} {params}"
+        cmd = f"helm --kubeconfig {self.config_path} --namespace {namespace} install --timeout {timeout} --create-namespace {release} {chart_name} {params}"
         if chart_values_file:
             cmd += f" -f {chart_values_file}"
         rc, out, err = self._execute(cmd)

--- a/jumpscale/sals/kubernetes/manager.py
+++ b/jumpscale/sals/kubernetes/manager.py
@@ -97,7 +97,9 @@ class Manager:
         return out
 
     @helm_required
-    def install_chart(self, release, chart_name, namespace="default", extra_config=None, chart_values_file=None):
+    def install_chart(
+        self, release, chart_name, namespace="default", extra_config=None, chart_values_file=None, env_vars=None
+    ):
         """deployes a helm chart
 
         Args:
@@ -115,6 +117,11 @@ class Manager:
         params = ""
         for key, arg in extra_config.items():
             params += f" --set {key}={quote(arg)}"
+
+        if env_vars:
+            for key, arg in env_vars.items():
+                params += f" --set-string {key}={quote(arg)}"
+
         cmd = f"helm --kubeconfig {self.config_path} --namespace {namespace} install --create-namespace {release} {chart_name} {params}"
         if chart_values_file:
             cmd += f" -f {chart_values_file}"


### PR DESCRIPTION
### Description

- Update the chatflow to send port number, and other possible numerical values without the need to double quotes the value.
- Add method `get_config_string_safe` to handle setting or override existing chart values without the helm type casting.
- Increase helm ’install’ command timeout from the default 5 minutes to 7 minutes in the `Kubernetes manager`.
- Handle the exception raised by the k8s `manager` when helm command failed by delete the release and stop the chat flow.
- Increase the default values for `timeout` and `pod_initialization_timeout`.


### Related Issues

https://github.com/threefoldtech/js-sdk/issues/2942
https://github.com/threefoldtech/js-sdk/issues/2951