### PR TITLE
validate vdc admin suffix ends with .3bot

### DIFF
--- a/jumpscale/packages/vdc_dashboard/bottle/api/deployments.py
+++ b/jumpscale/packages/vdc_dashboard/bottle/api/deployments.py
@@ -202,6 +202,7 @@ def list_all_admins() -> str:
 @app.route("/api/admins/add", method="POST")
 @package_authorized("vdc_dashboard")
 def add_admin() -> str:
+    suffix = ".3bot"
     data = j.data.serializers.json.loads(request.body.read())
     name = data.get("name")
     threebot = j.servers.threebot.get("default")
@@ -210,6 +211,9 @@ def add_admin() -> str:
         raise j.exceptions.Value(f"Admin name shouldn't be empty")
     if name in package.admins:
         raise j.exceptions.Value(f"Admin {name} already exists")
+    # Validating the admin name ends with 3bot suffix
+    if not name.endswith(suffix):
+        name += suffix
     package.admins.append(name)
     threebot.packages.save()
 


### PR DESCRIPTION
### Description

Validate VDC admin suffix ends with `.3bot` and if it is not ended `3bot` we append it.

 
### Changes

- we updated end point `/api/admins/add`
jumpscale/packages/vdc_dashboard/bottle/api/deployments.py

### Related Issues

List of related issues
https://github.com/threefoldtech/js-sdk/issues/3265

