### PR TITLE
Fixing the node resources calculation.

### DIFF
--- a/jumpscale/sals/vdc/kubernetes_auto_extend.py
+++ b/jumpscale/sals/vdc/kubernetes_auto_extend.py
@@ -124,10 +124,10 @@ class KubernetesMonitor:
         nodes_allocated_requests = []
         for node_info in nodes_list:
             allocated_requests = {}
-            allocated_requests["node_name"] = re.match(r"Name:\s*([^\n\r]*)", node_info).group(1)
+            allocated_requests["node_name"] = re.search(r"Name:\s*([^\n\r]*)", node_info).group(1)
             allocated_resources = re.search(r"(?<=Allocated resources:)[\s\S]*(?=Event)", node_info).group()
-            allocated_requests["cpu"] = int(re.match(r"cpu\s*([^\n\r]\d*)", allocated_resources).group(1))
-            allocated_requests["memory"] = int(re.match(r"memory\s*([^\n\r]\d*)", allocated_resources).group(1))
+            allocated_requests["cpu"] = int(re.search(r"cpu\s*([^\n\r]\d*)", allocated_resources).group(1))
+            allocated_requests["memory"] = int(re.search(r"memory\s*([^\n\r]\d*)", allocated_resources).group(1))
             nodes_allocated_requests.append(allocated_requests)
         return nodes_allocated_requests
 


### PR DESCRIPTION
Co-authored-by: Mohammed Essam <mohammedelborolossy@gmail.com>

### Description

fixing few methods in KubernetesMonitor class that responsible for calculating the **total, reserved, and free** resources on the VDC cluster.

### Changes

**before** (incorrect calcs) js-sdk 011bea80b0603dd2ca106fefa6832fa54658757c
![Screenshot from 2021-06-17 11-43-05](https://user-images.githubusercontent.com/42457449/122373392-b9bed200-cf61-11eb-85c1-923bcaf61b27.png)

**after - this branch**
![Screenshot from 2021-06-17 11-30-43](https://user-images.githubusercontent.com/42457449/122374113-626d3180-cf62-11eb-9d3d-8f72fe45e144.png)

### Related Issues

closes #3179
also related to #3180 

### Checklist

- [X] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstrings
