### PR TITLE
fixing err "uninstall: Release not loaded: traefik"

### DIFF
--- a/jumpscale/sals/vdc/kubernetes.py
+++ b/jumpscale/sals/vdc/kubernetes.py
@@ -553,10 +553,10 @@ class VDCKubernetesDeployer(VDCBaseComponent):
         def clean_traefik(manager, ns):
             # wait until traefik chart is installed on the cluster then uninstall it
             checks = 12
-            while checks > 0 and not is_traefik_installed(manager):
+            while checks > 0 and not is_traefik_installed(manager, ns):
                 gevent.sleep(5)
                 checks -= 1
-            if is_traefik_installed(manager):
+            if is_traefik_installed(manager, ns):
                 manager.delete_deployed_release("traefik", ns)
 
         kubeconfig_path = f"{j.core.dirs.CFGDIR}/vdc/kube/{self.vdc_deployer.tname}/{self.vdc_name}.yaml"


### PR DESCRIPTION
### Description

fix for "Error: uninstall: Release not loaded: traefik: release: not found" which shows in the logs when the UpgradeTraefik service runs.

```
[-] threebot: 2021-07-18 15:54:10.710 | INFO     | upgrade_traefik:job:16 - Upgrade Traefik Service:: Updating traefik from 2.4.9 to 2.4.8
...
[-] threebot: 2021-07-18 15:54:17.320 | DEBUG    | jumpscale.sals.kubernetes.manager:_execute:45 - kubernetes manager: helm --kubeconfig /root/sandbox/cfg/vdc/kube/samehabouelsaad/dev18072021.yaml --namespace kube-system delete traefik
[-] threebot: 2021-07-18 15:54:17.333 | DEBUG    | jumpscale.sals.kubernetes.manager:_execute:45 - kubernetes manager: helm --kubeconfig /root/sandbox/cfg/vdc/kube/samehabouelsaad/dev18072021.yaml --namespace k3os-system delete traefik
[-] threebot: Traceback (most recent call last):
[-] threebot:   File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
[-] threebot:   File "/sandbox/code/github/threefoldtech/js-sdk/jumpscale/sals/vdc/kubernetes.py", line 560, in clean_traefik
[-] threebot:     manager.delete_deployed_release("traefik", ns)
[-] threebot:   File "/sandbox/code/github/threefoldtech/js-sdk/jumpscale/sals/kubernetes/manager.py", line 25, in wrapper
[-] threebot:     return method(self, *args, **kwargs)
[-] threebot:   File "/sandbox/code/github/threefoldtech/js-sdk/jumpscale/sals/kubernetes/manager.py", line 181, in delete_deployed_release
[-] threebot:     raise j.exceptions.Runtime(f"Failed to deploy chart {release} , error was {err}")
[-] threebot: jumpscale.core.exceptions.exceptions.Runtime: Failed to deploy chart traefik , error was WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/sandbox/cfg/vdc/kube/samehabouelsaad/dev18072021.yaml
[-] threebot: WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /root/sandbox/cfg/vdc/kube/samehabouelsaad/dev18072021.yaml
[-] threebot: Error: uninstall: Release not loaded: traefik: release: not found
[-] threebot: 
[-] threebot: 2021-07-18T15:54:19Z <Greenlet at 0x7fbd481bb370: clean_traefik(<jumpscale.sals.kubernetes.manager.Manager object , 'k3os-system')> failed with Runtime
[-] threebot: 
```
this is caused because the clean_traefik method will check whether Traefik is installed or not on a namespace and if found it will try to delete it on a different namespace.

### Changes

the method will use the same namespace as checking and deleting.

### Related Issues
closes #3261

### Checklist

- [X] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
