### PR TITLE
Use different chatUID for chatflows with query params

### DIFF
--- a/jumpscale/packages/chatflows/frontend/App.vue
+++ b/jumpscale/packages/chatflows/frontend/App.vue
@@ -104,7 +104,15 @@
         return window.self === window.top
       },
       chatUID () {
-        return `${this.package}_${this.chat}`
+        let uid = `${this.package}_${this.chat}`
+        const query = this.$route.query || {}
+        let keys = Object.keys(query)
+        keys.sort()
+        keys.forEach((key) => {
+          uid += `${key}_${query[key]}`
+        })
+
+        return MD5(uid)
       },
       nextButtonDisable () {
         return ['error', 'loading', 'infinite_loading'].includes(this.work.payload.category)

--- a/jumpscale/packages/chatflows/frontend/index.html
+++ b/jumpscale/packages/chatflows/frontend/index.html
@@ -18,6 +18,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.js"></script>
     <script src='https://api.mapbox.com/mapbox-gl-js/v1.10.0/mapbox-gl.js'></script>
+    <script src="https://www.unpkg.com/md5@2.3.0/dist/md5.min.js"></script>
     <script type="text/javascript">
 
       Vue.use(Vuex)


### PR DESCRIPTION
### Description

If there is a chatflow (example: extend pools) that takes query params `pool_id` to be extended and this chat is opened with a different `pool_id`, it will open the same chatflow as both depend only on the chat name.
This should solve the problem by taking the query params into consideration and get different sessions for the difference in query params.