### PR TITLE
Use curl installer for poetry

### DIFF
--- a/jumpscale/install/Dockerfile
+++ b/jumpscale/install/Dockerfile
@@ -5,7 +5,7 @@ ARG TRC=false
 RUN apt-get update && apt-get install curl wget git python3-pip python3-venv redis-server tmux nginx restic -y
 
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-RUN bash -c 'echo '"'"'PATH="/root/.poetry/bin:${PATH}"'"'"' >> ~/.bashrc'
+RUN bash -c 'echo PATH=/root/.poetry/bin:\${PATH} >> ~/.bashrc'
 ENV PATH=/root/.poetry/bin:$PATH
 RUN mkdir -p /sandbox/code/github/threefoldtech
 

--- a/jumpscale/install/Dockerfile
+++ b/jumpscale/install/Dockerfile
@@ -4,7 +4,9 @@ ARG BRANCH
 ARG TRC=false
 RUN apt-get update && apt-get install curl wget git python3-pip python3-venv redis-server tmux nginx restic -y
 
-RUN pip3 install poetry
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+RUN bash -c 'echo '"'"'PATH="/root/.poetry/bin:${PATH}"'"'"' >> ~/.bashrc'
+ENV PATH=/root/.poetry/bin:$PATH
 RUN mkdir -p /sandbox/code/github/threefoldtech
 
 RUN git clone https://github.com/threefoldtech/js-sdk.git /sandbox/code/github/threefoldtech/js-sdk -b $BRANCH


### PR DESCRIPTION
### Description

The recommended poetry install method is applied.

Poetry adds its bin to path in ~/.profile but it's not loaded when logging in with bash so it's added also to ~/.bashrc. 

### Related Issues

#3081 