### PR TITLE
fix mounting multiple non-standalone apps per package...

### DIFF
--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -612,13 +612,13 @@ class PackageManager(Base):
         # we first merge all apps of a package into a single app
         # then mount this app on threebot main app
         # this will work with multiple non-standalone apps
-        package_app = j.server.appserver.make_main_app()
+        package_app = j.servers.appserver.make_main_app()
         for bottle_server in package.bottle_servers:
             path = j.sals.fs.join_paths(package.path, bottle_server["file_path"])
             if not j.sals.fs.exists(path):
                 raise j.exceptions.NotFound(f"Cannot find bottle server path {path}")
 
-            is_standalone = bottle_server.get("standalone", False)
+            standalone = bottle_server.get("standalone", False)
             if standalone:
                 bottle_wsgi_server = package.get_bottle_server(path, bottle_server["host"], bottle_server["port"])
                 self.threebot.rack.add(f"{package.name}_{bottle_server['name']}", bottle_wsgi_server)


### PR DESCRIPTION
### Description

Fix mounting multiple non-standalone apps per package as mounting only will allow a single app per package, we should merge all apps of a package into one first. @AhmedHanafy725 discovered this and did many tests to ensure the fix is working.

### Changes

- Update mounting apps in threebot server.

### Related Issues

None

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
