### PR TITLE
Revert "Update stellar endpoint to use the new node (#3280)"

### DIFF
--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -30,7 +30,7 @@ _THREEFOLDFOUNDATION_TFTSTELLAR_SERVICES = {
 }  # TODO: add tftech link
 _HORIZON_NETWORKS = {
     "TEST": "https://horizon-testnet.stellar.org",
-    "STD": "https://stellar-mainnet.grid.tf/",
+    "STD": "https://horizon.stellar.org",
     "TFTECHTEST": "https://horizon.testnet.threefold.io",
 }
 _NETWORK_PASSPHRASES = {


### PR DESCRIPTION
This reverts commit b7c2a555b5d741fcad74fe548689a95cefe6f76b.

### Description

Restore stellar original nodes

### Related Issues

- https://github.com/threefoldtech/tf_operations/issues/250

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
