### PR TITLE
Drain kubernetes node before deleting

### DIFF
--- a/jumpscale/packages/vdc_dashboard/bottle/api/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/api/deployments.py
@@ -87,7 +87,7 @@ def delete_node():
     # Delete the node
     try:
         j.logger.info(f"Deleting node with wid: {wid}")
-        deployer.delete_k8s_node(wid)
+        deployer.delete_k8s_node(wid, True)
     except Exception as e:
         j.logger.error(f"Error: Failed to delete workload due to the following {str(e)}")
         abort(500, "Error: Failed to delete workload")

--- a/jumpscale/packages/vdc_dashboard/frontend/api.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/api.js
@@ -96,11 +96,11 @@ const apiClient = {
         method: "get"
       })
     },
-    deleteWorkerWorkload: (wid) => {
+    deleteWorkerWorkload: (wid, podsToDelete) => {
       return axios({
         url: `${baseURL}/kube/nodes/delete`,
         method: "post",
-        data: { wid: wid },
+        data: { wid: wid, pods_to_delete: podsToDelete },
         headers: { 'Content-Type': 'application/json' }
       })
     },

--- a/jumpscale/packages/vdc_dashboard/frontend/api.js
+++ b/jumpscale/packages/vdc_dashboard/frontend/api.js
@@ -104,6 +104,14 @@ const apiClient = {
         headers: { 'Content-Type': 'application/json' }
       })
     },
+    checkBeforeDeleteWorkerWorkload: (wid) => {
+      return axios({
+        url: `${baseURL}/kube/nodes/check_before_delete`,
+        method: "post",
+        data: { wid: wid },
+        headers: { 'Content-Type': 'application/json' }
+      })
+    },
     deleteZdb: (wid) => {
       return axios({
         url: `${baseURL}/s3/zdbs/delete`,

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/DeleteConfirmation.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/DeleteConfirmation.vue
@@ -9,6 +9,15 @@
   >
     <template #default>
       {{ messages.confirmationMsg }}
+      <v-alert
+        border="bottom"
+        colored-border
+        type="warning"
+        elevation="2"
+        v-if="isnodereadytodelete"
+      >
+        {{ message.warningMsg }}
+      </v-alert>
     </template>
     <template #actions>
       <v-btn text @click="close">Close</v-btn>
@@ -25,8 +34,8 @@ module.exports = {
     api: String,
     wid: Number,
     messages: Object,
-    isNodeReadyToDelete: Boolean,
-    podsToDelete: Array
+    isnodereadytodelete: Boolean,
+    podstodelete: Array
   },
   methods: {
     submit() {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/DeleteConfirmation.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/DeleteConfirmation.vue
@@ -10,7 +10,7 @@
     <template #default>
       {{ messages.confirmationMsg }}
       <v-alert v-if="isnodereadytodelete == false" border="top" colored-border type="warning" elevation="2">
-        {{ messages.warningMsg }}
+        <span v-html="messages.warningMsg"></span>
       </v-alert>
     </template>
     <template #actions>

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/DeleteConfirmation.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/DeleteConfirmation.vue
@@ -25,6 +25,8 @@ module.exports = {
     api: String,
     wid: Number,
     messages: Object,
+    isNodeReadyToDelete: Boolean,
+    podsToDelete: Array
   },
   methods: {
     submit() {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/DeleteConfirmation.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/DeleteConfirmation.vue
@@ -9,16 +9,10 @@
   >
     <template #default>
       {{ messages.confirmationMsg }}
-    </template>
-    <v-alert
-      border="bottom"
-      colored-border
-      type="warning"
-      elevation="2"
-      v-if="isnodereadytodelete"
-    >
-      {{ message.warningMsg }}
+      <v-alert v-if="isnodereadytodelete == false" border="top" colored-border type="warning" elevation="2">
+        {{ messages.warningMsg }}
       </v-alert>
+    </template>
     <template #actions>
       <v-btn text @click="close">Close</v-btn>
       <v-btn text color="error" @click="submit">Confirm</v-btn>
@@ -41,7 +35,7 @@ module.exports = {
     submit() {
       this.loading = true;
       this.error = null;
-      this.$api.solutions[this.api](this.wid)
+      this.$api.solutions[this.api](this.wid, this.podstodelete)
         .then((response) => {
           this.alert(this.messages.successMsg, "success");
           this.close();

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/DeleteConfirmation.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/DeleteConfirmation.vue
@@ -9,16 +9,16 @@
   >
     <template #default>
       {{ messages.confirmationMsg }}
-      <v-alert
-        border="bottom"
-        colored-border
-        type="warning"
-        elevation="2"
-        v-if="isnodereadytodelete"
-      >
-        {{ message.warningMsg }}
-      </v-alert>
     </template>
+    <v-alert
+      border="bottom"
+      colored-border
+      type="warning"
+      elevation="2"
+      v-if="isnodereadytodelete"
+    >
+      {{ message.warningMsg }}
+      </v-alert>
     <template #actions>
       <v-btn text @click="close">Close</v-btn>
       <v-btn text color="error" @click="submit">Confirm</v-btn>

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
@@ -94,6 +94,8 @@
       title="Delete Worker"
       :messages="deletionMessages"
       :wid="selectedworker"
+      :isNodeReadyToDelete="isNodeReadyToDelete"
+      :podsToDelete="podsToDelete"
       @reload-vdcinfo="reloadVdcInfo"
     ></cancel-workload>
     <download-kubeconfig v-model="dialogs.downloadKube"></download-kubeconfig>
@@ -132,6 +134,8 @@ module.exports = {
         confirmationMsg: "Are you sure you want to delete this worker?",
         successMsg: "Worker deleted successfully",
       },
+      isNodeReadyToDelete: false,
+      podsToDelete: null
     };
   },
   methods: {
@@ -147,6 +151,16 @@ module.exports = {
     },
     deleteNode(wid) {
       this.selectedworker = wid;
+      this.$api.solutions['checkBeforeDeleteWorkerWorkload'](wid)
+        .then((response) => {
+          console.log(`Check Before Delete Node Response: ${response.data}`)
+          this.isNodeReadyToDelete = response.data.is_ready
+          this.podsToDelete = response.data.pods_to_delete
+          if (!this.isNodeReadyToDelete) {
+            this.deletionMessages.confirmationMsg += "\nThe following Pods will be deleted:\n" + this.podsToDelete
+          }
+          console.log(`Deletion msg: ${this.deletionMessages}`)
+        })
       this.dialogs.cancelWorkload = true;
     },
 

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
@@ -163,8 +163,8 @@ module.exports = {
           }
           console.log("Deletion msg:" ,this.deletionMessages);
         }).finally(() => {
-          this.dialogs.cancelWorkload = true;
           this.loading = false;
+          this.dialogs.cancelWorkload = true;
         });
     },
 

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
@@ -151,17 +151,20 @@ module.exports = {
     },
     deleteNode(wid) {
       this.selectedworker = wid;
-      this.$api.solutions['checkBeforeDeleteWorkerWorkload'](wid)
+      this.loading = true;
+      this.$api.solutions.checkBeforeDeleteWorkerWorkload(wid)
         .then((response) => {
-          console.log(`Check Before Delete Node Response: ${response.data}`)
-          this.isNodeReadyToDelete = response.data.is_ready
-          this.podsToDelete = response.data.pods_to_delete
+          console.log("Check Before Delete Node Response:" , response.data);
+          this.isNodeReadyToDelete = response.data.is_ready;
+          this.podsToDelete = response.data.pods_to_delete;
           if (!this.isNodeReadyToDelete) {
-            this.deletionMessages.confirmationMsg += "\nThe following Pods will be deleted:\n" + this.podsToDelete
+            this.deletionMessages.confirmationMsg += "<br> The following Pods will be deleted:<br>" + this.podsToDelete;
           }
-          console.log(`Deletion msg: ${this.deletionMessages}`)
-        })
-      this.dialogs.cancelWorkload = true;
+          console.log("Deletion msg:" ,this.deletionMessages);
+        }).finally(() => {
+          this.dialogs.cancelWorkload = true;
+          this.loading = false;
+        });
     },
 
     downloadKubeConfigFile() {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
@@ -160,11 +160,12 @@ module.exports = {
           this.isNodeReadyToDelete = response.data.is_ready;
           this.podsToDelete = response.data.pods_to_delete;
           podsString = "<br>"
+          timeWarning = "<br> This operation may take time, to safely delete your worker"
           for (pod in this.podsToDelete){
-            podsString += this.podsToDelete[pod] + "<br>"
+            podsString += "- " + this.podsToDelete[pod] + "<br>"
           }
           if (!this.isNodeReadyToDelete) {
-            this.deletionMessages.warningMsg = "The following release/s will be deleted: " + podsString;
+            this.deletionMessages.warningMsg = "The following release/s will be deleted: " + podsString + timeWarning;
           }
           console.log("Deletion msg:" ,this.deletionMessages);
         }).finally(() => {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
@@ -159,8 +159,12 @@ module.exports = {
           console.log("Check Before Delete Node Response:" , response.data);
           this.isNodeReadyToDelete = response.data.is_ready;
           this.podsToDelete = response.data.pods_to_delete;
+          podsString = "<br>"
+          for (pod in this.podsToDelete){
+            podsString += this.podsToDelete[pod] + "<br>"
+          }
           if (!this.isNodeReadyToDelete) {
-            this.deletionMessages.warningMsg = "The following release will be deleted: " + this.podsToDelete;
+            this.deletionMessages.warningMsg = "The following release/s will be deleted: " + podsString;
           }
           console.log("Deletion msg:" ,this.deletionMessages);
         }).finally(() => {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
@@ -94,8 +94,8 @@
       title="Delete Worker"
       :messages="deletionMessages"
       :wid="selectedworker"
-      :isNodeReadyToDelete="isNodeReadyToDelete"
-      :podsToDelete="podsToDelete"
+      :isnodereadytodelete="isNodeReadyToDelete"
+      :podstodelete="podsToDelete"
       @reload-vdcinfo="reloadVdcInfo"
     ></cancel-workload>
     <download-kubeconfig v-model="dialogs.downloadKube"></download-kubeconfig>
@@ -132,6 +132,7 @@ module.exports = {
       kubernetesSizeMap: KUBERNETES_VM_SIZE_MAP,
       deletionMessages: {
         confirmationMsg: "Are you sure you want to delete this worker?",
+        warningMsg: "",
         successMsg: "Worker deleted successfully",
       },
       isNodeReadyToDelete: false,
@@ -158,7 +159,7 @@ module.exports = {
           this.isNodeReadyToDelete = response.data.is_ready;
           this.podsToDelete = response.data.pods_to_delete;
           if (!this.isNodeReadyToDelete) {
-            this.deletionMessages.confirmationMsg += "<br> The following Pods will be deleted:<br>" + this.podsToDelete;
+            this.deletionMessages.warningMsg = "The following Pods will be deleted: " + this.podsToDelete;
           }
           console.log("Deletion msg:" ,this.deletionMessages);
         }).finally(() => {

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Kubernetes.vue
@@ -23,7 +23,7 @@
     <v-data-table
       :headers="headers"
       :items="kubernetesData"
-      :loading="loading"
+      :loading="loading || tableLoading"
       class="elevation-1"
     >
       <template slot="no-data">No VDC instances available</template>
@@ -115,6 +115,7 @@ module.exports = {
     return {
       selected: null,
       selectedworker: null,
+      tableLoading: false,
       dialogs: {
         info: false,
         cancelWorkload: false,
@@ -152,18 +153,18 @@ module.exports = {
     },
     deleteNode(wid) {
       this.selectedworker = wid;
-      this.loading = true;
+      this.tableLoading = true;
       this.$api.solutions.checkBeforeDeleteWorkerWorkload(wid)
         .then((response) => {
           console.log("Check Before Delete Node Response:" , response.data);
           this.isNodeReadyToDelete = response.data.is_ready;
           this.podsToDelete = response.data.pods_to_delete;
           if (!this.isNodeReadyToDelete) {
-            this.deletionMessages.warningMsg = "The following Pods will be deleted: " + this.podsToDelete;
+            this.deletionMessages.warningMsg = "The following release will be deleted: " + this.podsToDelete;
           }
           console.log("Deletion msg:" ,this.deletionMessages);
         }).finally(() => {
-          this.loading = false;
+          this.tableLoading = false;
           this.dialogs.cancelWorkload = true;
         });
     },

--- a/jumpscale/sals/vdc/deployer.py
+++ b/jumpscale/sals/vdc/deployer.py
@@ -763,8 +763,8 @@ class VDCDeployer:
             raise j.exceptions.Runtime(f"All tries to deploy on farm {farm_name} has failed")
         return wids
 
-    def delete_k8s_node(self, wid):
-        return self.kubernetes.delete_worker(wid)
+    def delete_k8s_node(self, wid, is_ready=False):
+        return self.kubernetes.delete_worker(wid, is_ready)
 
     def delete_s3_zdb(self, wid):
         return self.s3.delete_zdb(wid)

--- a/jumpscale/sals/vdc/kubernetes.py
+++ b/jumpscale/sals/vdc/kubernetes.py
@@ -126,7 +126,9 @@ class VDCKubernetesDeployer(VDCBaseComponent):
                     break
 
             if not can_deploy:
-                pods_to_delete.append(pod["metadata"]["namespace"])
+                if not pod["metadata"]["namespace"] in pods_to_delete:
+                    pods_to_delete.append(pod["metadata"]["namespace"])
+
                 j.logger.warning(f"Pod: {pod['metadata']['name']} can't be redeployed on any other node")
 
         # Return bool for check, and pods that can not redeployed again

--- a/jumpscale/sals/vdc/kubernetes.py
+++ b/jumpscale/sals/vdc/kubernetes.py
@@ -93,7 +93,7 @@ class VDCKubernetesDeployer(VDCBaseComponent):
 
         # Get pods on the node we want to delete
         out = kube_manager.execute_native_cmd(
-            f"kubectl get pods -A -o json --field-selector spec.nodeName={node_name_to_delete[0]}"
+            f"kubectl get pods -A -o json --sort-by='.metadata.namespace' --field-selector spec.nodeName={node_name_to_delete[0]}"
         )
         all_pods_to_redeploy = j.data.serializers.json.loads(out)
         pods_to_delete = []

--- a/jumpscale/sals/vdc/kubernetes.py
+++ b/jumpscale/sals/vdc/kubernetes.py
@@ -133,7 +133,7 @@ class VDCKubernetesDeployer(VDCBaseComponent):
                     break
 
             if not can_deploy:
-                pods_to_delete.append(pod)
+                pods_to_delete.append(pod["metadata"]["namespace"])
                 j.logger.warning(f"Pod: {pod['metadata']['name']} can't be redeployed on any other node")
 
         # Return bool for check, and pods that can not redeployed again

--- a/jumpscale/sals/vdc/kubernetes.py
+++ b/jumpscale/sals/vdc/kubernetes.py
@@ -93,7 +93,7 @@ class VDCKubernetesDeployer(VDCBaseComponent):
 
         # Get pods on the node we want to delete
         out = kube_manager.execute_native_cmd(
-            f"kubectl get pods -A -o json --field-selector spec.nodeName={node_name_to_delete}"
+            f"kubectl get pods -A -o json --field-selector spec.nodeName={node_name_to_delete[0]}"
         )
         all_pods_to_redeploy = j.data.serializers.json.loads(out)
         pods_to_delete = []

--- a/jumpscale/sals/vdc/kubernetes.py
+++ b/jumpscale/sals/vdc/kubernetes.py
@@ -89,7 +89,7 @@ class VDCKubernetesDeployer(VDCBaseComponent):
         all_node_stats = kube_monitor.node_stats
         node_name_to_delete = [node for node in all_node_stats.keys() if all_node_stats[node]["wid"] == wid]
         remaining_nodes_reservations = kube_monitor.fetch_resource_reservations(exclude_nodes=node_name_to_delete)
-        system_namespaces = ["k3os-system", "kube-public", "kube-system", " velero"]
+        system_namespaces = ["k3os-system", "kube-public", "kube-system", "velero"]
 
         # Get pods on the node we want to delete
         out = kube_manager.execute_native_cmd(

--- a/jumpscale/sals/vdc/kubernetes.py
+++ b/jumpscale/sals/vdc/kubernetes.py
@@ -95,7 +95,7 @@ class VDCKubernetesDeployer(VDCBaseComponent):
                 # Get name of the node we want to delete
                 node_name_to_delete = node.name
                 # Remove it from the all node stats and reservations
-                all_node_stats.pop(node)
+                all_node_stats.pop(node.name)
                 all_nodes_reservations.remove(node)
 
         # Get pods on the node we want to delete
@@ -134,6 +134,8 @@ class VDCKubernetesDeployer(VDCBaseComponent):
 
             if not can_deploy:
                 pods_to_delete.append(pod)
+                j.logger.warning(f"Pod: {pod['metadata']['name']} can't be redeployed on any other node")
+
         # Return bool for check, and pods that can not redeployed again
         return len(pods_to_delete) == 0, pods_to_delete
 

--- a/jumpscale/sals/vdc/kubernetes_auto_extend.py
+++ b/jumpscale/sals/vdc/kubernetes_auto_extend.py
@@ -190,7 +190,8 @@ class KubernetesMonitor:
         deployer.extend_k8s_workloads(duration, *wids)
         return wids
 
-    def fetch_resource_reservations(self):
+    def fetch_resource_reservations(self, exclude_nodes=None):
+        exclude_nodes = exclude_nodes or []
         out = self.manager.execute_native_cmd("kubectl get pod -A -o json")
         result = j.data.serializers.json.loads(out)
         node_reservations = defaultdict(lambda: {"cpu": 0.0, "memory": 0.0, "total_cpu": 0.0, "total_memory": 0.0})
@@ -216,7 +217,7 @@ class KubernetesMonitor:
 
         result = []
         for node_name, resv in node_reservations.items():
-            if node_name not in self.node_stats:
+            if node_name not in self.node_stats or node_name in exclude_nodes:
                 continue
             node_reservations[node_name]["total_cpu"] = self.node_stats[node_name]["cpu"]["total"]
             node_reservations[node_name]["total_memory"] = self.node_stats[node_name]["memory"]["total"]


### PR DESCRIPTION
### Description

Drain Kubernetes node before deleting it

### Changes

- Check for availability of using drain by check the remaining cluster resources and the pods on the node to be drained
- Inform the user if there are pods that can't be deployed again due to lack of resources in the cluster after deleting the node.
-If the user confirms the deletion, delete the releases that need to be deleted and then drain node, and delete it safely

### Related Issues

#3065

### Screenshots
- list of the pods deployed on the node we want to delete, (Taiga, Cryptpad, Peertube)
![image](https://user-images.githubusercontent.com/11272864/119707338-573f4e00-be5b-11eb-85fa-c8c19b78ae05.png)

- Delete the worker for UI (Cryptpad can't be redeployed again because of resources limitation)
![delete_worker](https://user-images.githubusercontent.com/11272864/119707389-66260080-be5b-11eb-8091-cd629e5a962c.gif)

- Check that all the remaining pods redeployed on other nodes and solutions still running (Taiga, Peertube)
![image](https://user-images.githubusercontent.com/11272864/119707696-bdc46c00-be5b-11eb-8550-771a0beebbc6.png)


### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
