### PR TITLE
Add refund for failed pool extensions in threebot deployer

### DIFF
--- a/jumpscale/packages/threebot_deployer/chats/change_location.py
+++ b/jumpscale/packages/threebot_deployer/chats/change_location.py
@@ -30,7 +30,7 @@ class ThreebotRedeploy(MarketPlaceAppsChatflow):
         "deploy",
         "initializing",
         "new_expiration",
-        "solution_extension",
+        "extension_with_billing_package",
         "success",
     ]
 

--- a/jumpscale/packages/threebot_deployer/chats/change_size.py
+++ b/jumpscale/packages/threebot_deployer/chats/change_size.py
@@ -30,7 +30,7 @@ class ThreebotRedeploy(MarketPlaceAppsChatflow):
         "deploy",
         "initializing",
         "new_expiration",
-        "solution_extension",
+        "extension_with_billing_package",
         "success",
     ]
 

--- a/jumpscale/packages/threebot_deployer/chats/restart_threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/restart_threebot.py
@@ -21,7 +21,7 @@ class ThreebotRedeploy(MarketPlaceAppsChatflow):
         "choose_name",
         "enter_password",
         "new_expiration",
-        "solution_extension",
+        "extension_with_billing_package",
         "deploy",
         "initializing",
         "success",

--- a/jumpscale/packages/threebot_deployer/chats/threebot.py
+++ b/jumpscale/packages/threebot_deployer/chats/threebot.py
@@ -46,7 +46,7 @@ class ThreebotDeploy(MarketPlaceAppsChatflow):
         "reservation",
         "initializing",
         "new_expiration",
-        "solution_extension",
+        "extension_with_billing_package",
         "wireguard_configs",
         "success",
     ]


### PR DESCRIPTION
### Description

When 3bot deployment fails, the user will lose the money sent to the explorer directly

### Changes

Add refund using billing package to use intermediate wallet that will be responsible to refund the user in case the pool extension failed

### Related Issues

https://github.com/threefoldtech/js-sdk/issues/3170

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstrings
