### PR TITLE
fix VM multiple public ips reservation

### DIFF
--- a/jumpscale/sals/reservation_chatflow/deployer.py
+++ b/jumpscale/sals/reservation_chatflow/deployer.py
@@ -1260,15 +1260,14 @@ As an example, if you want to be able to run some workloads that consumes `5CU` 
         identity_name = metadata.get("owner", j.core.identity.me.instance_name)
         public_ip_wid = 0
         public_ip = ""
+        # Reserve public_Ip on node_id[0]
         if enable_public_ip:
-            # Reserve public_Ip on node_id[0]
-            if enable_public_ip:
-                public_ip_wid, public_ip = self.create_public_ip(
-                    pool_id, node_id, solution_uuid=metadata.get("solution_uuid")
-                )
-                if not public_ip_wid or not public_ip:
-                    raise DeploymentFailed(f"Can not get public ip for your solutions")
-                public_ip = public_ip.split("/")[0] if public_ip else ""
+            public_ip_wid, public_ip = self.create_public_ip(
+                pool_id, node_id, solution_uuid=metadata.get("solution_uuid")
+            )
+            if not public_ip_wid or not public_ip:
+                raise DeploymentFailed(f"Can not get public ip for your solutions")
+            public_ip = public_ip.split("/")[0] if public_ip else ""
         vmachine = j.sals.zos.get(identity_name).vm.create(
             node_id, network_name, name, ip_address, ssh_keys, pool_id, size, public_ip_wid
         )

--- a/jumpscale/sals/vdc/vmachine.py
+++ b/jumpscale/sals/vdc/vmachine.py
@@ -166,16 +166,6 @@ class VirtualMachineDeployer(VDCBaseComponent):
                 self.vdc_deployer.error("All attempts to deploy virtual machine on nodes node have been failed")
                 raise j.exceptions.Runtime("All attempts to deploy virtual machine on nodes node have been failed")
 
-            # reserve public_ip
-            if enable_public_ip:
-                public_ip_wid = self.vdc_deployer.public_ip.get_public_ip(
-                    pool_id, vmachine_node.node_id, solution_uuid=solution_uuid
-                )
-
-                if not public_ip_wid:
-                    self.vdc_deployer.error(f"Failed to reserve public ip on node {vmachine_node.node_id}")
-                    continue
-
             network_view = network_view.copy()
             private_ip_address = network_view.get_free_ip(vmachine_node)
 

--- a/jumpscale/sals/vdc/vmachine.py
+++ b/jumpscale/sals/vdc/vmachine.py
@@ -193,7 +193,7 @@ class VirtualMachineDeployer(VDCBaseComponent):
                 return {"public_ip": public_ip, "ip_address": private_ip_address, "vm_wid": wid}
             except DeploymentFailed:
                 if enable_public_ip:
-                    self.zos.workloads.decomission(public_ip_wid)
+                    self.zos.workloads.decomission(self.zos.workloads.get(wid).public_ip)
                 self.vdc_deployer.error(f"Failed to deploy virtual machine wid: {wid}")
                 continue
         self.vdc_deployer.error(f"All attempts to deploy virtual machine have failed")


### PR DESCRIPTION
### Description

there was a bug in the create VM that lead to reserve more than one public IP for the VM,  issue #3239 
this PR should fix the issue above.

### Changes

- remove the `get_public_ip` call in `VirtualMachineDeployer`, as we already call `create_public_ip` from another part of the code.

### Related Issues

- closes #3239

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstrings
