### PR TITLE
Fix poetry permissions and path

### DIFF
--- a/jumpscale/install/Dockerfile
+++ b/jumpscale/install/Dockerfile
@@ -5,7 +5,7 @@ ARG TRC=false
 RUN apt-get update && apt-get install curl wget git python3-pip python3-venv redis-server tmux nginx restic -y
 
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-RUN bash -c 'echo PATH=/root/.poetry/bin:\${PATH} >> ~/.bashrc'
+RUN bash -c 'echo "export PATH=/root/.poetry/bin:\${PATH}" >> ~/.bashrc'
 ENV PATH=/root/.poetry/bin:$PATH
 RUN mkdir -p /sandbox/code/github/threefoldtech
 

--- a/jumpscale/install/Dockerfile
+++ b/jumpscale/install/Dockerfile
@@ -5,7 +5,7 @@ ARG TRC=false
 RUN apt-get update && apt-get install curl wget git python3-pip python3-venv redis-server tmux nginx restic -y
 
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-RUN bash -c 'echo "export PATH=/root/.poetry/bin:\${PATH}" >> ~/.bashrc'
+RUN bash -c 'echo "export PATH=\${HOME}/.poetry/bin:\${PATH}" >> ~/.bashrc'
 ENV PATH=/root/.poetry/bin:$PATH
 RUN mkdir -p /sandbox/code/github/threefoldtech
 

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
@@ -9,7 +9,7 @@ chmod -R 500 /etc/ssh
 service ssh restart
 echo $SSHKEY > /root/.ssh/authorized_keys
 
-chmod u+x /root/.poetry/bin/poetry
+chmod u+x $HOME/.poetry/bin/poetry
 
 echo "[*] Switching to the correct version (${SDK_VERSION}) ..."
 cd ${SDK_PATH}

--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/entrypoint.sh
@@ -9,6 +9,8 @@ chmod -R 500 /etc/ssh
 service ssh restart
 echo $SSHKEY > /root/.ssh/authorized_keys
 
+chmod u+x /root/.poetry/bin/poetry
+
 echo "[*] Switching to the correct version (${SDK_VERSION}) ..."
 cd ${SDK_PATH}
 


### PR DESCRIPTION
### Description

Apparently the permissions in the container is discarded in the flist when started.

### Changes

1. add export to poetry path addition in ~/.bashrc
2. chmod its permission.

### Related Issues

#3081 