### PR TITLE
Development dashboard update hotfix1

### DIFF
--- a/jumpscale/packages/vdc_dashboard/bottle/api/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/api/deployments.py
@@ -336,7 +336,7 @@ def update():
         branch = os.environ.get("SDK_VERSION", "development")
     sdk_path = "/sandbox/code/github/threefoldtech/js-sdk"
     cmd = f"bash jumpscale/packages/vdc_dashboard/scripts/update.sh {branch}"
-    rc, out, err = j.sals.process.execute(cmd, cwd=sdk_path, showout=True)
+    rc, out, err = j.sals.process.execute(cmd, cwd=sdk_path, showout=True, timeout=1200)
     if rc:
         return HTTPResponse(
             j.data.serializers.json.dumps(


### PR DESCRIPTION
### Description

fix #3087 by increasing invoke timeout from 600 to 1200 to cover rare cases when the dependencies take a long time to install during update the VDC

List of related issues
#3087