### PR TITLE
Improving the deployed solutions listing performance

### DIFF
--- a/jumpscale/packages/vdc_dashboard/bottle/api/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/api/deployments.py
@@ -20,10 +20,7 @@ from jumpscale.packages.vdc_dashboard.bottle.vdc_helpers import (
     check_plan_autoscalable,
     get_wallet_info,
 )
-from jumpscale.packages.vdc_dashboard.sals.vdc_dashboard_sals import (
-    get_all_deployments,
-    get_deployments,
-)
+from jumpscale.packages.vdc_dashboard.sals.vdc_dashboard_sals import get_deployments, get_all_vdc_deployments
 
 from .root import app
 
@@ -175,10 +172,11 @@ def list_deployments(solution_type: str) -> str:
 @package_authorized("vdc_dashboard")
 def list_all_deployments() -> str:
     deployments = []
+    vdc = get_vdc()
     data = j.data.serializers.json.loads(request.body.read())
     solution_types = data.get("solution_types")
     try:
-        deployments = get_all_deployments(solution_types)
+        deployments = get_all_vdc_deployments(vdc.vdc_name, solution_types=solution_types)
     except Exception as e:
         j.logger.exception(message=str(e), exception=e)
 

--- a/jumpscale/packages/vdc_dashboard/sals/vdc_dashboard_sals.py
+++ b/jumpscale/packages/vdc_dashboard/sals/vdc_dashboard_sals.py
@@ -117,7 +117,7 @@ def get_deployments(solution_type: str = None, username: str = None) -> list:
     return all_deployments
 
 
-def get_all_vdc_deployments(vdc_name):
+def get_all_vdc_deployments(vdc_name, solution_types=None):
     all_deployments = []
     config_path = j.sals.fs.expanduser("~/.kube/config")
     k8s_client = j.sals.kubernetes.Manager(config_path=config_path)
@@ -136,6 +136,8 @@ def get_all_vdc_deployments(vdc_name):
 
         namespace = deployment_info["metadata"].get("namespace", "default")
         solution_type = deployment_info["metadata"]["labels"]["app.kubernetes.io/name"]
+        if solution_types and solution_type not in solution_types:
+            continue
         deployment_info = _filter_data(deployment_info)
         release_name = deployment_info["Release"]
         helm_chart_supplied_values = "{}"


### PR DESCRIPTION
### Description

Improving the deployed solutions listing performance by ~17X 

**before:**

![Screenshot from 2021-06-21 02-58-21](https://user-images.githubusercontent.com/42457449/122694084-91262900-d23c-11eb-817d-af4d9d597b54.png)

**after:**

![Screenshot from 2021-06-21 02-57-32](https://user-images.githubusercontent.com/42457449/122694054-7b186880-d23c-11eb-9c29-0f090780204e.png)

### Changes

- modifying get_all_vdc_deployments() from VDC dashboard sal and using it instead of get_all_deployments().
- adding an optional parameter get_all_vdc_deployments() to filter the solutions with a list of solution types.
- remove the blocking call.

### Related Issues

#3069

### Checklist

- [X] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstrings
