### PR TITLE
allow passing default domain and email when adding a package

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
@@ -168,19 +168,15 @@ while not vdc.threebot.domain and j.data.time.now().timestamp < deadline:
 j.core.config.set("OVER_PROVISIONING", True)
 server = j.servers.threebot.get("default")
 server.packages.add("/sandbox/code/github/threefoldtech/js-sdk/jumpscale/packages/billing")
-if TEST_CERT != "true":
-    package_config = toml.load(
-        "/sandbox/code/github/threefoldtech/js-sdk/jumpscale/packages/vdc_dashboard/package.toml"
-    )
-    package_config["servers"][0]["domain"] = vdc.threebot.domain
-    with open("/sandbox/code/github/threefoldtech/js-sdk/jumpscale/packages/vdc_dashboard/package.toml", "w") as f:
-        toml.dump(package_config, f)
-    if ACME_SERVER_URL:
-        server.acme_server_type = "custom"
-        server.acme_server_url = ACME_SERVER_URL
+if TEST_CERT != "true" and ACME_SERVER_URL:
+    server.acme_server_type = "custom"
+    server.acme_server_url = ACME_SERVER_URL
 
 server.packages.add(
-    "/sandbox/code/github/threefoldtech/js-sdk/jumpscale/packages/vdc_dashboard", admins=[f"{vdc.owner_tname}.3bot"]
+    "/sandbox/code/github/threefoldtech/js-sdk/jumpscale/packages/vdc_dashboard",
+    admins=[f"{vdc.owner_tname}.3bot"],
+    default_domain=vdc.threebot.domain,
+    default_email=VDC_EMAIL,
 )
 server.save()
 

--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -518,11 +518,13 @@ class PackageManager(Base):
             path = package_path
 
         admins = kwargs.pop("admins", [])
+        default_domain = kwargs.get("default_domain", self.threebot.domain)
+        default_email = kwargs.get("default_email", self.threebot.email)
 
         package = Package(
             path=path,
-            default_domain=self.threebot.domain,
-            default_email=self.threebot.email,
+            default_domain=default_domain,
+            default_email=default_email,
             giturl=giturl,
             kwargs=kwargs,
             admins=admins,


### PR DESCRIPTION
### Description

Resolve updating `package.toml` by supporting passing default domain and email when adding a package.

### Changes

* Update threebot server package.add to get default domain and email if passed
* Update `mimimal_entrypoint` to pass the domain when adding the `vdc_dashboard` package.

### Related Issues

#2031

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
