### PR TITLE
fix farm mangment countries listing

### DIFF
--- a/jumpscale/packages/farmmanagement/frontend/views/farmmanagement/farmmanagement.js
+++ b/jumpscale/packages/farmmanagement/frontend/views/farmmanagement/farmmanagement.js
@@ -77,7 +77,7 @@ module.exports = new Promise(async (resolve, reject) => {
                 namerules: [v => !!v || "Name is required"],
                 nameError: [],
                 mailError: [],
-                countries: [],
+                countries: getCountries(),
                 loading: false,
                 upgrade: false,
                 showUpgradeConfirmation: false,
@@ -289,7 +289,8 @@ module.exports = new Promise(async (resolve, reject) => {
     });
 });
 
-const countries = [
+function getCountries(){
+return  [
     "Afghanistan",
     "Albania",
     "Algeria",
@@ -487,3 +488,4 @@ const countries = [
     "Zambia",
     "Zimbabwe"
 ]
+}


### PR DESCRIPTION
### Description

Fixing the country listing while adding new farm in farm management 

### Changes
- Give the countries the right scope to be called right
jumpscale/packages/farmmanagement/frontend/views/farmmanagement/farmmanagement.js### Related Issues

List of related issues
https://github.com/threefoldtech/js-sdk/issues/3301
