### PR TITLE
fixing CI workflow issue #3110

### DIFF
--- a/.github/workflows/js-sdk.yml
+++ b/.github/workflows/js-sdk.yml
@@ -50,11 +50,12 @@ jobs:
           sudo apt-get install -y git python3-pip python3-venv python3-setuptools tmux redis restic nginx cron
           sudo service redis stop
           sudo service nginx stop
-          sudo pip3 install poetry
-          sudo poetry run pip3 install pytest selenium
+          pip3 install poetry
       - name: Install
         run: |
-          sudo poetry install
+          poetry config virtualenvs.in-project true
+          poetry run pip3 install pytest selenium
+          poetry install
       - name: Run tests
         env:
           TNAME: ${{ secrets.TNAME }}
@@ -63,5 +64,6 @@ jobs:
           FAKE_EMAIL: ${{ secrets.FAKE_EMAIL }}
           FAKE_GITHUB_TOKEN: ${{ secrets.FAKE_GITHUB_TOKEN }}
         run: |
+          POETRY=$(which poetry)
           sudo --preserve-env=TNAME --preserve-env=EMAIL --preserve-env=WORDS --preserve-env=FAKE_EMAIL --preserve-env=FAKE_GITHUB_TOKEN \
-          poetry run pytest tests -sv -m "unittests"
+          $POETRY run pytest tests -sv -m "unittests"


### PR DESCRIPTION
### Description

Fixing issue #3110 with js-sdk current workflow, the problem was setup-python GitHub action sets a new python Installation for the current user `runner` while using `sudo` with pip makes poetry get installed for default root Python installation that comes preinstalled with the system, which in the case of ubuntu 18, was 3.6 and for ubuntu 20, 3.8 regardless of the matrix setup.

### Changes

in this modified workflow:

- now poetry install will pick the correct Python environment sets by the GitHub action matrix


- before the fix
![Screenshot from 2021-05-24 12-20-02](https://user-images.githubusercontent.com/42457449/119336514-07f7f280-bc8e-11eb-9a64-69e968d4e83c.png)

- after the fix
![Screenshot from 2021-05-24 12-40-20](https://user-images.githubusercontent.com/42457449/119336532-0e866a00-bc8e-11eb-8277-0b3e687f3d13.png)


### Related Issues

closes #3110 

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
