### PR TITLE
Make vdc is_empty method load the info by default

### DIFF
--- a/jumpscale/packages/vdc/bottle/api.py
+++ b/jumpscale/packages/vdc/bottle/api.py
@@ -28,7 +28,6 @@ def _list_vdcs():
         if vdc.state == VDCSTATE.EMPTY:
             return
 
-        vdc.load_info()
         if vdc.is_empty():
             j.logger.warning(f"vdc {vdc.solution_uuid} is empty")
             vdc.state = VDCSTATE.EMPTY

--- a/jumpscale/packages/vdc/chats/new_vdc.py
+++ b/jumpscale/packages/vdc/chats/new_vdc.py
@@ -78,7 +78,9 @@ class VDCDeploy(GedisChatBot):
         self.vdc.save()
 
     def _vdc_form(self):
-        vdc_names = [vdc.vdc_name for vdc in j.sals.vdc.list(self.username, load_info=True) if not vdc.is_empty()]
+        vdc_names = [
+            vdc.vdc_name for vdc in j.sals.vdc.list(self.username, load_info=True) if not vdc.is_empty(load_info=False)
+        ]
         vdc_flavors = [flavor for flavor in VDC_SIZE.VDC_FLAVORS]
         vdc_flavor_messages = []
         for flavor in vdc_flavors:
@@ -341,7 +343,7 @@ class VDCDeploy(GedisChatBot):
         if self.vdc:
             if not self.vdc.is_empty():
                 j.core.db.hdel(VCD_DEPLOYING_INSTANCES, self.vdc_instance_name)
-                self.stop(f"There is another active vdc with name {self.vdc_name}")
+                self.stop(f"There is another active vdc with name {self.vdc_name.value}")
             j.sals.vdc.delete(self.vdc_instance_name)
         self.vdc = j.sals.vdc.new(
             vdc_name=self.vdc_name.value, owner_tname=self.username, flavor=VDC_SIZE.VDCFlavor[self.vdc_flavor],

--- a/jumpscale/packages/vdc/services/fund_prices_diff.py
+++ b/jumpscale/packages/vdc/services/fund_prices_diff.py
@@ -21,9 +21,9 @@ class FundPricesDifference(BackgroundService):
         for vdc_name in VDCFACTORY.list_all():
             vdc_instance = VDCFACTORY.find(vdc_name)
             vdc_instance.load_info()
-            vdc_spec_price = vdc_instance.calculate_spec_price() / (24 * 30)  # user price
+            vdc_spec_price = vdc_instance.calculate_spec_price(load_info=False) / (24 * 30)  # user price
             # check if vdc in grace period
-            if vdc_instance.is_blocked or vdc_instance.is_empty():
+            if vdc_instance.is_blocked or vdc_instance.is_empty(load_info=False):
                 j.logger.info(f"FUND PRICES DIFF: VDC {vdc_instance.instance_name} is empty or in grace period")
                 continue
             # check if prepaid has enough money

--- a/jumpscale/packages/vdc/services/update_expiration.py
+++ b/jumpscale/packages/vdc/services/update_expiration.py
@@ -19,7 +19,6 @@ class UpdateExpiration(BackgroundService):
 
     def update_expiration(self, name):
         vdc = j.sals.vdc.get(name)
-        vdc.load_info()
         if vdc.is_empty():
             return
         vdc.expiration = vdc.calculate_expiration_value()

--- a/jumpscale/sals/vdc/grace_period.py
+++ b/jumpscale/sals/vdc/grace_period.py
@@ -25,7 +25,6 @@ class VDCGracePeriodFactory(StoredFactory):
         return False
 
     def is_eligible(self, vdc_instance) -> bool:
-        vdc_instance.load_info()
         if vdc_instance.is_empty():
             j.logger.debug(f"vdc {vdc_instance.vdc_name} is empty and not eligible")
             return False

--- a/jumpscale/sals/vdc/vdc.py
+++ b/jumpscale/sals/vdc/vdc.py
@@ -76,7 +76,9 @@ class UserVDC(Base):
             node["size"] = node["_size"]
         return d
 
-    def is_empty(self):
+    def is_empty(self, load_info=True):
+        if load_info:
+            self.load_info()
         if any([self.kubernetes, self.threebot.wid, self.threebot.domain, self.s3.minio.wid, self.s3.zdbs]):
             return False
         return True


### PR DESCRIPTION
### Description

- Make vdc is_empty method load the info by default
- Fix error message in vdc chatflow

### Related Issues

#2958

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
