### PR TITLE
removing the push notifications and the alerts related to system-backup service 

### DIFF
--- a/jumpscale/packages/backup/services/system_backup.py
+++ b/jumpscale/packages/backup/services/system_backup.py
@@ -59,33 +59,14 @@ class SystemBackupService(BackgroundService):
             j.logger.warning(
                 f"[Backup Package - System Backup Service] couldn't get instance of BackupJob with name {self.BACKUP_JOB_NAME}!"
             )
-            j.tools.notificationsqueue.push(
-                f"couldn't get instance of BackupJob with name {self.BACKUP_JOB_NAME}!",
-                category="SystemBackupService",
-                level=LEVEL.WARNING,
-            )
 
             if not SystemBackupService._create_system_backup_job():
                 j.logger.error(
                     f"[Backup Package - System Backup Service] There is no preconfigure restic repo/s. Backup job won't executed!"
                 )
-                j.tools.notificationsqueue.push(
-                    f"There is no preconfigure restic repo/s. Backup job won't executed!",
-                    category="SystemBackupService",
-                    level=LEVEL.ERROR,
-                )
-                j.tools.alerthandler.alert_raise(
-                    app_name="SystemBackupJob",
-                    category="exception",
-                    message="There is no preconfigure restic repo/s. System Backup job won't executed!",
-                    alert_type="exception",
-                )
                 return
             j.logger.info(
                 f"[Backup Package - System Backup Service] {self.BACKUP_JOB_NAME} job successfully created\npaths to backup: {self.BACKUP_JOB_PATHS}\npaths excluded: {self.PATHS_TO_EXCLUDE}."
-            )
-            j.tools.notificationsqueue.push(
-                f"System backup job job successfully created!", category="SystemBackupService", level=LEVEL.INFO
             )
 
         backupjob = j.sals.backupjob.get(self.BACKUP_JOB_NAME)


### PR DESCRIPTION
### Description

removing the push notifications and the alerts that related to system-backup service not configured,

### Changes

now the UI will show the related alerts and notifications only when the service is configured in the system.

### Related Issues

https://github.com/threefoldtech/tf_support/issues/6

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
