### PR TITLE
harden entrypoint against empty env variables when redeploying 3bot container

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
@@ -141,8 +141,11 @@ j.core.config.set(
     },
 )
 
-j.core.config.set("NETWORK_FARMS", NETWORK_FARMS.split(","))
-j.core.config.set("COMPUTE_FARMS", COMPUTE_FARMS.split(","))
+if NETWORK_FARMS:
+    j.core.config.set("NETWORK_FARMS", NETWORK_FARMS.split(","))
+
+if COMPUTE_FARMS:
+    j.core.config.set("COMPUTE_FARMS", COMPUTE_FARMS.split(","))
 
 j.core.config.set("VDC_THREEBOT", True)
 


### PR DESCRIPTION
- harden entrypoint against empty env variables when redeploying 3bot container

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
