### PR TITLE
Use numbers and small letters only for backup name

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Actions.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Actions.vue
@@ -10,7 +10,9 @@
       <template #default v-else-if="title == 'Create'">
         Please enter backup name to confirm.
         <v-text-field v-model="confirmName" dense></v-text-field>
-        <p v-if="disableSubmit" style="color:red">{{errorMsg}}</p>
+        <v-alert dense outlined type="error" v-if="disableSubmit && errorMsg">
+          {{errorMsg}}
+        </v-alert>
       </template>
       <template #actions>
         <v-btn text @click="close">Cancel</v-btn>
@@ -99,8 +101,8 @@ module.exports = {
       }else if (currentBackupsName.includes(backupName)){
         this.errorMsg = "Can't use the same name twice, Please use another name"
         return false
-      }else if (backupName.indexOf(' ') > 0) {
-        this.errorMsg = "Space is not allowed"
+      }else if (backupName.match('^[a-z0-9]*$') == null) {
+        this.errorMsg = "Numbers and small letters only allowed"
         return false
       }else{
         return true


### PR DESCRIPTION
### Description

Describe the changes introduced by this PR and what does it affect

### Changes

- Use numbers and small letters only for backup name
- Use v-alert instead of regular p element

### Related Issues

#3035

### Screenshots
![image](https://user-images.githubusercontent.com/11272864/120188667-ae0ba580-c216-11eb-9e46-9bce7c047338.png)
![image](https://user-images.githubusercontent.com/11272864/120188753-c8de1a00-c216-11eb-9a9b-9e8a0f743c8e.png)


### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
