### PR TITLE
Update VDC by latest tag

### DIFF
--- a/jumpscale/packages/vdc_dashboard/scripts/update.sh
+++ b/jumpscale/packages/vdc_dashboard/scripts/update.sh
@@ -4,50 +4,51 @@
 # 64                  Error: poetry install failed                              POETRY_INSTALL_ERROR
 # 65                  Error: hard reset files to HEAD failed                    GIT_RESET_ERROR
 # 66                  Error: switch to the upstream branch failed               GIT_CHECKOUT_ERROR
-# 67                  Error: can't find the branch name in the repository       GIT_BRANCH_NOT_EXIST
+# 67                  Error: can't find the branch name in the repository       GIT_BRANCH_OR_TAG_NOT_EXIST
 #################
 POETRY_INSTALL_ERROR=64
 GIT_RESET_ERROR=65
 GIT_CHECKOUT_ERROR=66
-GIT_BRANCH_NOT_EXIST=67
+GIT_BRANCH_OR_TAG_NOT_EXIST=67
 
 # fetching all remote branches"
-git fetch --all
+git fetch --all --force
 
-# setting the branch name to use on updating
-if [ $1 ]; then SDK_BRANCH=$1; else SDK_BRANCH=development; fi
-echo "we will use origin/${SDK_BRANCH} branch to update the code"
+# setting the branch/tag name to use on updating
+if [ $1 ]; then SDK_REFS=$1; else SDK_REFS=development; fi
+echo "we will use ${SDK_REFS} branch/tag to update the code"
 
-# find out if a remote git branch with $SDK_BRANCH name exists in the repository
-if ! git show-ref --quiet --verify "refs/remotes/origin/$SDK_BRANCH"; then
-  >&2 echo "error: can't find the branch <$SDK_BRANCH> in the repository"
-  exit $GIT_BRANCH_NOT_EXIST
+# find out if a git branch/tag with $SDK_REFS name exists in the repository
+if ! (git show-ref --quiet --verify "refs/heads/$SDK_REFS" || git show-ref --quiet --verify "refs/tags/$SDK_REFS"); then
+  >&2 echo "error: can't find the branch/ tag <$SDK_REFS> in the repository"
+  exit $GIT_BRANCH_OR_TAG_NOT_EXIST
 fi
 
 # save the current information to use in case of update failure
 SAVED_BRANCH_NAME=$(git branch --show-current)
+SAVED_TAG_NAME=$(git describe)
 SAVED_COMMIT_HASH=$(git log -1 --pretty=format:"%H")
-echo "we will revert to $SAVED_BRANCH_NAME $SAVED_COMMIT_HASH in case of failure"
+echo "we will revert to tag=$SAVED_TAG_NAME branch=$SAVED_BRANCH_NAME commit=$SAVED_COMMIT_HASH in case of failure"
 
 # checking if poetry.lock has changed
 POETRY_INSTALL=false
-if ! git diff --quiet origin/$SDK_BRANCH poetry.lock; then
+if ! git diff --quiet $SDK_REFS poetry.lock; then
   # They are differnet
   echo "poetry.lock has changed"
   POETRY_INSTALL=true
 fi
 
-git stash push jumpscale/packages/vdc_dashboard/package.toml
+  git stash push -m "package.toml" -- jumpscale/packages/vdc_dashboard/package.toml
 
-# git rid of the uncommited local changes and switch the branch
-if ! git checkout -f $SDK_BRANCH; then
-  >&2 echo "error: switch to the upstream branch <$SDK_BRANCH> failed"
-  git stash pop
+# git rid of the uncommited local changes and switch the branch/tag
+if ! git checkout -f $SDK_REFS; then
+  >&2 echo "error: switch to the upstream branch <$SDK_REFS> failed"
+  git stash apply stash^{/package.toml}
   exit $GIT_CHECKOUT_ERROR
 fi
 
 RESET_SUCCEEDED=false
-if git reset --hard origin/$SDK_BRANCH; then
+if git reset --hard $DEST; then
   RESET_SUCCEEDED=true
 else
   ERR=$GIT_RESET_ERROR
@@ -62,7 +63,7 @@ if $RESET_SUCCEEDED; then
     while [  $COUNT -lt $MAX_TRIES ]; do
         poetry install --no-interaction --no-dev
         if [ $? -eq 0 ];then
-          git stash pop
+          git stash apply stash^{/package.toml}
           echo "Code updated and all defined dependencies successfully installed!"
           exit 0
         fi
@@ -70,13 +71,17 @@ if $RESET_SUCCEEDED; then
     done
     >&2 echo "Error: Failed to install the defined dependencies!"
   else
-    git stash pop
+    git stash apply stash^{/package.toml}
     echo "code updated successfully!"
     exit 0
   fi
 fi
 
 # reverting to saved info if hard reset files to HEAD or installing the defined dependencies was failed
-git checkout -f $SAVED_BRANCH_NAME && git reset --hard $SAVED_COMMIT_HASH
-git stash pop
+if $SAVED_BRANCH_NAME == ""; then
+  git checkout -f $SAVED_TAG_NAME && git reset --hard $SAVED_COMMIT_HASH
+else
+  git checkout -f $SAVED_BRANCH_NAME && git reset --hard $SAVED_COMMIT_HASH
+fi
+git stash apply stash^{/package.toml}
 exit $ERR


### PR DESCRIPTION
### Description

- updating from the UI or `update` rest API url endpoint without specifying branch param will update using the latest remote tag.

### Changes

- now `update.sh` script can work with git tag ref too. before it was accepted only a branch name.
- modifying the update API controller to check the code from the latest remote release by default unless the `branch` param was given with a specific branch name. before it was checked the HEAD of the development branch.

### Related Issues

### Checklist

- [x] [Pre-commit hook is installed](https://github.com/threefoldtech/js-ng#pre-commit) to do formatting checks before committing code...etc
- [ ] Build pass
- [x] Code format and docstrings
