### PR TITLE
Development last admin remove

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Admins.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Admins.vue
@@ -18,11 +18,11 @@
         min-width="50"
         v-for="admin in admins"
         :key="admin"
-        @click:close="removeAdmin(admin)"
+        @click:close="admins.length > 1 ? removeAdmin(admin) : undefined"
         outlined
         label
-        close
-        close-icon="mdi-close-circle-outline"
+        :close="admins.length > 1"
+        :close-icon="admins.length > 1 ? 'mdi-close-circle-outline' : undefined"
         >{{ admin }}</v-chip
       >
     </base-section>

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Admins.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Admins.vue
@@ -18,11 +18,11 @@
         min-width="50"
         v-for="admin in admins"
         :key="admin"
-        @click:close="admins.length > 1 ? removeAdmin(admin) : undefined"
+        @click:close="isLastAdmin() ? undefined : removeAdmin(admin)"
         outlined
         label
-        :close="admins.length > 1"
-        :close-icon="admins.length > 1 ? 'mdi-close-circle-outline' : undefined"
+        :close="!isLastAdmin()"
+        :close-icon="isLastAdmin() ? undefined : 'mdi-close-circle-outline'"
         >{{ admin }}</v-chip
       >
     </base-section>
@@ -66,6 +66,9 @@ module.exports = {
     removeAdmin(name) {
       this.selectedAdmin = name;
       this.dialogs.removeAdmin = true;
+    },
+    isLastAdmin() {
+      return this.admins.length === 1;
     },
   },
   mounted() {


### PR DESCRIPTION
### Description

Removed the ability to remove the last admin in vdc

### Changes
Removed close icon whenever there is only one user
jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Admins.vue

### Related Issues
https://github.com/threefoldtech/js-sdk/issues/3266

