### PR TITLE
harden default value to calculate capacity for nodes with usage 0 or not ready

### DIFF
--- a/jumpscale/sals/vdc/kubernetes_auto_extend.py
+++ b/jumpscale/sals/vdc/kubernetes_auto_extend.py
@@ -87,8 +87,8 @@ class KubernetesMonitor:
                 )
                 cpu_mill = cpu_percentage = memory_usage = memory_percentage = 0
 
-            cpu_percentage = cpu_percentage or 1
-            memory_percentage = memory_percentage or 1
+            cpu_percentage = cpu_percentage or 1 / 100
+            memory_percentage = memory_percentage or 1 / 100
             self._node_stats[node_name] = {
                 "cpu": {"used": cpu_mill, "total": cpu_mill / cpu_percentage},
                 "memory": {"used": memory_usage, "total": memory_usage / memory_percentage},


### PR DESCRIPTION
### Description

- In case the node usage is 0 it can cause miscalculations or zero division error

### Related Issues

- https://github.com/threefoldtech/js-sdk/issues/3040

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
