### PR TITLE
Fix generate identity

### DIFF
--- a/jumpscale/sals/vdc/deployer.py
+++ b/jumpscale/sals/vdc/deployer.py
@@ -228,6 +228,8 @@ class VDCDeployer:
         # create a user identity from an old one or create a new one
         if self._identity:
             return
+        if self.password and len(self.password) != 32:
+            raise ValueError("Password length should be 32")
         username = VDC_IDENTITY_FORMAT.format(self.tname, self.vdc_name, self.vdc_uuid)
         words = j.data.encryption.key_to_mnemonic(self.password.encode())
         identity_name = f"vdc_ident_{self.vdc_uuid}"

--- a/tests/sals/vdc/vdc_base.py
+++ b/tests/sals/vdc/vdc_base.py
@@ -68,7 +68,7 @@ class VDCBase(BaseTests):
     @classmethod
     def deploy_vdc(cls, hours=1):
         cls.vdc_name = cls.random_name().lower()
-        cls.password = cls.random_string()
+        cls.password = j.data.hash.md5(cls.random_string())
         cls.vdc = j.sals.vdc.new(cls.vdc_name, cls.tname, cls.flavor)
 
         cls.info(f"Transfer needed TFT to deploy vdc for {hours} hour/s to the provisioning wallet.")


### PR DESCRIPTION
### Description

Fix _generate_identity to raise value error if password length not 32

### Changes

- Fix _generate_identity to raise value error if password length not 32
- Fix VDC tests by hash the password in deploy_vdc

### Related Issues

List of related issues

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
