### PR TITLE
fixing VDC deployer calls string method on Enum object

### DIFF
--- a/jumpscale/sals/vdc/deployer.py
+++ b/jumpscale/sals/vdc/deployer.py
@@ -566,8 +566,9 @@ class VDCDeployer:
             old_node_ids.append(k8s_node.node_id)
         cc = CapacityChecker(farm_name)
         cc.exclude_nodes(*old_node_ids)
-        node_flavor_size = VDC_SIZE.K8SNodeFlavor[flavor.upper()]
-        if not cc.add_query(**VDC_SIZE.K8S_SIZES[node_flavor_size]):
+        if isinstance(flavor, str):
+            flavor = VDC_SIZE.K8SNodeFlavor[flavor.upper()]
+        if not cc.add_query(**VDC_SIZE.K8S_SIZES[flavor]):
             return False
         return True
 


### PR DESCRIPTION
### Description

fixing issue #2963, where VDC deployer calls a string method on Enum object when VDC chat-flow triggers the auto-extend.
however, a major refactor should be considered so the variable passed to the deployer always be either Enum or string for the sake of consistency.

### Changes

Add type checking in` _check_added_worker_capacity` method to ensure proper handling of `flavor` variable to handle the case when the variable is Enum object, not a string. 

### Related Issues
https://github.com/threefoldtech/js-sdk/issues/2963