### PR TITLE
Development redisdisconnect

### DIFF
--- a/jumpscale/clients/stellar/stellar.py
+++ b/jumpscale/clients/stellar/stellar.py
@@ -6,7 +6,7 @@ import decimal
 from urllib import parse
 from urllib.parse import urlparse
 from typing import Union
-
+import gevent
 import stellar_sdk
 from jumpscale.clients.base import Client
 from jumpscale.core.base import fields
@@ -486,6 +486,7 @@ class Stellar(Client):
                 )
             except Exception as e:
                 nretries += 1
+                gevent.sleep(1)
                 j.logger.warning(str(e))
 
         raise j.exceptions.Runtime(f"Failed to make transaction for {retries} times, Please try again later")

--- a/jumpscale/servers/gedis/server.py
+++ b/jumpscale/servers/gedis/server.py
@@ -233,7 +233,7 @@ class GedisServer(Base):
 
     def _on_connection(self, socket, address):
         j.logger.debug(f"New connection from {address}")
-        parser = DefaultParser(65536)
+        parser = DefaultParser(4096)
         connection = RedisConnectionAdapter(socket)
         try:
             encoder = ResponseEncoder(socket)
@@ -277,6 +277,7 @@ class GedisServer(Base):
 
                 except ConnectionError:
                     j.logger.debug(f"Client {address} closed the connection", address)
+                    parser.on_disconnect()
 
                 except Exception as exception:
                     j.logger.exception("internal error", exception=exception)
@@ -285,8 +286,6 @@ class GedisServer(Base):
 
                 response["success"] = response["error"] is None
                 encoder.encode(json.dumps(response, default=serialize))
-
-            parser.on_disconnect()
 
         except BrokenPipeError:
             pass

--- a/jumpscale/servers/gedis/server.py
+++ b/jumpscale/servers/gedis/server.py
@@ -233,7 +233,7 @@ class GedisServer(Base):
 
     def _on_connection(self, socket, address):
         j.logger.debug(f"New connection from {address}")
-        parser = DefaultParser(4096)
+        parser = DefaultParser(65536)
         connection = RedisConnectionAdapter(socket)
         try:
             encoder = ResponseEncoder(socket)
@@ -278,6 +278,7 @@ class GedisServer(Base):
                 except ConnectionError:
                     j.logger.debug(f"Client {address} closed the connection", address)
                     parser.on_disconnect()
+                    return
 
                 except Exception as exception:
                     j.logger.exception("internal error", exception=exception)


### PR DESCRIPTION
- calling disconnect was never reached
- for stellar on retries we should yield the control back to the event loop

tries to address #3262 #3101 #3298 