### PR TITLE
Update Traefik service now working

### DIFF
--- a/jumpscale/packages/tfgrid_solutions/scripts/threebot/velero.py
+++ b/jumpscale/packages/tfgrid_solutions/scripts/threebot/velero.py
@@ -20,8 +20,7 @@ if all([ak, sk, url, region]):
     aws_secret_access_key={sk}
     """,
     )
-    mon = vdc.get_zdb_monitor()
-    password = mon.get_password()
+    password = vdc.get_password()
     password_hash = hashlib.md5(password.encode()).hexdigest()
     j.sals.process.execute(
         f"/sbin/velero install --provider aws --use-restic --plugins magedmotawea/velero-plugin-for-aws-amd64:main --bucket {bucket} --secret-file /root/credentials --backup-location-config region={region},s3ForcePathStyle=true,s3Url={url},encryptionSecret={password_hash} --prefix {vdc.owner_tname}/{vdc.vdc_name}",

--- a/jumpscale/packages/vdc_dashboard/services/upgrade_traefik.py
+++ b/jumpscale/packages/vdc_dashboard/services/upgrade_traefik.py
@@ -13,7 +13,7 @@ class UpgradeTraefik(BackgroundService):
         current_ver = self.get_traefik_version()
         if current_ver != UPGRADE_TO_VER:
             j.logger.info(f"Upgrade Traefik Service:: Updating traefik from {current_ver} to {UPGRADE_TO_VER}")
-            vdc_instance = j.sals.vdc.find(list(j.sals.vdc.list_all())[0], load_info=True)
+            vdc_instance = j.sals.vdc.find(list(j.sals.vdc.list_all())[0])
             vdc_instance.get_deployer().kubernetes.upgrade_traefik(version=UPGRADE_TO_VER)
         else:
             j.logger.info(f"Upgrade Traefik Service:: Traefik using latest version {current_ver}")

--- a/jumpscale/packages/vdc_dashboard/services/upgrade_traefik.py
+++ b/jumpscale/packages/vdc_dashboard/services/upgrade_traefik.py
@@ -27,7 +27,7 @@ class UpgradeTraefik(BackgroundService):
     def get_traefik_version(self):
         current_ver = j.core.db.get("traefik:version:current")
         if not current_ver:
-            _, out, _ = j.sals.kubernetes.Manager()._excute("helm list -A -o json")
+            _, out, _ = j.sals.kubernetes.Manager()._execute("helm list -A -o json")
             results = j.data.serializers.json.loads(out)
             for release in results:
                 if release["name"] == "traefik":

--- a/jumpscale/packages/vdc_dashboard/services/upgrade_traefik.py
+++ b/jumpscale/packages/vdc_dashboard/services/upgrade_traefik.py
@@ -2,43 +2,28 @@ from jumpscale.loader import j
 
 from jumpscale.tools.servicemanager.servicemanager import BackgroundService
 
+UPGRADE_TO_VER = "2.4.8"
+
 
 class UpgradeTraefik(BackgroundService):
     def __init__(self, interval=5 * 60, *args, **kwargs):
         super().__init__(interval, *args, **kwargs)
 
     def job(self):
-        j.logger.info("Starting upgrade traefik service")
         current_ver = self.get_traefik_version()
-        upgrade_to_ver = j.core.db.get("traefik:version:latest")
-        if not upgrade_to_ver:
-            upgrade_to_ver = "2.4.8"
-            j.core.db.set("traefik:version:latest", upgrade_to_ver)
-        else:
-            upgrade_to_ver = upgrade_to_ver.decode("utf-8")
-
-        if current_ver != upgrade_to_ver:
-            j.logger.info(f"Upgrade Traefik Service:: Updating traefik from {current_ver} to {upgrade_to_ver}")
+        if current_ver != UPGRADE_TO_VER:
+            j.logger.info(f"Upgrade Traefik Service:: Updating traefik from {current_ver} to {UPGRADE_TO_VER}")
             vdc_instance = j.sals.vdc.find(list(j.sals.vdc.list_all())[0], load_info=True)
-            vdc_instance.get_deployer().kubernetes.upgrade_traefik(version=upgrade_to_ver)
+            vdc_instance.get_deployer().kubernetes.upgrade_traefik(version=UPGRADE_TO_VER)
         else:
             j.logger.info(f"Upgrade Traefik Service:: Traefik using latest version {current_ver}")
 
     def get_traefik_version(self):
-        current_ver = j.core.db.get("traefik:version:current")
-        if not current_ver:
-            _, out, _ = j.sals.kubernetes.Manager()._execute("helm list -A -o json")
-            results = j.data.serializers.json.loads(out)
-            for release in results:
-                if release["name"] == "traefik":
-                    current_ver = release["app_version"]
-                    j.core.db.set("traefik:version:current", current_ver)
-                else:
-                    continue
-        else:
-            current_ver = current_ver.decode("utf-8")
-
-        return current_ver
+        _, out, _ = j.sals.kubernetes.Manager()._execute("helm list -A -o json")
+        results = j.data.serializers.json.loads(out)
+        for release in results:
+            if release["name"] == "traefik":
+                return release["app_version"]
 
 
 service = UpgradeTraefik()

--- a/jumpscale/tools/servicemanager/servicemanager.py
+++ b/jumpscale/tools/servicemanager/servicemanager.py
@@ -125,7 +125,7 @@ class ServiceManager(Base):
         """
         message = f"Service {greenlet.service.name} raised an exception: {greenlet.exception}"
         j.tools.alerthandler.alert_raise(app_name="servicemanager", message=message, alert_type="exception")
-        j.logger.exception(message)
+        j.logger.exception(f"Service {greenlet.service.name} raised an exception", exception=greenlet.exception)
 
     def __callback(self, greenlet):
         """Callback runs after greenlet finishes execution

--- a/jumpscale/tools/servicemanager/servicemanager.py
+++ b/jumpscale/tools/servicemanager/servicemanager.py
@@ -125,6 +125,7 @@ class ServiceManager(Base):
         """
         message = f"Service {greenlet.service.name} raised an exception: {greenlet.exception}"
         j.tools.alerthandler.alert_raise(app_name="servicemanager", message=message, alert_type="exception")
+        j.logger.exception(message)
 
     def __callback(self, greenlet):
         """Callback runs after greenlet finishes execution


### PR DESCRIPTION
### Description

Use different way to get version of the current traefik release, fix some typos

### Changes
- Get the version of the current Traefik release correctly
- Add logs for the exceptions to the running services in the service manager.
- Get password from vdc directly instead of zdb monitor in velero service.

### Related Issues

#3190, #3195

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
