### PR TITLE
Use Number instead of String for wid in redeploy master frontend

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/RedeployMaster.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/RedeployMaster.vue
@@ -16,7 +16,7 @@
 <script>
 module.exports = {
   mixins: [dialog],
-  props: { wid: { type: String, default: "" } },
+  props: { wid: Number },
   methods: {
     submit() {
       this.loading = true;


### PR DESCRIPTION
### Description

Use Number instead of String for wid in redeploy master prop

### Related Issues

#3209 

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstrings
