### PR TITLE
Fix side effects of moving all bottle apps to a single server

### DIFF
--- a/jumpscale/install/rootfs/etc/zinit/start.yaml
+++ b/jumpscale/install/rootfs/etc/zinit/start.yaml
@@ -1,5 +1,5 @@
 exec: jsng "j.servers.threebot.start_default(wait=True, local=False)"
-test: bash -c "curl http://localhost:8989/api/heartbeat --connect-timeout 10 -f"
+test: bash -c "curl http://localhost:31000/admin/api/heartbeat --connect-timeout 10 -f"
 log: stdout
 after:
   - init

--- a/jumpscale/packages/admin/package.toml
+++ b/jumpscale/packages/admin/package.toml
@@ -15,4 +15,3 @@ file_path = "bottle/admin.py"
 path_url = "/api/"
 path_dest = "/api/"
 host = "0.0.0.0"
-port = 8989

--- a/jumpscale/packages/auth/package.toml
+++ b/jumpscale/packages/auth/package.toml
@@ -13,4 +13,3 @@ file_path = "bottle/auth.py"
 path_url = ""
 path_dest = ""
 host = "0.0.0.0"
-port = 8787

--- a/jumpscale/packages/chatflows/package.toml
+++ b/jumpscale/packages/chatflows/package.toml
@@ -13,4 +13,3 @@ file_path = "bottle/bottle.py"
 path_url = "/"
 path_dest = "/"
 host = "0.0.0.0"
-port = 8552

--- a/jumpscale/packages/marketplace/package.toml
+++ b/jumpscale/packages/marketplace/package.toml
@@ -17,8 +17,6 @@ file_path = "bottle/solutions.py"
 path_url = "/api/"
 path_dest = "/api/"
 host = "0.0.0.0"
-port = 5555
-
 
 [[servers]]
 name = "marketplace_root_proxy"

--- a/jumpscale/packages/polls/package.toml
+++ b/jumpscale/packages/polls/package.toml
@@ -8,7 +8,6 @@ file_path = "bottle/polls_bottle.py"
 path_url = "/api/"
 path_dest = "/api/"
 host = "0.0.0.0"
-port = 8554
 
 [[servers]]
 name = "root"

--- a/jumpscale/packages/stellar_stats/package.toml
+++ b/jumpscale/packages/stellar_stats/package.toml
@@ -8,7 +8,6 @@ file_path = "bottle/stellar_stats.py"
 path_url = "/api/"
 path_dest = "/api/"
 host = "0.0.0.0"
-port = 8558
 is_auth = false
 is_admin = false
 

--- a/jumpscale/packages/threebot_deployer/package.toml
+++ b/jumpscale/packages/threebot_deployer/package.toml
@@ -16,7 +16,6 @@ file_path = "bottle/solutions.py"
 path_url = "/api/"
 path_dest = "/api/"
 host = "0.0.0.0"
-port = 5560
 
 [[bottle_servers]]
 name = "backup"
@@ -24,8 +23,6 @@ file_path = "bottle/backup.py"
 path_url = "/backup/"
 path_dest = "/backup/"
 host = "0.0.0.0"
-port = 5561
-
 
 [[servers]]
 name = "threebot_deployer_root_proxy"

--- a/jumpscale/packages/vdc/package.toml
+++ b/jumpscale/packages/vdc/package.toml
@@ -17,8 +17,6 @@ file_path = "bottle/api.py"
 path_url = "/api/"
 path_dest = "/api/"
 host = "0.0.0.0"
-port = 5562
-
 
 [[servers]]
 name = "vdc_proxy"

--- a/jumpscale/packages/vdc_dashboard/bottle/api/controller.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/api/controller.py
@@ -1,7 +1,9 @@
+# controller API
+# need to have a separate app because it shouldn't be authenticated using "auth" package
 import random
 from math import ceil
 
-from bottle import HTTPResponse, request
+from bottle import Bottle, HTTPResponse, request
 from jumpscale.clients.explorer.models import DiskType
 from jumpscale.loader import j
 from jumpscale.packages.vdc_dashboard.bottle.api.backup import _list as list_backups
@@ -11,7 +13,7 @@ from jumpscale.packages.vdc_dashboard.bottle.vdc_helpers import _list_alerts
 from jumpscale.packages.vdc_dashboard.sals.vdc_dashboard_sals import get_kubeconfig_file, get_zstor_config_file
 from jumpscale.sals.vdc.size import VDC_SIZE, ZDB_STARTING_SIZE
 
-from .root import app
+app = Bottle()
 
 
 @app.route("/api/controller/vdc", method="GET")

--- a/jumpscale/packages/vdc_dashboard/bottle/app.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/app.py
@@ -1,6 +1,5 @@
 import jumpscale.packages.vdc_dashboard.bottle.api.root
 import jumpscale.packages.vdc_dashboard.bottle.api.backup
-import jumpscale.packages.vdc_dashboard.bottle.api.controller
 import jumpscale.packages.vdc_dashboard.bottle.api.deployments
 import jumpscale.packages.vdc_dashboard.bottle.api.export
 

--- a/jumpscale/packages/vdc_dashboard/package.toml
+++ b/jumpscale/packages/vdc_dashboard/package.toml
@@ -27,7 +27,6 @@ file_path = "bottle/app.py"
 path_url = "/api/"
 path_dest = "/api/"
 host = "0.0.0.0"
-port = 5556
 
 [[bottle_servers]]
 name = "controller"
@@ -35,7 +34,6 @@ file_path = "bottle/api/controller.py"
 path_url = "/api/controller"
 path_dest = "/api/controller"
 host = "0.0.0.0"
-port = 5556
 is_auth = false
 is_admin = false
 is_package_authorized = false

--- a/jumpscale/packages/vdc_dashboard/package.toml
+++ b/jumpscale/packages/vdc_dashboard/package.toml
@@ -29,6 +29,16 @@ path_dest = "/api/"
 host = "0.0.0.0"
 port = 5556
 
+[[bottle_servers]]
+name = "controller"
+file_path = "bottle/api/controller.py"
+path_url = "/api/controller"
+path_dest = "/api/controller"
+host = "0.0.0.0"
+port = 5556
+is_auth = false
+is_admin = false
+is_package_authorized = false
 
 [[servers]]
 name = "vdc_dashboard_root_proxy"


### PR DESCRIPTION
### Description

Fix side effects of moving all bottle apps to a single server.

### Changes

- Remove 3bot auth from controller API as it already has its own authentication.
- Make controller a separate app
- Add a new non-standalone bottle server in `package.toml` of `vdc_dashbord`
- Fix status check in vdc start script
- Remove unwanted port from all non-standalone bottle servers 

### Related Issues

#3090

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
