### PR TITLE
VDC dashboard: fix reloading vdc info after create/delete

### DIFF
--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Home.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Home.vue
@@ -22,7 +22,7 @@
       </v-tab-item>
       <v-tab-item class="ml-2">
         <v-card flat>
-          <virtual-machine :vmachines="vdc ? vdc.vmachines : []" :tableloading="tableloading"></virtual-machine>
+          <virtual-machine></virtual-machine>
         </v-card>
       </v-tab-item>
       <v-tab-item class="ml-2">

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Home.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/Home.vue
@@ -22,7 +22,7 @@
       </v-tab-item>
       <v-tab-item class="ml-2">
         <v-card flat>
-          <virtual-machine></virtual-machine>
+          <virtual-machine :vmachines="vdc ? vdc.vmachines : []" :tableloading="tableloading"></virtual-machine>
         </v-card>
       </v-tab-item>
       <v-tab-item class="ml-2">

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
@@ -88,16 +88,6 @@
 
 <script>
 module.exports = {
-  props: {
-    // vmachines: {
-    //   type: Array,
-    //   default: () => [],
-    // },
-    // tableloading: {
-    //   type: Boolean,
-    //   default: false,
-    // },
-  },
   mixins: [dialog],
   components: {
     "solution-info": httpVueLoader("../base/Info.vue"),

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
@@ -81,7 +81,7 @@
       title="Delete VM"
       :messages="deletionMessages"
       :wid="selectedvm"
-      @reload-vdcinfo="getVMSinfo"
+      @reload-vdcinfo="getVms"
     ></cancel-workload>
   </div>
 </template>

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
@@ -14,7 +14,7 @@
 
     <v-data-table
       :headers="headers"
-      :items="getVms()"
+      :items="[]"
       :loading="loading || tableloading"
       class="elevation-1"
     >
@@ -158,6 +158,12 @@ module.exports = {
       return vmachines
     }
   },
+  created(){
+    console.log("Created event")
+  },
+  updated(){
+    console.log("Updated event")
+  }
 };
 </script>
 

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
@@ -81,7 +81,7 @@
       title="Delete VM"
       :messages="deletionMessages"
       :wid="selectedvm"
-      @reload-vdcinfo="$emit('vm-deleted', selectedvm)"
+      @reload-vdcinfo="removeVm()"
     ></cancel-workload>
   </div>
 </template>
@@ -136,7 +136,6 @@ module.exports = {
     deleteVm(wid) {
       this.selectedvm = wid;
       this.dialogs.cancelWorkload = true;
-      this.deletedVms.push(wid);
     },
     openChatflow(topic) {
       this.$router.push({
@@ -144,15 +143,12 @@ module.exports = {
         params: { topic: topic },
       });
     },
+    removeVm() {
+      this.deletedVms.push(this.selectedvm);
+    },
     getVms() {
       return this.vmachines.filter(({wid}) => !(this.deletedVms.includes(wid)))
     }
-  },
-  created() {
-    console.log('created', this.deletedVms);
-  },
-  destroyed() {
-    console.log('destroyed', this.deletedVms);
   }
 };
 </script>

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
@@ -14,7 +14,7 @@
 
     <v-data-table
       :headers="headers"
-      :items="[]"
+      :items="vmachines"
       :loading="loading || tableloading"
       class="elevation-1"
     >
@@ -106,6 +106,7 @@ module.exports = {
   data() {
     return {
       tableloading: true,
+      vmachines : [],
       selected: null,
       selectedvm: null,
       headers: [
@@ -144,26 +145,22 @@ module.exports = {
       });
     },
     getVms(){
-      vmachines = null;
       this.tableloading = true;
       this.$api.vdc
         .getVdcInfo()
         .then((response) => {
           vdc = response.data;
-          vmachines = vdc.vmachines
+          this.vmachines = vdc.vmachines
         })
         .finally(() => {
           this.tableloading = false;
         });
-      return vmachines
     }
   },
   created(){
-    console.log("Created event")
+    this.getVms()
   },
-  updated(){
-    console.log("Updated event")
-  }
+
 };
 </script>
 

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
@@ -14,7 +14,7 @@
 
     <v-data-table
       :headers="headers"
-      :items="vmachines"
+      :items="getVms()"
       :loading="loading || tableloading"
       class="elevation-1"
     >
@@ -81,13 +81,23 @@
       title="Delete VM"
       :messages="deletionMessages"
       :wid="selectedvm"
-      @reload-vdcinfo="UpdateVms"
+      @reload-vdcinfo="$emit('vm-deleted', selectedvm)"
     ></cancel-workload>
   </div>
 </template>
 
 <script>
 module.exports = {
+  props: {
+    vmachines: {
+      type: Array,
+      default: () => [],
+    },
+    tableloading: {
+      type: Boolean,
+      default: false,
+    },
+  },
   mixins: [dialog],
   components: {
     "solution-info": httpVueLoader("../base/Info.vue"),
@@ -96,7 +106,6 @@ module.exports = {
   data() {
     return {
       tableloading: true,
-      vmachines : [],
       selected: null,
       selectedvm: null,
       headers: [
@@ -117,6 +126,7 @@ module.exports = {
           "Are you sure you want to delete this virtual machine?",
         successMsg: "Virtual machine deleted successfully",
       },
+      deletedVms: []
     };
   },
   methods: {
@@ -127,6 +137,7 @@ module.exports = {
     deleteVm(wid) {
       this.selectedvm = wid;
       this.dialogs.cancelWorkload = true;
+      this.deletedVms.push(wid);
     },
     openChatflow(topic) {
       this.$router.push({
@@ -134,29 +145,16 @@ module.exports = {
         params: { topic: topic },
       });
     },
-    getVms(){
-      this.tableloading = true;
-      this.$api.vdc
-        .getVdcInfo()
-        .then((response) => {
-          vdc = response.data;
-          this.vmachines = vdc.vmachines
-        })
-        .finally(() => {
-          this.tableloading = false;
-        });
-    },
-    UpdateVms(){
-      if(this.vmachines){
-        this.vmachines = this.vmachines.filter( vm => vm.wid != this.selectedvm)
-      }
-
+    getVms() {
+      return this.vmachines.filter(({wid}) => !(this.deletedVms.includes(wid)))
     }
   },
-  created(){
-    this.getVms()
+  created() {
+    console.log(this.deletedVms);
   },
-
+  destory() {
+    console.log(this.deletedVms);
+  }
 };
 </script>
 

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
@@ -14,7 +14,7 @@
 
     <v-data-table
       :headers="headers"
-      :items="vmachines"
+      :items="getVms()"
       :loading="loading || tableloading"
       class="elevation-1"
     >
@@ -89,14 +89,14 @@
 <script>
 module.exports = {
   props: {
-    vmachines: {
-      type: Array,
-      default: () => [],
-    },
-    tableloading: {
-      type: Boolean,
-      default: false,
-    },
+    // vmachines: {
+    //   type: Array,
+    //   default: () => [],
+    // },
+    // tableloading: {
+    //   type: Boolean,
+    //   default: false,
+    // },
   },
   mixins: [dialog],
   components: {
@@ -105,6 +105,7 @@ module.exports = {
   },
   data() {
     return {
+      tableloading: true,
       selected: null,
       selectedvm: null,
       headers: [
@@ -142,6 +143,20 @@ module.exports = {
         params: { topic: topic },
       });
     },
+    getVms(){
+      vmachines = null;
+      this.tableloading = true;
+      this.$api.vdc
+        .getVdcInfo()
+        .then((response) => {
+          vdc = response.data;
+          vmachines = vdc.vmachines
+        })
+        .finally(() => {
+          this.tableloading = false;
+        });
+      return vmachines
+    }
   },
 };
 </script>

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
@@ -81,7 +81,7 @@
       title="Delete VM"
       :messages="deletionMessages"
       :wid="selectedvm"
-      @reload-vdcinfo="getVms"
+      @reload-vdcinfo="UpdateVms"
     ></cancel-workload>
   </div>
 </template>
@@ -145,6 +145,12 @@ module.exports = {
         .finally(() => {
           this.tableloading = false;
         });
+    },
+    UpdateVms(){
+      if(this.vmachines){
+        this.vmachines = this.vmachines.filter( vm => vm.wid != this.selectedvm)
+      }
+
     }
   },
   created(){

--- a/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
+++ b/jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
@@ -105,7 +105,6 @@ module.exports = {
   },
   data() {
     return {
-      tableloading: true,
       selected: null,
       selectedvm: null,
       headers: [
@@ -150,10 +149,10 @@ module.exports = {
     }
   },
   created() {
-    console.log(this.deletedVms);
+    console.log('created', this.deletedVms);
   },
-  destory() {
-    console.log(this.deletedVms);
+  destroyed() {
+    console.log('destroyed', this.deletedVms);
   }
 };
 </script>


### PR DESCRIPTION
### Description

- Update virtual machine component to load its data (VMs) using created event
- while deletion we raise an event in which we remove the delete VM

### Changes

load data in created event
jumpscale/packages/vdc_dashboard/frontend/components/vdcSettings/VirtualMachine.vue
### Related Issues
https://github.com/threefoldtech/js-sdk/issues/3296

