### PR TITLE
Update reachability check in 3bot deployer listing to not use gevent

### DIFF
--- a/jumpscale/packages/threebot_deployer/bottle/utils.py
+++ b/jumpscale/packages/threebot_deployer/bottle/utils.py
@@ -126,7 +126,9 @@ def list_threebot_solutions(owner):
             return
 
         domain = f"https://{zos.workloads.get(threebot.subdomain_wid).domain}/admin"
-        reachable = j.sals.reservation_chatflow.wait_http_test(domain, timeout=10, verify=not j.config.get("TEST_CERT"))
+        reachable = j.sals.reservation_chatflow.check_url_reachable(
+            domain, timeout=10, verify=not j.config.get("TEST_CERT")
+        )
         if (
             threebot.state in [ThreebotState.RUNNING, ThreebotState.ERROR, ThreebotState.STOPPED]
             and compute_pool.empty_at == 9223372036854775807


### PR DESCRIPTION
### Description

Listing 3bots deployed take time, loading needs to be quicker

### Changes

Changed check for reaching 3bot to `j.sals.reservation_chatflow.check_url_reachable(...)` to not use gevent which waits on failure of reaching so waits for timeout.

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/3228

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
