### PR TITLE
VDC: pre-fetch certificate and install it directly for controller threebot

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/minimal_entrypoint.py
@@ -101,6 +101,9 @@ VDC_VARS = {
     "S3_AK": S3_AK,
     "S3_SK": S3_SK,
     "S3_BUCKET": S3_BUCKET,
+    "CERT": os.environ.get("CERT", ""),
+    "CERT_PRIVATE_KEY": os.environ.get("CERT_PRIVATE_KEY", ""),
+    "CERT_FULLCHAIN": os.environ.get("CERT_FULLCHAIN", ""),
 }
 
 
@@ -174,6 +177,21 @@ if TEST_CERT != "true":
         "/sandbox/code/github/threefoldtech/js-sdk/jumpscale/packages/vdc_dashboard/package.toml"
     )
     package_config["servers"][0]["domain"] = vdc.threebot.domain
+
+    if VDC_VARS.get("CERT"):
+        certs_path = j.sals.fs.join_paths(j.core.dirs.CFGDIR, "certs")
+        cert_path = j.sals.fs.join_paths(certs_path, "cert.pem")
+        key_path = j.sals.fs.join_paths(certs_path, "key.pem")
+        fullchain_path = j.sals.fs.join_paths(certs_path, "fullchain.pem")
+
+        j.sals.fs.makedirs(certs_path)
+        j.sals.fs.write_file(cert_path, VDC_VARS["CERT"])
+        j.sals.fs.write_file(key_path, VDC_VARS["CERT_PRIVATE_KEY"])
+        j.sals.fs.write_file(fullchain_path, VDC_VARS["CERT_FULLCHAIN"])
+
+        package_config["servers"][0]["cert_path"] = cert_path
+        package_config["servers"][0]["key_path"] = key_path
+        package_config["servers"][0]["fullchain_path"] = fullchain_path
     with open("/sandbox/code/github/threefoldtech/js-sdk/jumpscale/packages/vdc_dashboard/package.toml", "w") as f:
         toml.dump(package_config, f)
     if ACME_SERVER_URL:

--- a/jumpscale/packages/vdc/chats/new_vdc.py
+++ b/jumpscale/packages/vdc/chats/new_vdc.py
@@ -382,8 +382,7 @@ class VDCDeploy(GedisChatBot):
         open("/tmp/times", "a").write(f"TIMESTAMP: end_wallet_init {datetime.datetime.now()}\n")
 
         open("/tmp/times", "a").write(f"TIMESTAMP: start_domain_check {datetime.datetime.now()}\n")
-        prefix = self.deployer.get_prefix()
-        subdomain = f"{prefix}.{VDC_PARENT_DOMAIN}"
+        subdomain = self.deployer.threebot.get_subdomain()
         j.logger.info(f"checking the availability of subdomain {subdomain}")
         if self.deployer.proxy.check_domain_availability(subdomain):
             j.logger.info(f"subdomain {subdomain} is resolvable. checking owner info")

--- a/jumpscale/sals/nginx/nginx.py
+++ b/jumpscale/sals/nginx/nginx.py
@@ -177,7 +177,7 @@ class Certbot(Base):
     def install_cmd(self):
         # replace "certbot" with "certbot install"
         cmd = self.run_cmd
-        cmd[0] = f"{DEFAULT_NAME} install"
+        cmd[0] += " install"
         return cmd
 
 

--- a/jumpscale/sals/nginx/nginx.py
+++ b/jumpscale/sals/nginx/nginx.py
@@ -177,7 +177,7 @@ class Certbot(Base):
     def install_cmd(self):
         # replace "certbot" with "certbot install"
         name = self.DEFAULT_NAME
-        return f"{name} install" + super().run_cmd[len(name) :]
+        return f"{name} install" + self.run_cmd[len(name) :]
 
 
 class NginxCertbot(Certbot):

--- a/jumpscale/sals/nginx/nginx.py
+++ b/jumpscale/sals/nginx/nginx.py
@@ -177,7 +177,7 @@ class Certbot(Base):
     def install_cmd(self):
         # replace "certbot" with "certbot install"
         cmd = self.run_cmd
-        cmd[0] += " install"
+        cmd.insert(1, "install")
         return cmd
 
 

--- a/jumpscale/sals/nginx/nginx.py
+++ b/jumpscale/sals/nginx/nginx.py
@@ -176,8 +176,9 @@ class Certbot(Base):
     @property
     def install_cmd(self):
         # replace "certbot" with "certbot install"
-        name = self.DEFAULT_NAME
-        return f"{name} install" + self.run_cmd[len(name) :]
+        cmd = self.run_cmd
+        cmd[0] = f"{DEFAULT_NAME} install"
+        return cmd
 
 
 class NginxCertbot(Certbot):

--- a/jumpscale/sals/vdc/deployer.py
+++ b/jumpscale/sals/vdc/deployer.py
@@ -677,9 +677,12 @@ class VDCDeployer:
             # deploy threebot container
             self.bot_show_update("Deploying 3Bot container")
             gevent.joinall([cert_greenlet])
-            cert = None
             if cert_greenlet.value:
                 cert = cert_greenlet.value
+                j.logger.info("certificate was prefetched successfully")
+            else:
+                cert = None
+                j.logger.warning("couldn't prefetch certificate")
 
             threebot_wid = self.threebot.deploy_threebot(
                 minio_wid,

--- a/jumpscale/sals/vdc/threebot.py
+++ b/jumpscale/sals/vdc/threebot.py
@@ -3,7 +3,7 @@ import uuid
 
 import requests
 
-from jumpscale.core.base import Base
+from jumpscale.core.base import Base, fields
 from jumpscale.loader import j
 from jumpscale.sals.reservation_chatflow import deployer
 from jumpscale.sals.reservation_chatflow.deployer import DeploymentFailed

--- a/jumpscale/sals/vdc/threebot.py
+++ b/jumpscale/sals/vdc/threebot.py
@@ -67,7 +67,8 @@ class VDCThreebotDeployer(VDCBaseComponent):
         return self._branch
 
     def prefetch_cert(self):
-        prefix = self.vdc_deployer.get_prefix()
+        # FIXME: why it should have a .vdc in the first place?
+        prefix = j.data.text.removesuffix(self.vdc_deployer.get_prefix(), ".vdc")
         parent_domain = VDC_PARENT_DOMAIN
         subdomain = f"{prefix}.{parent_domain}"
 

--- a/jumpscale/sals/vdc/threebot.py
+++ b/jumpscale/sals/vdc/threebot.py
@@ -68,9 +68,11 @@ class VDCThreebotDeployer(VDCBaseComponent):
 
     def prefetch_cert(self):
         # FIXME: why it should have a .vdc in the first place?
+        # FIXME: just using .devnet for now for testing
+        #        need to know how we can the correct domain from start
         prefix = j.data.text.removesuffix(self.vdc_deployer.get_prefix(), ".vdc")
         parent_domain = VDC_PARENT_DOMAIN
-        subdomain = f"{prefix}.{parent_domain}"
+        subdomain = f"{prefix}.devnet.{parent_domain}"
 
         url = f"{self.acme_server_url}/api/prefetch"
         domains = [subdomain]

--- a/jumpscale/sals/vdc/threebot.py
+++ b/jumpscale/sals/vdc/threebot.py
@@ -1,23 +1,29 @@
+import random
+import uuid
+
+import requests
+
+from jumpscale.core.base import Base
+from jumpscale.loader import j
+from jumpscale.sals.reservation_chatflow import deployer
 from jumpscale.sals.reservation_chatflow.deployer import DeploymentFailed
+
 from .base_component import VDCBaseComponent
+from .namemanager import NameManager
+from .proxy import VDC_PARENT_DOMAIN
+from .scheduler import Scheduler
 from .size import (
-    THREEBOT_CPU,
-    THREEBOT_MEMORY,
-    THREEBOT_DISK,
-    VDC_SIZE,
+    COMPUTE_FARMS,
+    NETWORK_FARMS,
     S3_AUTO_TOPUP_FARMS,
     S3_NO_DATA_NODES,
     S3_NO_PARITY_NODES,
-    NETWORK_FARMS,
-    COMPUTE_FARMS,
+    THREEBOT_CPU,
+    THREEBOT_DISK,
+    THREEBOT_MEMORY,
+    VDC_SIZE,
 )
-from jumpscale.loader import j
-from .scheduler import Scheduler
-from jumpscale.sals.reservation_chatflow import deployer
-from .proxy import VDC_PARENT_DOMAIN
-from .namemanager import NameManager
-import uuid
-import random
+
 
 THREEBOT_FLIST = "https://hub.grid.tf/ahmed_hanafy_1/ahmedhanafy725-js-sdk-latest.flist"
 THREEBOT_TRC_FLIST = "https://hub.grid.tf/ahmed_hanafy_1/ahmedhanafy725-js-sdk-latest_trc.flist"
@@ -29,10 +35,19 @@ JS-NG> s3_config = {"S3_URL": "https://s3.grid.tf", "S3_BUCKET": "vdc-devnet", "
 JS-NG> """
 
 
+class ThreebotCertificate(Base):
+    private_key = fields.String()
+    cert = fields.String()
+    fullchain = fields.String()
+    csr = fields.String()
+
+
 class VDCThreebotDeployer(VDCBaseComponent):
     def __init__(self, *args, **kwargs):
         self._branch = None
         super().__init__(*args, **kwargs)
+        self.acme_server_url = j.core.config.get("VDC_ACME_SERVER_URL", "https://ca1.grid.tf")
+        self.acme_server_api_key = j.core.config.get("VDC_ACME_SERVER_API_KEY", "")
 
     @property
     def branch(self):
@@ -51,8 +66,19 @@ class VDCThreebotDeployer(VDCBaseComponent):
                 self._branch = "development"
         return self._branch
 
+    def prefetch_cert(self):
+        prefix = self.vdc_deployer.get_prefix()
+        parent_domain = VDC_PARENT_DOMAIN
+        subdomain = f"{prefix}.{parent_domain}"
+
+        url = f"{self.acme_server_url}/api/prefetch"
+        domains = [subdomain]
+        resp = requests.post(url, json={"domains": domains}, headers={"X-API-KEY": self.acme_server_api_key})
+        resp.raise_for_status()
+        return ThreebotCertificate.from_dict(resp.json())
+
     def deploy_threebot(
-        self, minio_wid, pool_id, kube_config, embed_trc=True, backup_config=None, zdb_farms=None,
+        self, minio_wid, pool_id, kube_config, embed_trc=True, backup_config=None, zdb_farms=None, cert=None
     ):
         backup_config = backup_config or {}
         etcd_backup_config = j.core.config.get("VDC_S3_CONFIG", {})
@@ -80,6 +106,12 @@ class VDCThreebotDeployer(VDCBaseComponent):
             "S3_AK": etcd_backup_config.get("S3_AK", ""),
             "S3_SK": etcd_backup_config.get("S3_SK", ""),
         }
+
+        if cert:
+            secret_env["CERT"] = cert.cert
+            secret_env["CERT_PRIVATE_KEY"] = cert.private_key
+            secret_env["CERT_FULLCHAIN"] = cert.fullchain
+
         env = {
             "VDC_NAME": self.vdc_name,
             "MONITORING_SERVER_URL": j.config.get("MONITORING_SERVER_URL", ""),
@@ -99,7 +131,7 @@ class VDCThreebotDeployer(VDCBaseComponent):
             "SSHKEY": self.vdc_deployer.ssh_key.public_key.strip(),
             "MINIMAL": "true",
             "TEST_CERT": "true" if j.core.config.get("TEST_CERT") else "false",
-            "ACME_SERVER_URL": j.core.config.get("VDC_ACME_SERVER_URL", "https://ca1.grid.tf"),
+            "ACME_SERVER_URL": self.acme_server_url,
         }
         if embed_trc:
             _, secret, remote = self._prepare_proxy()

--- a/jumpscale/sals/vdc/threebot.py
+++ b/jumpscale/sals/vdc/threebot.py
@@ -72,7 +72,7 @@ class VDCThreebotDeployer(VDCBaseComponent):
         #        need to know how we can the correct domain from start
         prefix = j.data.text.removesuffix(self.vdc_deployer.get_prefix(), ".vdc")
         parent_domain = VDC_PARENT_DOMAIN
-        subdomain = f"{prefix}.devnet.{parent_domain}"
+        subdomain = f"{prefix}.vdcdev.{parent_domain}"
 
         url = f"{self.acme_server_url}/api/prefetch"
         domains = [subdomain]

--- a/jumpscale/servers/threebot/threebot.py
+++ b/jumpscale/servers/threebot/threebot.py
@@ -164,6 +164,12 @@ class NginxPackageConfig:
                     "acme_server_type", self.default_config[0].get("acme_server_type")
                 )
                 website.acme_server_url = server.get("acme_server_url", self.default_config[0].get("acme_server_url"))
+                if server.get("key_path"):
+                    website.key_path = server["key_path"]
+                if server.get("cert_path"):
+                    website.cert_path = server["cert_path"]
+                if server.get("fullchain_path"):
+                    website.fullchain_path = server["fullchain_path"]
 
                 for location in server.get("locations", []):
                     loc = None


### PR DESCRIPTION
### Description

Use the new pre-fetching API of our CA server and update certbot to accept existing cert.

### Changes

* Update custom certbot to accept `key_path`, `cert_path` and `fullchain_path`
* Update package config to accept these path argument
* Update VDC deployer to pre-fetch the certificate and pass it to theebot being deployed
* Update `minimal_entrypoint.py` to write these key/certificates and update `vdc_dashboard` config with it.

### Related Issues

https://github.com/threefoldtech/home/issues/1068

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
