### PR TITLE
verify Nginx by pid file instead of regex string

### DIFF
--- a/tests/sals/nginx/test_nginx.py
+++ b/tests/sals/nginx/test_nginx.py
@@ -79,10 +79,9 @@ class TestNginxSal(BaseTests):
         self.assertIn("Welcome to 3Bot", request_content(http_link))
         self.info("Cleaning up the config and stoping the server")
         self.nginx_server.stop()
-        self.nginx_conf.clean()
 
         self.info("Checking the server is stopped")
-        self.assertFalse(j.sals.fs.is_file(j.sals.fs.join_paths(self.config_base_dir, NGINX_CONFIG_FILE)))
+        self.assertFalse(j.sals.nettools.wait_http_test(http_link, 5))
         self.assertTrue(wait_connection_lost_test(http_link, 5))
 
     def test02_static_location(self):


### PR DESCRIPTION
### Description
due to an OS limitation (on macOS, and possibly Solaris), checking if Nginx started by matching the full command line started the process with the command line of running processes could fail, or require higher privileges.

this PR introduce a better and faster approach to verify if Nginx started that should work equally well on both Mac and Linux.

check this issue #3116 and this [comment](https://github.com/threefoldtech/js-sdk/issues/3116#issuecomment-848637414) for more context.

### Changes

knowing that The process ID of the Nginx master process is written to the `nginx.pid` file after Nginx started.
- getting the path to the PID file by reading the PID directive in the Nginx configuration file.
- set a check command for `startupcmd`, that checking if the file exists to verify if the Nginx process is running.
- fix Nginx sal test1

### Related Issues

closes #3116 

### Checklist

- [X] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstrings
