### PR TITLE
fix for duplicated solutions in VDC dashboard

### DIFF
--- a/jumpscale/packages/vdc_dashboard/sals/vdc_dashboard_sals.py
+++ b/jumpscale/packages/vdc_dashboard/sals/vdc_dashboard_sals.py
@@ -140,6 +140,8 @@ def get_all_vdc_deployments(vdc_name, solution_types=None):
             continue
         deployment_info = _filter_data(deployment_info)
         release_name = deployment_info["Release"]
+        if release_name in deployment_names:
+            continue
         helm_chart_supplied_values = "{}"
         try:
             helm_chart_supplied_values = k8s_client.get_helm_chart_user_values(release=release_name)


### PR DESCRIPTION
### Description
handle the case when the deployed solution has multiple k8s deployments or stateful-sets and make sure the solution will appear only once
fix issue #3302

### Changes
 filtering the solutions using the instance name.

### Related Issues
closes #3302
List of related issues

### Checklist

- [ ] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstrings
