### PR TITLE
Runs the js-sdk image build workflow only if Dockerfile changed

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -3,6 +3,7 @@ name: Build docker image
 on:
   push:
     branches: [ development ]
+    paths: [ jumpscale/install/Dockerfile ]
 jobs:
     build-docker:
         runs-on: ubuntu-latest

--- a/.github/workflows/build_image_with_trc.yml
+++ b/.github/workflows/build_image_with_trc.yml
@@ -3,6 +3,7 @@ name: js-sdk with trc
 on:
   push:
     branches: [ development ]
+    paths: [ jumpscale/install/Dockerfile ]
 jobs:
     build-docker:
         runs-on: ubuntu-latest

--- a/.github/workflows/build_vdc_image.yml
+++ b/.github/workflows/build_vdc_image.yml
@@ -3,6 +3,7 @@ name: js-sdk with trc and vdc dependencies
 on:
   push:
     branches: [ development ]
+    paths: [ jumpscale/install/Dockerfile ]
 jobs:
     build-docker:
         runs-on: ubuntu-latest

--- a/.github/workflows/build_vdc_image.yml
+++ b/.github/workflows/build_vdc_image.yml
@@ -3,7 +3,7 @@ name: js-sdk with trc and vdc dependencies
 on:
   push:
     branches: [ development ]
-    paths: [ jumpscale/install/Dockerfile ]
+    paths: [ jumpscale/install/Dockerfile.vdc ]
 jobs:
     build-docker:
         runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

Runs the js-sdk image build workflows only if Dockerfile changed

### Changes

these workflows will run only if Dockerfile change instead of running on every push to development:
- .github/workflows/build_image_with_trc.yml
- .github/workflows/build_image.yml
- .github/workflows/build_vdc_image.yml

### Related Issues

List of related issues

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
