### PR TITLE
Allow to define admins while creating identity

### DIFF
--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -127,7 +127,13 @@ class Admin(BaseActor):
         return j.data.serializers.json.dumps({"data": False})
 
     @actor_method
-    def add_identity(self, display_name: str, tname: str, email: str, words: str, explorer_type: str) -> str:
+    def add_identity(self, display_name: str, tname: str, email: str, words: str, explorer_type: str, admins: list) -> str:
+        checked_admins = []
+        for admin in admins:
+            if type(admin) is str and not admin.endswith(".3bot"):
+                admin = admin + ".3bot"
+            checked_admins.append(admin)
+
         if not display_name.isidentifier() or not display_name.islower():
             raise j.exceptions.Value(
                 "The display name must be a lowercase valid python identitifier (English letters, underscores, and numbers not starting with a number)."
@@ -138,7 +144,7 @@ class Admin(BaseActor):
             raise j.exceptions.Value("Identity with the same name already exists")
         try:
             new_identity = j.core.identity.new(
-                name=identity_instance_name, tname=tname, email=email, words=words, explorer_url=explorer_url
+                name=identity_instance_name, tname=tname, email=email, words=words, explorer_url=explorer_url, admins=checked_admins
             )
             new_identity.register()
             new_identity.save()

--- a/jumpscale/packages/admin/actors/admin.py
+++ b/jumpscale/packages/admin/actors/admin.py
@@ -82,6 +82,7 @@ class Admin(BaseActor):
                         "tid": identity.tid,
                         "explorer_url": identity.explorer_url,
                         "words": identity.words,
+                        "admins": identity.admins,
                     }
                 }
             )

--- a/jumpscale/packages/admin/frontend/api.js
+++ b/jumpscale/packages/admin/frontend/api.js
@@ -277,12 +277,12 @@ const apiClient = {
                 url: `${baseURL}/admin/list_identities`
             })
         },
-        add: (display_name, tname, email, words, explorer_type) => {
+        add: (display_name, tname, email, words, explorer_type, admins) => {
             return axios({
                 url: `${baseURL}/admin/add_identity`,
                 method: "post",
                 headers: { 'Content-Type': 'application/json' },
-                data: { display_name: display_name, tname: tname, email: email, words: words, explorer_type: explorer_type }
+                data: { display_name, tname, email, words, explorer_type, admins }
             })
         },
         generateMnemonic: () => {

--- a/jumpscale/packages/admin/frontend/components/settings/AdminConfirmation.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/AdminConfirmation.vue
@@ -1,0 +1,18 @@
+<template>
+  <base-dialog title="Admin Confirmation" v-model="dialog" :error="error" :loading="loading">
+    <template #default>
+      No admins were found. Are you sure you want to set as default ?
+    </template>
+    <template #actions>
+      <v-btn text @click="close">No</v-btn>
+      <v-btn text @click="$emit('admin-confirm')" color="red">Yes</v-btn>
+    </template>
+  </base-dialog>  
+</template>
+
+<script>
+
+module.exports = {
+  mixins: [dialog]
+}
+</script>

--- a/jumpscale/packages/admin/frontend/components/settings/IdentityInfo.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/IdentityInfo.vue
@@ -39,6 +39,20 @@
                 ></v-text-field>
               </td>
             </tr>
+            <tr>
+              <td>admins</td>
+              <td>
+                <v-chip
+                  class="ma-2"
+                  color="primary"
+                  outlined
+                  v-for="admin in identity.admins"
+                  :key="admin"
+                >
+                  {{ admin }}
+                </v-chip>
+              </td>
+            </tr>
           </tbody>
         </template>
       </v-simple-table>

--- a/jumpscale/packages/admin/frontend/components/settings/IdentityInfo.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/IdentityInfo.vue
@@ -1,74 +1,84 @@
 <template>
-  <base-dialog title="Identity details" v-model="dialog" :loading="loading">
-    <template #default>
-      <v-simple-table v-if="identity">
-        <template v-slot:default>
-          <tbody>
-            <tr>
-              <td>Instance Name</td>
-              <td>{{ name }}</td>
-            </tr>
-            <tr>
-              <td>3Bot ID</td>
-              <td>{{ identity.tid }}</td>
-            </tr>
-            <tr>
-              <td>3Bot Name</td>
-              <td>{{ identity.name }}</td>
-            </tr>
-            <tr>
-              <td>Email</td>
-              <td>{{ identity.email }}</td>
-            </tr>
-            <tr>
-              <td>Explorer URL</td>
-              <td>{{ identity.explorer_url }}</td>
-            </tr>
-            <tr>
-              <td>Words</td>
-              <td>
-                <v-text-field
-                  hide-details
-                  :value="identity.words"
-                  readonly
-                  solo
-                  flat
-                  :append-icon="showWords ? 'mdi-eye' : 'mdi-eye-off'"
-                  :type="showWords ? 'text' : 'password'"
-                  @click:append="showWords = !showWords"
-                ></v-text-field>
-              </td>
-            </tr>
-            <tr>
-              <td>admins</td>
-              <td>
-                <v-chip
-                  class="ma-2"
-                  color="primary"
-                  outlined
-                  v-for="admin in identity.admins"
-                  :key="admin"
-                >
-                  {{ admin }}
-                </v-chip>
-              </td>
-            </tr>
-          </tbody>
-        </template>
-      </v-simple-table>
-    </template>
-    <template #actions>
-      <v-btn icon @click.stop="deleteIdentity">
-        <v-icon color="primary" left>mdi-delete</v-icon>
-      </v-btn>
-      <v-btn text color="primary" :disabled="name == currentIdentity" @click.stop="setDefault">Set Default</v-btn>
-      <v-btn text class="text--lighten-1" color="red" @click.done="close">Close</v-btn>
-    </template>
-  </base-dialog>
+  <div>
+    <base-dialog title="Identity details" v-model="dialog" :loading="loading">
+      <template #default>
+        <v-simple-table v-if="identity">
+          <template v-slot:default>
+            <tbody>
+              <tr>
+                <td>Instance Name</td>
+                <td>{{ name }}</td>
+              </tr>
+              <tr>
+                <td>3Bot ID</td>
+                <td>{{ identity.tid }}</td>
+              </tr>
+              <tr>
+                <td>3Bot Name</td>
+                <td>{{ identity.name }}</td>
+              </tr>
+              <tr>
+                <td>Email</td>
+                <td>{{ identity.email }}</td>
+              </tr>
+              <tr>
+                <td>Explorer URL</td>
+                <td>{{ identity.explorer_url }}</td>
+              </tr>
+              <tr>
+                <td>Words</td>
+                <td>
+                  <v-text-field
+                    hide-details
+                    :value="identity.words"
+                    readonly
+                    solo
+                    flat
+                    :append-icon="showWords ? 'mdi-eye' : 'mdi-eye-off'"
+                    :type="showWords ? 'text' : 'password'"
+                    @click:append="showWords = !showWords"
+                  ></v-text-field>
+                </td>
+              </tr>
+              <tr>
+                <td>admins</td>
+                <td>
+                  <v-chip
+                    class="ma-2"
+                    color="primary"
+                    outlined
+                    v-for="admin in identity.admins"
+                    :key="admin"
+                  >
+                    {{ admin }}
+                  </v-chip>
+                </td>
+              </tr>
+            </tbody>
+          </template>
+        </v-simple-table>
+      </template>
+      <template #actions>
+        <v-btn icon @click.stop="deleteIdentity">
+          <v-icon color="primary" left>mdi-delete</v-icon>
+        </v-btn>
+        <v-btn text color="primary" :disabled="name == currentIdentity" @click.stop="shouldOpenConfirmation">Set Default</v-btn>
+        <v-btn text class="text--lighten-1" color="red" @click.done="close">Close</v-btn>
+      </template>
+    </base-dialog>
+
+    <admin-confirmation
+      v-model="openConfirmation"
+      @admin-confirm="setDefault"
+      />
+    </div>
 </template>
 
 <script>
 module.exports = {
+  components: {
+    "admin-confirmation": httpVueLoader("./AdminConfirmation.vue"),
+  },
   props: { name: String },
   mixins: [dialog],
   data() {
@@ -76,6 +86,7 @@ module.exports = {
       identity: null,
       showWords: false,
       currentIdentity: null,
+      openConfirmation: false
     };
   },
   watch: {
@@ -110,7 +121,14 @@ module.exports = {
           this.loading.identities = false;
         });
     },
+    shouldOpenConfirmation() {
+      if (this.identity.admins.length === 0) {
+        return this.openConfirmation = true
+      }
+      this.setDefault();
+    },
     setDefault() {
+      this.openConfirmation = false;
       this.$api.identities
         .setIdentity(this.name)
         .then((response) => {

--- a/jumpscale/packages/admin/frontend/components/settings/Settings.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/Settings.vue
@@ -303,15 +303,6 @@
       :name="selectedAdmin"
       @done="listAdmins"
     ></remove-admin>
-    <identity-info
-      v-model="dialogs.identityInfo"
-      :name="selectedIdentity"
-      @done="listIdentities"
-    ></identity-info>
-    <add-identity
-      v-model="dialogs.addIdentity"
-      @done="listIdentities"
-    ></add-identity>
     <config-view
       v-if="configurations"
       v-model="dialogs.configurations"

--- a/jumpscale/packages/admin/frontend/components/settings/Settings.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/Settings.vue
@@ -323,7 +323,6 @@ module.exports = {
     "identity-info": httpVueLoader("./IdentityInfo.vue"),
     "add-identity": httpVueLoader("./AddIdentity.vue"),
     "config-view": httpVueLoader("./ConfigurationsInfo.vue"),
-    // "admin-confirmation": httpVueLoader("./AdminConfirmation.vue")
   },
   data() {
     return {
@@ -346,7 +345,6 @@ module.exports = {
         escalationEmail: false,
         emailServerConfig: false,
         configurations: false,
-        // adminConfirmation: false
       },
       admins: [],
       sshkeys: [],

--- a/jumpscale/packages/admin/frontend/components/settings/Settings.vue
+++ b/jumpscale/packages/admin/frontend/components/settings/Settings.vue
@@ -323,6 +323,7 @@ module.exports = {
     "identity-info": httpVueLoader("./IdentityInfo.vue"),
     "add-identity": httpVueLoader("./AddIdentity.vue"),
     "config-view": httpVueLoader("./ConfigurationsInfo.vue"),
+    // "admin-confirmation": httpVueLoader("./AdminConfirmation.vue")
   },
   data() {
     return {
@@ -345,6 +346,7 @@ module.exports = {
         escalationEmail: false,
         emailServerConfig: false,
         configurations: false,
+        // adminConfirmation: false
       },
       admins: [],
       sshkeys: [],


### PR DESCRIPTION
### Description
1. Validate that identity cannot be set as default when there is no admins expect via confirmation message
2. while creating new identity we set current user on admins list
3. Added admins list in ui & server for identity
4. Removed code duplication from Setting.vue `jumpscale/packages/admin/frontend/components/settings/Settings.vue`

### Changes
-while adding a new identity:
  - Add the logged-in user to admins
  - Add comma-separated admins
  - while setting an identity to be the default and this one doesn't have admins, we have to show a confirmation message that there are no admins

jumpscale/packages/admin/frontend/components/settings/IdentityInfo.vue
jumpscale/packages/admin/frontend/components/settings/AdminConfirmation.vue
jumpscale/packages/admin/frontend/components/settings/Settings.vue
jumpscale/packages/admin/actors/admin.py

### Related Issues
https://github.com/threefoldtech/js-sdk/issues/3299