### PR TITLE
add option for services to immediate schedule upon addition

### DIFF
--- a/jumpscale/tools/servicemanager/servicemanager.py
+++ b/jumpscale/tools/servicemanager/servicemanager.py
@@ -57,6 +57,7 @@ class BackgroundService(ABC):
             interval (int | CronTab object | str): scheduled job is executed every interval in seconds / CronTab object / CronTab-formatted string
         """
         self.interval = interval
+        self.schedule_on_start = False
 
     @abstractmethod
     def job(self):
@@ -183,7 +184,7 @@ class ServiceManager(Base):
             j.logger.debug(f"Service {service.name} is already running. Reloading...")
             self.stop_service(service.name)
 
-        next_start = ceil(self.seconds_to_next_interval(service.interval))
+        next_start = 0 if service.schedule_on_start else ceil(self.seconds_to_next_interval(service.interval))
         self._scheduled[service.name] = gevent.spawn_later(next_start, self._schedule_service, service=service)
         self.services[service.name] = service
         j.logger.debug(f"Service {service.name} is added.")


### PR DESCRIPTION
### Description

add option for services to immediate schedule upon addition

### Usage

- Add `self.schedule_on_start = True` on your service and you are good to go

![Screenshot from 2021-06-22 13-57-30](https://user-images.githubusercontent.com/10658229/122920570-d42dec80-d361-11eb-9db6-e43becbf5dba.png)


### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
