### PR TITLE
Fix usage of accessnode flag in scheduler

### DIFF
--- a/jumpscale/sals/reservation_chatflow/reservation_chatflow.py
+++ b/jumpscale/sals/reservation_chatflow/reservation_chatflow.py
@@ -1226,7 +1226,7 @@ class ReservationChatflow:
 
         return network_config
 
-    def get_ip_range(self, bot):
+    def get_ip_range(self, bot=None):
         """prompt user to select iprange
 
         Args:
@@ -1235,14 +1235,16 @@ class ReservationChatflow:
         Returns:
             [IPRange]: ip selected by user
         """
-        ip_range_choose = ["Configure IP range myself", "Choose IP range for me"]
-        iprange_user_choice = bot.single_choice(
-            "How would you like to configure the network IP range",
-            ip_range_choose,
-            required=True,
-            default=ip_range_choose[1],
-        )
-        if iprange_user_choice == "Configure IP range myself":
+        iprange_choice = "Choose IP range for me"
+        if bot:
+            ip_range_choose = ["Configure IP range myself", "Choose IP range for me"]
+            iprange_choice = bot.single_choice(
+                "How would you like to configure the network IP range",
+                ip_range_choose,
+                required=True,
+                default=ip_range_choose[1],
+            )
+        if iprange_choice == "Configure IP range myself":
             ip_range = bot.string_ask("Please add private IP Range of the network")
         else:
             first_digit = random.choice([172, 10])


### PR DESCRIPTION
Change bot usage in reservation chatflow sal to be optional in get_ip_range

### Description

- Update usage of accessnode flag in scheduler
- Change bot usage in reservation chatflow sal to be optional in get_ip_range

### Changes

- Pass accessnode flag to be used correctly in scheduler
- get_ip_range now takes bot=None, and is updated to work if no chatbot is passed

### Related Issues



### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
