### PR TITLE
minor fix to reporting the allocated resources

### DIFF
--- a/jumpscale/sals/vdc/kubernetes_auto_extend.py
+++ b/jumpscale/sals/vdc/kubernetes_auto_extend.py
@@ -268,5 +268,7 @@ class KubernetesMonitor:
         return True
 
     def _parse_memory_in_Mi(self, memory):
+        if memory == '0':  # For handling very rare cases
+            return 0
         mem_value, mem_unit = int(memory[:-2]), memory[-2:]
         return self._memory_unit_to_Mi[mem_unit](mem_value)

--- a/jumpscale/sals/vdc/kubernetes_auto_extend.py
+++ b/jumpscale/sals/vdc/kubernetes_auto_extend.py
@@ -268,7 +268,7 @@ class KubernetesMonitor:
         return True
 
     def _parse_memory_in_Mi(self, memory):
-        if memory == '0':  # For handling very rare cases
+        if memory == "0":
             return 0
         mem_value, mem_unit = int(memory[:-2]), memory[-2:]
         return self._memory_unit_to_Mi[mem_unit](mem_value)


### PR DESCRIPTION
Co-authored-by: Mohammed Essam <mohammedelborolossy@gmail.com>

### Description

enhance parsing `kubectl` output to handle a very rare case (but valid) when the node allocated memory requests is '0'.

### Checklist

- [X] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstrings
