### PR TITLE
Verify backup name

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Actions.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Actions.vue
@@ -10,6 +10,7 @@
       <template #default v-else-if="title == 'Create'">
         Please enter backup name to confirm.
         <v-text-field v-model="confirmName" dense></v-text-field>
+        <p v-if="disableSubmit" style="color:red">{{errorMsg}}</p>
       </template>
       <template #actions>
         <v-btn text @click="close">Cancel</v-btn>
@@ -41,7 +42,7 @@ module.exports = {
     disableSubmit() {
       if (this.title == "Delete" && this.confirmName === this.name.toString()) {
         return false;
-      } else if (this.title == "Create" && this.confirmName) {
+      } else if (this.title == "Create" && this.verifyBackupName(this.confirmName)) {
         return false;
       }
       return true;
@@ -55,7 +56,7 @@ module.exports = {
     };
   },
   mixins: [dialog],
-  props: ["name", "title", "vdcbackup", "configbackup"],
+  props: ["name", "title", "vdcbackup", "configbackup","backups"],
   methods: {
     del() {
       this.loading = true;
@@ -90,6 +91,21 @@ module.exports = {
     getlist(timeout=2000) {
       this.$emit("reload-backups", timeout, { message: "Backup list reloaded!" });
     },
+    verifyBackupName(backupName){
+      currentBackupsName = this.backups.map(item => item.name)
+      if (!backupName) {
+        this.errorMsg = ""
+        return false
+      }else if (currentBackupsName.includes(backupName)){
+        this.errorMsg = "Can't use the same name twice, Please use another name"
+        return false
+      }else if (backupName.indexOf(' ') > 0) {
+        this.errorMsg = "Space is not allowed"
+        return false
+      }else{
+        return true
+      }
+    }
   },
   mounted() {
     this.show = false;

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Backups.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Backups.vue
@@ -92,6 +92,7 @@
       :name="selectedBackup"
       :vdcbackup="vdcBackupName"
       :configbackup="configBackupName"
+      :backups="backups"
       @reload-backups="reload"
     ></actions>
     <restore-backup


### PR DESCRIPTION
### Description

Verify new backup names that the user creates if it contains space or used before.

### Changes

- Check if the backup name contains space
- Check if the backup name duplicated

### Related Issues

#3035 
#3104

### Screen record
![backupNameVerifcation](https://user-images.githubusercontent.com/11272864/119266768-5d7bc300-bbec-11eb-80d0-23946891ec3c.gif)

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
